### PR TITLE
feat: Respect XDG_CONFIG_HOME env

### DIFF
--- a/internal/cmd/root/root.go
+++ b/internal/cmd/root/root.go
@@ -3,7 +3,6 @@ package root
 import (
 	"fmt"
 
-	"github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
@@ -21,11 +20,6 @@ import (
 	jiraConfig "github.com/ankitpokhrel/jira-cli/internal/config"
 )
 
-const (
-	configDir  = ".config/jira"
-	configName = ".jira"
-)
-
 var (
 	config string
 	debug  bool
@@ -36,14 +30,14 @@ func init() {
 		if config != "" {
 			viper.SetConfigFile(config)
 		} else {
-			home, err := homedir.Dir()
+			home, err := cmdutil.GetConfigHome()
 			if err != nil {
 				cmdutil.Errorf("Error: %s", err)
 				return
 			}
 
-			viper.AddConfigPath(fmt.Sprintf("%s/%s", home, configDir))
-			viper.SetConfigName(configName)
+			viper.AddConfigPath(fmt.Sprintf("%s/%s", home, jiraConfig.Dir))
+			viper.SetConfigName(jiraConfig.FileName)
 		}
 
 		viper.AutomaticEnv()
@@ -79,11 +73,11 @@ func NewCmdRoot() *cobra.Command {
 
 	cmd.PersistentFlags().StringVarP(
 		&config, "config", "c", "",
-		fmt.Sprintf("Config file (default is $HOME/%s/%s.yml)", configDir, configName),
+		fmt.Sprintf("Config file (default is $HOME/%s/%s.yml)", jiraConfig.Dir, jiraConfig.FileName),
 	)
 	cmd.PersistentFlags().StringP(
 		"project", "p", "",
-		fmt.Sprintf("Jira project to look into (defaults to value from $HOME/%s/%s.yml)", configDir, configName),
+		fmt.Sprintf("Jira project to look into (defaults to value from $HOME/%s/%s.yml)", jiraConfig.Dir, jiraConfig.FileName),
 	)
 	cmd.PersistentFlags().BoolVar(&debug, "debug", false, "Turn on debug output")
 

--- a/internal/cmdutil/utils.go
+++ b/internal/cmdutil/utils.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/briandowns/spinner"
 	"github.com/fatih/color"
+	"github.com/mitchellh/go-homedir"
 	"github.com/pkg/browser"
 
 	"github.com/ankitpokhrel/jira-cli/pkg/jira"
@@ -65,4 +66,17 @@ func FormatDateTimeHuman(dt, format string) string {
 		return dt
 	}
 	return t.Format("Mon, 02 Jan 06")
+}
+
+// GetConfigHome returns the config home directory.
+func GetConfigHome() (string, error) {
+	home := os.Getenv("XDG_CONFIG_HOME")
+	if home != "" {
+		return home, nil
+	}
+	home, err := homedir.Dir()
+	if err != nil {
+		return "", err
+	}
+	return home + "/.config", nil
 }

--- a/internal/cmdutil/utils_test.go
+++ b/internal/cmdutil/utils_test.go
@@ -1,15 +1,19 @@
 package cmdutil
 
 import (
+	"os"
 	"testing"
 	"time"
 
+	"github.com/mitchellh/go-homedir"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/ankitpokhrel/jira-cli/pkg/jira"
 )
 
 func TestFormatDateTimeHuman(t *testing.T) {
+	t.Parallel()
+
 	cases := []struct {
 		name     string
 		format   func() string
@@ -54,4 +58,21 @@ func TestFormatDateTimeHuman(t *testing.T) {
 			assert.Equal(t, tc.expected, tc.format())
 		})
 	}
+}
+
+func TestGetConfigHome(t *testing.T) {
+	t.Parallel()
+
+	userHome, err := homedir.Dir()
+	assert.NoError(t, err)
+
+	configHome, err := GetConfigHome()
+	assert.NoError(t, err)
+	assert.Equal(t, userHome+"/.config", configHome)
+
+	assert.NoError(t, os.Setenv("XDG_CONFIG_HOME", "./test"))
+
+	configHome, err = GetConfigHome()
+	assert.NoError(t, err)
+	assert.Equal(t, "./test", configHome)
 }

--- a/internal/config/generator.go
+++ b/internal/config/generator.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/AlecAivazis/survey/v2"
-	"github.com/mitchellh/go-homedir"
 	"github.com/spf13/viper"
 
 	"github.com/ankitpokhrel/jira-cli/api"
@@ -17,8 +16,12 @@ import (
 )
 
 const (
-	configDir  = ".config/jira"
-	configFile = ".jira.yml"
+	// Dir is a jira-cli config directory.
+	Dir = ".jira"
+	// FileName is a jira-cli config file name.
+	FileName = ".config"
+	// FileExt is a jira-cli config file extension.
+	FileExt = "yml"
 )
 
 var (
@@ -77,12 +80,12 @@ func (c *JiraCLIConfig) Generate() error {
 		s := cmdutil.Info("Creating new configuration...")
 		defer s.Stop()
 
-		home, err := homedir.Dir()
+		home, err := cmdutil.GetConfigHome()
 		if err != nil {
 			return err
 		}
 
-		return create(fmt.Sprintf("%s/%s/", home, configDir), configFile)
+		return create(fmt.Sprintf("%s/%s/", home, Dir), fmt.Sprintf("%s.%s", FileName, FileExt))
 	}(); err != nil {
 		return err
 	}


### PR DESCRIPTION
From the [XDG spec](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html):
 
> $XDG_CONFIG_HOME defines the base directory relative to which user specific configuration files should be stored. If $XDG_CONFIG_HOME is either not set or empty, a default equal to $HOME/.config should be used.

Requires config regeneration.
