### PR TITLE
chore: Refactor config as per XDG spec

### DIFF
--- a/cmd/jira/init.go
+++ b/cmd/jira/init.go
@@ -25,11 +25,11 @@ func initialize(*cobra.Command, []string) {
 	if err := c.Generate(); err != nil {
 		switch err {
 		case jiraConfig.ErrSkip:
-			fmt.Printf("\n\033[0;32m✓\033[0m Skipping config generation. Current config: %s\n", viper.ConfigFileUsed())
+			fmt.Printf("\033[0;32m✓\033[0m Skipping config generation. Current config: %s\n", viper.ConfigFileUsed())
 		case jira.ErrUnexpectedStatusCode:
-			printErrF("\n\033[0;31m✗\033[0m Received unexpected status code from jira. Please try again.")
+			printErrF("\033[0;31m✗\033[0m Received unexpected status code from jira. Please try again.")
 		default:
-			printErrF("\n\033[0;31m✗\033[0m Unable to generate configuration: %s", viper.ConfigFileUsed())
+			printErrF("\033[0;31m✗\033[0m Unable to generate configuration: %s", err.Error())
 		}
 
 		os.Exit(1)

--- a/cmd/jira/root.go
+++ b/cmd/jira/root.go
@@ -15,6 +15,8 @@ import (
 )
 
 const (
+	configDir     = ".config/jira"
+	configName    = ".jira"
 	clientTimeout = 15 * time.Second
 	refreshRate   = 100 * time.Millisecond
 )
@@ -56,8 +58,14 @@ func Execute() error {
 func init() {
 	cobra.OnInitialize(initConfig, initJiraClient)
 
-	rootCmd.PersistentFlags().StringVarP(&config, "config", "c", "", "Config file (default is $HOME/.jira.yml)")
-	rootCmd.PersistentFlags().StringVarP(&project, "project", "p", "", "Jira project to look into (defaults to value from $HOME/.jira.yml)")
+	rootCmd.PersistentFlags().StringVarP(
+		&config, "config", "c", "",
+		fmt.Sprintf("Config file (default is $HOME/%s/%s.yml)", configDir, configName),
+	)
+	rootCmd.PersistentFlags().StringVarP(
+		&project, "project", "p", "",
+		fmt.Sprintf("Jira project to look into (defaults to value from $HOME/%s/%s.yml)", configDir, configName),
+	)
 	rootCmd.PersistentFlags().BoolVar(&debug, "debug", false, "Turn on debug output")
 
 	_ = viper.BindPFlag("config", rootCmd.PersistentFlags().Lookup("config"))
@@ -71,8 +79,8 @@ func initConfig() {
 		home, err := homedir.Dir()
 		exitIfError(err)
 
-		viper.AddConfigPath(home)
-		viper.SetConfigName(".jira")
+		viper.AddConfigPath(fmt.Sprintf("%s/%s", home, configDir))
+		viper.SetConfigName(configName)
 	}
 
 	viper.AutomaticEnv()

--- a/internal/config/generator.go
+++ b/internal/config/generator.go
@@ -16,6 +16,7 @@ import (
 )
 
 const (
+	configDir     = ".config/jira"
 	configFile    = ".jira.yml"
 	clientTimeout = 15 * time.Second
 	refreshRate   = 100 * time.Millisecond
@@ -67,7 +68,7 @@ func (c *JiraCLIConfig) Generate() error {
 			return err
 		}
 
-		return create(home + "/" + configFile)
+		return create(fmt.Sprintf("%s/%s/", home, configDir), configFile)
 	}(); err != nil {
 		return err
 	}
@@ -287,14 +288,22 @@ func shallOverwrite() bool {
 	return ans
 }
 
-func create(path string) error {
-	if Exists(path) {
-		if err := os.Rename(path, path+".bkp"); err != nil {
+func create(path, name string) error {
+	if !Exists(path) {
+		if err := os.MkdirAll(path, 0700); err != nil {
 			return err
 		}
 	}
 
-	_, err := os.Create(path)
+	file := path + name
+
+	if Exists(file) {
+		if err := os.Rename(file, file+".bkp"); err != nil {
+			return err
+		}
+	}
+
+	_, err := os.Create(file)
 
 	return err
 }

--- a/internal/config/generator_test.go
+++ b/internal/config/generator_test.go
@@ -53,15 +53,17 @@ func TestCreate(t *testing.T) {
 	cwd, err := os.Getwd()
 	assert.NoError(t, err)
 
-	file := cwd + "/testdata/.jira.yml"
+	path := cwd + "/testdata/.tmp/"
+	file := ".jira.yml"
 
 	// case: file doesn't exist
-	assert.NoError(t, create(file))
+	assert.NoError(t, create(path, file))
 
 	// case: file exists, will create .bkp file
-	assert.NoError(t, create(file))
+	assert.NoError(t, create(path, file))
 
 	// Remove created file. Fails if those files were not created.
-	assert.NoError(t, os.Remove(file))
-	assert.NoError(t, os.Remove(file+".bkp"))
+	assert.NoError(t, os.Remove(path+file))
+	assert.NoError(t, os.Remove(path+file+".bkp"))
+	assert.NoError(t, os.Remove(path))
 }


### PR DESCRIPTION
This PR moves config to `$HOME/.config` from `$HOME` as recommended by the [XDG spec](https://wiki.archlinux.org/index.php/XDG_Base_Directory#Specification). We don't comply with the full spec though.
