### PR TITLE
Add support for raw JQL

### DIFF
--- a/cmd/jira/issue.go
+++ b/cmd/jira/issue.go
@@ -83,4 +83,5 @@ func init() {
 	issueCmd.Flags().StringArrayP("label", "l", []string{}, "Filter issues by label")
 	issueCmd.Flags().Bool("reverse", false, "Reverse the display order (default is DESC)")
 	issueCmd.Flags().Bool("plain", false, "Display output in plain mode")
+	issueCmd.Flags().StringP("jql", "j", "", "raw pql")
 }

--- a/internal/query/issue.go
+++ b/internal/query/issue.go
@@ -73,6 +73,9 @@ func (i *Issue) Get() string {
 	if i.params.debug {
 		fmt.Printf("JQL: %s\n", q.String())
 	}
+	if i.params.jql != "" {
+		q.And(func() { q.Raw(i.params.jql) })
+	}
 
 	return q.String()
 }
@@ -164,6 +167,7 @@ type issueParams struct {
 	updatedAfter  string
 	createdBefore string
 	updatedBefore string
+	jql           string
 	labels        []string
 	reverse       bool
 	debug         bool
@@ -174,9 +178,19 @@ func (ip *issueParams) init(flags FlagParser) error {
 
 	boolParams := []string{"history", "watching", "reverse", "debug"}
 	stringParams := []string{
-		"resolution", "type", "status", "priority", "reporter", "assignee",
-		"created", "created-after", "created-before",
-		"updated", "updated-after", "updated-before",
+		"resolution",
+		"type",
+		"status",
+		"priority",
+		"reporter",
+		"assignee",
+		"created",
+		"created-after",
+		"created-before",
+		"updated",
+		"updated-after",
+		"updated-before",
+		"jql",
 	}
 
 	boolParamsMap := make(map[string]bool)
@@ -249,6 +263,8 @@ func (ip *issueParams) setStringParams(paramsMap map[string]string) {
 			ip.updatedAfter = v
 		case "updated-before":
 			ip.updatedBefore = v
+		case "jql":
+			ip.jql = v
 		}
 	}
 }

--- a/pkg/jql/jql.go
+++ b/pkg/jql/jql.go
@@ -30,12 +30,15 @@ func NewJQL(project string) *JQL {
 	}
 }
 
+// Raw sets the passed jql query along with project context
 func (j *JQL) Raw(q string) *JQL {
 	if q == "" {
 		return j
 	}
+
 	j.filters = []string{j.filters[0]}
 	j.filters = append(j.filters, q)
+
 	return j
 }
 

--- a/pkg/jql/jql.go
+++ b/pkg/jql/jql.go
@@ -30,6 +30,15 @@ func NewJQL(project string) *JQL {
 	}
 }
 
+func (j *JQL) Raw(q string) *JQL {
+	if q == "" {
+		return j
+	}
+	j.filters = []string{j.filters[0]}
+	j.filters = append(j.filters, q)
+	return j
+}
+
 // History search through user issue history.
 func (j *JQL) History() *JQL {
 	j.filters = append(j.filters, "issue IN issueHistory()")


### PR DESCRIPTION
User should be able to pass raw JQL, user-supplied JQL should override other filters if passed to prevent confusion 

example: 

```
/jira-cli issue -j "assignee in (currentuser())"
```