### PR TITLE
fix: Back2back codeblock formatting issue

### DIFF
--- a/pkg/adf/markdown.go
+++ b/pkg/adf/markdown.go
@@ -24,7 +24,7 @@ type MarkdownTranslator struct {
 func (tr *MarkdownTranslator) Open(n Connector, d int) string {
 	var tag strings.Builder
 
-	nt := n.GetType()
+	nt, attrs := n.GetType(), n.GetAttributes()
 	tag.WriteString(tr.levelUp(nt, d))
 
 	switch nt {
@@ -32,6 +32,20 @@ func (tr *MarkdownTranslator) Open(n Connector, d int) string {
 		tag.WriteString("> ")
 	case NodeCodeBlock:
 		tag.WriteString("```")
+
+		nl := true
+		if attrs != nil {
+			a := attrs.(map[string]interface{})
+			for k := range a {
+				if k == "language" {
+					nl = false
+					break
+				}
+			}
+		}
+		if nl {
+			tag.WriteString("\n")
+		}
 	case NodePanel:
 		tag.WriteString("---\n")
 	case NodeTable:
@@ -85,7 +99,7 @@ func (tr *MarkdownTranslator) Open(n Connector, d int) string {
 		tag.WriteString(" [")
 	}
 
-	tag.WriteString(tr.setOpenTagAttributes(n.GetAttributes()))
+	tag.WriteString(tr.setOpenTagAttributes(attrs))
 
 	return tag.String()
 }


### PR DESCRIPTION
The description is not displayed as expected if there is back to back code block. This PR fixes the formatting issue.

**Before**
<img width="430" alt="Screen Shot 2021-01-28 at 19 09 19" src="https://user-images.githubusercontent.com/2364546/106182654-71b03600-619f-11eb-9aa3-24a779853f6c.png">

**After**
<img width="425" alt="Screen Shot 2021-01-28 at 19 10 27" src="https://user-images.githubusercontent.com/2364546/106182667-770d8080-619f-11eb-9c00-32689b907527.png">
