### PR TITLE
feat: Add --no-truncate flag

### DIFF
--- a/cmd/jira/issue.go
+++ b/cmd/jira/issue.go
@@ -17,21 +17,25 @@ var issueCmd = &cobra.Command{
 	Short: "Issue lists issues in a project",
 	Long: `Issue lists issues in a given project.
 
-You can combine different flags together to create a unique query. For instance,
+You can combine different flags to create a unique query. For instance,
 	
 	# Issues that are of high priority, is in progress, was created this month,
 	# and has given labels
 	jira issue -yHigh -s"In Progress" --created month -lbackend -l"high prio"
 
-By default issues are displayed in a interactive list view. You can use --plain flag
-to display output in a plain text mode. --no-headers flag will hide the table headers
-in plain view.
+Issues are displayed in an interactive list view by default. You can use a --plain flag
+to display output in a plain text mode. A --no-headers flag will hide the table headers
+in plain view. A --no-truncate flag will display all available fields in plain mode.
 
+EG:
 	# Display issues in a plain table view without headers
 	jira issue --plain --no-headers
 
-	# Display some columns of issue in a plain table view
+	# Display some columns of the issue in a plain table view
 	jira issue --plain --columns key,assignee,status
+
+	# Display issues in a plain table view and show all fields
+	jira issue --plain --no-truncate
 `,
 	Aliases: []string{"issues", "list"},
 	Run:     issue,
@@ -67,6 +71,9 @@ func issue(cmd *cobra.Command, _ []string) {
 	noHeaders, err := cmd.Flags().GetBool("no-headers")
 	exitIfError(err)
 
+	noTruncate, err := cmd.Flags().GetBool("no-truncate")
+	exitIfError(err)
+
 	columns, err := cmd.Flags().GetString("columns")
 	exitIfError(err)
 
@@ -76,8 +83,9 @@ func issue(cmd *cobra.Command, _ []string) {
 		Total:   total,
 		Data:    issues,
 		Display: view.DisplayFormat{
-			Plain:     plain,
-			NoHeaders: noHeaders,
+			Plain:      plain,
+			NoHeaders:  noHeaders,
+			NoTruncate: noTruncate,
 			Columns: func() []string {
 				if columns != "" {
 					return strings.Split(columns, ",")
@@ -121,6 +129,7 @@ func injectIssueFlags(cmd *cobra.Command) {
 	cmd.Flags().Bool("reverse", false, "Reverse the display order (default is DESC)")
 	cmd.Flags().Bool("plain", false, "Display output in plain mode")
 	cmd.Flags().Bool("no-headers", false, "Don't display table headers in plain mode. Works only with --plain")
+	cmd.Flags().Bool("no-truncate", false, "Show all available columns in plain mode. Works only with --plain")
 
 	if cmd.Name() != "sprint" {
 		cmd.Flags().String("columns", "", "Comma separated list of columns to display in the plain mode.\n"+

--- a/cmd/jira/sprint.go
+++ b/cmd/jira/sprint.go
@@ -20,9 +20,10 @@ var sprintCmd = &cobra.Command{
 	Short: fmt.Sprintf("Sprint lists top %d sprints in a board", numSprints),
 	Long: fmt.Sprintf("Sprint lists top %d sprints in a board.\n", numSprints) +
 		`
-By default sprints are displayed in an explorer view. You can use --list
+Sprints are displayed in an explorer view by default. You can use --list
 and --plain flags to display output in different modes.
 
+EG:
 	# Display sprints or sprint issues in an interactive list
 	jira sprint --list
 	jira sprint <SPRINT_ID> --list
@@ -38,6 +39,9 @@ and --plain flags to display output in different modes.
 	# Display some columns of sprint or sprint issues in a plain table view
 	jira sprint --list --plain --columns name,start,end
 	jira sprint <SPRINT_ID> --plain --columns type,key,summary
+
+	# Display sprint issues in a plain table view and show all fields
+	jira sprint <SPRINT_ID> --list --plain --no-truncate
 `,
 	Args:    cobra.MaximumNArgs(1),
 	Aliases: []string{"sprints"},
@@ -86,6 +90,9 @@ func singleSprintView(flags query.FlagParser, boardID, sprintID int, project, se
 	noHeaders, err := flags.GetBool("no-headers")
 	exitIfError(err)
 
+	noTruncate, err := flags.GetBool("no-truncate")
+	exitIfError(err)
+
 	columns, err := flags.GetString("columns")
 	exitIfError(err)
 
@@ -95,8 +102,9 @@ func singleSprintView(flags query.FlagParser, boardID, sprintID int, project, se
 		Total:   total,
 		Data:    issues,
 		Display: view.DisplayFormat{
-			Plain:     plain,
-			NoHeaders: noHeaders,
+			Plain:      plain,
+			NoHeaders:  noHeaders,
+			NoTruncate: noTruncate,
 			Columns: func() []string {
 				if columns != "" {
 					return strings.Split(columns, ",")

--- a/internal/view/issue.go
+++ b/internal/view/issue.go
@@ -18,9 +18,10 @@ const (
 
 // DisplayFormat is a issue display type.
 type DisplayFormat struct {
-	Plain     bool
-	NoHeaders bool
-	Columns   []string
+	Plain      bool
+	NoHeaders  bool
+	NoTruncate bool
+	Columns    []string
 }
 
 // IssueList is a list view for issues.
@@ -71,7 +72,11 @@ func (l IssueList) header() []string {
 	validColumns, columnsMap := ValidIssueColumns(), l.validColumnsMap()
 
 	if len(l.Display.Columns) == 0 {
-		return validColumns
+		if l.Display.NoTruncate || !l.Display.Plain {
+			return validColumns
+		}
+
+		return validColumns[0:4]
 	}
 
 	var headers []string

--- a/internal/view/issue_test.go
+++ b/internal/view/issue_test.go
@@ -51,8 +51,36 @@ func TestIssueRenderInPlainView(t *testing.T) {
 		Server:  "https://test.local",
 		Data:    data,
 		Display: DisplayFormat{
-			Plain:     true,
-			NoHeaders: false,
+			Plain:      true,
+			NoHeaders:  false,
+			NoTruncate: false,
+		},
+	}
+
+	assert.NoError(t, issue.renderPlain(&b))
+
+	expected := `TYPE	KEY	SUMMARY	STATUS
+Bug	TEST-1	This is a test	Done
+Story	TEST-2	This is another test	Open
+`
+
+	assert.Equal(t, expected, b.String())
+}
+
+func TestIssueRenderInPlainViewAndNoTruncate(t *testing.T) {
+	var b bytes.Buffer
+
+	data := getIssues()
+
+	issue := IssueList{
+		Total:   2,
+		Project: "TEST",
+		Server:  "https://test.local",
+		Data:    data,
+		Display: DisplayFormat{
+			Plain:      true,
+			NoHeaders:  false,
+			NoTruncate: true,
 		},
 	}
 
@@ -77,8 +105,9 @@ func TestIssueRenderInPlainViewWithoutHeaders(t *testing.T) {
 		Server:  "https://test.local",
 		Data:    data,
 		Display: DisplayFormat{
-			Plain:     true,
-			NoHeaders: true,
+			Plain:      true,
+			NoHeaders:  true,
+			NoTruncate: true,
 		},
 	}
 


### PR DESCRIPTION
Trim columns by default in plain mode so that it won't overflow the screen. A new `--no-truncate` option is available to display all available fields in plain mode.

EG:
```
# This will only display 4 fields by default
$ jira issue --plain

# However, this will display all available fields
$ jira issue --plain --no-truncate
```
