### PR TITLE
feat: Ability to add issues to the epic

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,17 @@ $ jira epic create
 $ jira epic create -n"Epic epic" -s"Everything" -yHigh -lbug -lurgent -b"Epic description"
 ```
 
+#### Add
+Add command allows you to add issues to the epic. You can add up to 50 issues to the epic at once.
+
+```sh
+# Add issues to the epic using interactive prompt
+$ jira epic add
+
+# Pass required parameters to skip prompt
+$ jira epic add EPIC_KEY ISSUE_1 ISSUE_2
+```
+
 ### Sprint
 Sprints are displayed in an explorer view by default. You can output the results in a table view using the `--table` flag.
 When viewing sprint issues, you can use all filters available for the issue command. The tool only shows 25 recent sprints.

--- a/internal/cmd/epic/add/add.go
+++ b/internal/cmd/epic/add/add.go
@@ -1,0 +1,127 @@
+package add
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/AlecAivazis/survey/v2"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/ankitpokhrel/jira-cli/api"
+	"github.com/ankitpokhrel/jira-cli/internal/cmdutil"
+	"github.com/ankitpokhrel/jira-cli/internal/query"
+	"github.com/ankitpokhrel/jira-cli/pkg/jira"
+)
+
+const (
+	helpText = `Add issues to an epic.`
+	examples = `$ jira epic add EPIC_KEY ISSUE_1 ISSUE_2`
+)
+
+// NewCmdAdd is an add command.
+func NewCmdAdd() *cobra.Command {
+	return &cobra.Command{
+		Use:     "add EPIC_KEY ISSUE_1 [...ISSUE_N]",
+		Short:   "Add issues to an epic",
+		Long:    helpText,
+		Example: examples,
+		Annotations: map[string]string{
+			"help:args": "EPIC_KEY\t\tEpic to which you want to assign issues to, eg: EPIC-1\n" +
+				"ISSUE_1 [...ISSUE_N]\tKey of the issues to add to an epic (max 50 issues at once)",
+		},
+		Run: add,
+	}
+}
+
+func add(cmd *cobra.Command, args []string) {
+	server := viper.GetString("server")
+	params := parseFlags(cmd.Flags(), args)
+	client := api.Client(jira.Config{Debug: params.debug})
+
+	qs := getQuestions(params)
+	if len(qs) > 0 {
+		ans := struct {
+			EpicKey string
+			Issues  string
+		}{}
+		err := survey.Ask(qs, &ans)
+		cmdutil.ExitIfError(err)
+
+		if params.epicKey == "" {
+			params.epicKey = ans.EpicKey
+		}
+		if len(params.issues) == 0 {
+			issues := strings.Split(ans.Issues, ",")
+			for i, iss := range issues {
+				issues[i] = strings.TrimSpace(iss)
+			}
+			params.issues = issues
+		}
+	}
+
+	err := func() error {
+		s := cmdutil.Info("Adding issues to an epic...")
+		defer s.Stop()
+
+		return client.EpicIssuesAdd(params.epicKey, params.issues...)
+	}()
+	cmdutil.ExitIfError(err)
+
+	fmt.Printf("\033[0;32m✓\033[0m Issues added to the epic %s\n%s/browse/%s\n", params.epicKey, server, params.epicKey)
+}
+
+func parseFlags(flags query.FlagParser, args []string) *addParams {
+	var (
+		epicKey string
+		issues  []string
+	)
+
+	nArgs := len(args)
+	if nArgs > 0 {
+		epicKey = args[0]
+	}
+
+	if nArgs > 1 {
+		issues = args[1:]
+	}
+
+	debug, err := flags.GetBool("debug")
+	cmdutil.ExitIfError(err)
+
+	return &addParams{
+		epicKey: epicKey,
+		issues:  issues,
+		debug:   debug,
+	}
+}
+
+func getQuestions(params *addParams) []*survey.Question {
+	var qs []*survey.Question
+
+	if params.epicKey == "" {
+		qs = append(qs, &survey.Question{
+			Name:     "epicKey",
+			Prompt:   &survey.Input{Message: "Epic Key"},
+			Validate: survey.Required,
+		})
+	}
+	if len(params.issues) == 0 {
+		qs = append(qs, &survey.Question{
+			Name: "issues",
+			Prompt: &survey.Input{
+				Message: "Issues",
+				Help:    "Comma separated list of issues key to add. eg: ISSUE_1, ISSUE_2",
+			},
+			Validate: survey.Required,
+		})
+	}
+
+	return qs
+}
+
+type addParams struct {
+	epicKey string
+	issues  []string
+	debug   bool
+}

--- a/internal/cmd/epic/add/add.go
+++ b/internal/cmd/epic/add/add.go
@@ -51,6 +51,7 @@ func add(cmd *cobra.Command, args []string) {
 		if params.epicKey == "" {
 			params.epicKey = ans.EpicKey
 		}
+
 		if len(params.issues) == 0 {
 			issues := strings.Split(ans.Issues, ",")
 			for i, iss := range issues {
@@ -61,7 +62,7 @@ func add(cmd *cobra.Command, args []string) {
 	}
 
 	err := func() error {
-		s := cmdutil.Info("Adding issues to an epic...")
+		s := cmdutil.Info("Adding issues to the epic...")
 		defer s.Stop()
 
 		return client.EpicIssuesAdd(params.epicKey, params.issues...)
@@ -81,7 +82,6 @@ func parseFlags(flags query.FlagParser, args []string) *addParams {
 	if nArgs > 0 {
 		epicKey = args[0]
 	}
-
 	if nArgs > 1 {
 		issues = args[1:]
 	}

--- a/internal/cmd/epic/epic.go
+++ b/internal/cmd/epic/epic.go
@@ -3,6 +3,7 @@ package epic
 import (
 	"github.com/spf13/cobra"
 
+	"github.com/ankitpokhrel/jira-cli/internal/cmd/epic/add"
 	"github.com/ankitpokhrel/jira-cli/internal/cmd/epic/create"
 	"github.com/ankitpokhrel/jira-cli/internal/cmd/epic/list"
 )
@@ -22,8 +23,9 @@ func NewCmdEpic() *cobra.Command {
 
 	lc := list.NewCmdList()
 	cc := create.NewCmdCreate()
+	ac := add.NewCmdAdd()
 
-	cmd.AddCommand(lc, cc)
+	cmd.AddCommand(lc, cc, ac)
 
 	list.SetFlags(lc)
 	create.SetFlags(cc)

--- a/pkg/jira/client.go
+++ b/pkg/jira/client.go
@@ -99,6 +99,15 @@ func (c *Client) Post(ctx context.Context, path string, body []byte, headers Hea
 	return res, err
 }
 
+// PostV1 sends POST request to v1 version of the jira api.
+func (c *Client) PostV1(ctx context.Context, path string, body []byte, headers Header) (*http.Response, error) {
+	res, err := c.request(ctx, http.MethodPost, c.server+baseURLv1+path, body, headers)
+	if err != nil {
+		return res, err
+	}
+	return res, err
+}
+
 // Put sends PUT request to v3 version of the jira api.
 func (c *Client) Put(ctx context.Context, path string, body []byte, headers Header) (*http.Response, error) {
 	res, err := c.request(ctx, http.MethodPut, c.server+baseURLv3+path, body, headers)

--- a/pkg/jira/client_test.go
+++ b/pkg/jira/client_test.go
@@ -76,6 +76,28 @@ func TestPost(t *testing.T) {
 	_ = resp.Body.Close()
 }
 
+func TestPostV1(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/rest/agile/1.0/issue", r.URL.Path)
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+		assert.Equal(t, "jira-cli", r.Header.Get("X-Requested-By"))
+
+		w.WriteHeader(201)
+	}))
+	defer server.Close()
+
+	client := NewClient(Config{Server: server.URL}, WithTimeout(3))
+	resp, err := client.PostV1(context.Background(), "/issue", []byte("hello"), Header{
+		"Content-Type":   "application/json",
+		"X-Requested-By": "jira-cli",
+	})
+
+	assert.NoError(t, err)
+	assert.Equal(t, 201, resp.StatusCode)
+
+	_ = resp.Body.Close()
+}
+
 func TestPut(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "/rest/api/3/issue/TEST-1/assignee", r.URL.Path)

--- a/pkg/jira/epic.go
+++ b/pkg/jira/epic.go
@@ -56,3 +56,34 @@ func (c *Client) EpicIssues(key, jql string, limit uint) (*SearchResult, error) 
 
 	return &out, err
 }
+
+// EpicIssuesAdd adds issues to an epic.
+func (c *Client) EpicIssuesAdd(key string, issues ...string) error {
+	path := fmt.Sprintf("/epic/%s/issue", key)
+
+	data := struct {
+		Issues []string `json:"issues"`
+	}{Issues: issues}
+
+	body, err := json.Marshal(&data)
+	if err != nil {
+		return err
+	}
+
+	res, err := c.PostV1(context.Background(), path, body, Header{
+		"Accept":       "application/json",
+		"Content-Type": "application/json",
+	})
+	if err != nil {
+		return err
+	}
+	if res == nil {
+		return ErrEmptyResponse
+	}
+	defer func() { _ = res.Body.Close() }()
+
+	if res.StatusCode != http.StatusNoContent {
+		return ErrUnexpectedStatusCode
+	}
+	return nil
+}


### PR DESCRIPTION
```sh
$ jira epic add -h
Add issues to an epic.

USAGE
  jira epic add EPIC_KEY ISSUE_1 [...ISSUE_N] [flags]

FLAGS
  -h, --help   help for add

INHERITED FLAGS
  -c, --config string    Config file (default is $HOME/.jira/.config.yml)
      --debug            Turn on debug output
  -p, --project string   Jira project to look into (defaults to value from $HOME/.jira/.config.yml)

ARGUMENTS
  EPIC_KEY		Epic to which you want to assign issues to, eg: EPIC-1
  ISSUE_1 [...ISSUE_N]	Key of the issues to add to an epic (max 50 issues at once)

EXAMPLES
  $ jira epic add EPIC_KEY ISSUE_1 ISSUE_2

LEARN MORE
  Use 'jira <command> <subcommand> --help' for more information about a command.
```

#### Example
```sh
# Yields a prompt
$ jira epic add

# Add ISSUE_1 and ISSUE_2 to EPIC_KEY
$ jira epic add EPIC_KEY ISSUE_1 ISSUE_2
```
