### PR TITLE
feat: Ability to unassign epic from issues

### DIFF
--- a/internal/cmd/epic/add/add.go
+++ b/internal/cmd/epic/add/add.go
@@ -26,6 +26,7 @@ func NewCmdAdd() *cobra.Command {
 		Short:   "Add issues to an epic",
 		Long:    helpText,
 		Example: examples,
+		Aliases: []string{"assign"},
 		Annotations: map[string]string{
 			"help:args": "EPIC_KEY\t\tEpic to which you want to assign issues to, eg: EPIC-1\n" +
 				"ISSUE_1 [...ISSUE_N]\tKey of the issues to add to an epic (max 50 issues at once)",

--- a/internal/cmd/epic/epic.go
+++ b/internal/cmd/epic/epic.go
@@ -6,6 +6,7 @@ import (
 	"github.com/ankitpokhrel/jira-cli/internal/cmd/epic/add"
 	"github.com/ankitpokhrel/jira-cli/internal/cmd/epic/create"
 	"github.com/ankitpokhrel/jira-cli/internal/cmd/epic/list"
+	"github.com/ankitpokhrel/jira-cli/internal/cmd/epic/remove"
 )
 
 const helpText = `Epic manage epics in a given project. See available commands below.`
@@ -24,8 +25,9 @@ func NewCmdEpic() *cobra.Command {
 	lc := list.NewCmdList()
 	cc := create.NewCmdCreate()
 	ac := add.NewCmdAdd()
+	rc := remove.NewCmdRemove()
 
-	cmd.AddCommand(lc, cc, ac)
+	cmd.AddCommand(lc, cc, ac, rc)
 
 	list.SetFlags(lc)
 	create.SetFlags(cc)

--- a/internal/cmd/epic/remove/remove.go
+++ b/internal/cmd/epic/remove/remove.go
@@ -1,0 +1,101 @@
+package remove
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/AlecAivazis/survey/v2"
+	"github.com/spf13/cobra"
+
+	"github.com/ankitpokhrel/jira-cli/api"
+	"github.com/ankitpokhrel/jira-cli/internal/cmdutil"
+	"github.com/ankitpokhrel/jira-cli/internal/query"
+	"github.com/ankitpokhrel/jira-cli/pkg/jira"
+)
+
+const (
+	helpText = `Remove issues from an epic.`
+	examples = `$ jira epic remove ISSUE_1 ISSUE_2`
+)
+
+// NewCmdRemove is a remove command.
+func NewCmdRemove() *cobra.Command {
+	return &cobra.Command{
+		Use:     "remove ISSUE_1 [...ISSUE_N]",
+		Short:   "Remove issues from an epic",
+		Long:    helpText,
+		Example: examples,
+		Aliases: []string{"rm", "unassign"},
+		Annotations: map[string]string{
+			"help:args": "ISSUE_1 [...ISSUE_N]\tKey of the issues to remove from epics (max 50 issues at once)",
+		},
+		Run: remove,
+	}
+}
+
+func remove(cmd *cobra.Command, args []string) {
+	params := parseFlags(cmd.Flags(), args)
+	client := api.Client(jira.Config{Debug: params.debug})
+
+	qs := getQuestions(params)
+	if len(qs) > 0 {
+		ans := struct {
+			EpicKey string
+			Issues  string
+		}{}
+		err := survey.Ask(qs, &ans)
+		cmdutil.ExitIfError(err)
+
+		if len(params.issues) == 0 {
+			issues := strings.Split(ans.Issues, ",")
+			for i, iss := range issues {
+				issues[i] = strings.TrimSpace(iss)
+			}
+			params.issues = issues
+		}
+	}
+
+	err := func() error {
+		s := cmdutil.Info("Removing issues from epics...")
+		defer s.Stop()
+
+		return client.EpicIssuesRemove(params.issues...)
+	}()
+	cmdutil.ExitIfError(err)
+
+	fmt.Printf("\033[0;32m✓\033[0m Issues removed from epics\n")
+}
+
+func parseFlags(flags query.FlagParser, args []string) *removeParams {
+	issues := args[0:]
+
+	debug, err := flags.GetBool("debug")
+	cmdutil.ExitIfError(err)
+
+	return &removeParams{
+		issues: issues,
+		debug:  debug,
+	}
+}
+
+func getQuestions(params *removeParams) []*survey.Question {
+	var qs []*survey.Question
+
+	if len(params.issues) == 0 {
+		qs = append(qs, &survey.Question{
+			Name: "issues",
+			Prompt: &survey.Input{
+				Message: "Issues",
+				Help:    "Comma separated list of issues key to remove. eg: ISSUE_1, ISSUE_2",
+			},
+			Validate: survey.Required,
+		})
+	}
+
+	return qs
+}
+
+type removeParams struct {
+	issues []string
+	debug  bool
+}

--- a/internal/cmd/epic/remove/remove.go
+++ b/internal/cmd/epic/remove/remove.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	helpText = `Remove issues from an epic.`
+	helpText = `Remove/unassign epic from issues.`
 	examples = `$ jira epic remove ISSUE_1 ISSUE_2`
 )
 
@@ -22,12 +22,12 @@ const (
 func NewCmdRemove() *cobra.Command {
 	return &cobra.Command{
 		Use:     "remove ISSUE_1 [...ISSUE_N]",
-		Short:   "Remove issues from an epic",
+		Short:   "Remove/unassign epic from issues",
 		Long:    helpText,
 		Example: examples,
 		Aliases: []string{"rm", "unassign"},
 		Annotations: map[string]string{
-			"help:args": "ISSUE_1 [...ISSUE_N]\tKey of the issues to remove from epics (max 50 issues at once)",
+			"help:args": "ISSUE_1 [...ISSUE_N]\tKey of the issues to remove assigned epic (max 50 issues at once)",
 		},
 		Run: remove,
 	}
@@ -56,14 +56,14 @@ func remove(cmd *cobra.Command, args []string) {
 	}
 
 	err := func() error {
-		s := cmdutil.Info("Removing issues from epics...")
+		s := cmdutil.Info("Removing assigned epic from issues...")
 		defer s.Stop()
 
 		return client.EpicIssuesRemove(params.issues...)
 	}()
 	cmdutil.ExitIfError(err)
 
-	fmt.Printf("\033[0;32m✓\033[0m Issues removed from epics\n")
+	fmt.Printf("\033[0;32m✓\033[0m Epic unassigned from given issues\n")
 }
 
 func parseFlags(flags query.FlagParser, args []string) *removeParams {

--- a/pkg/jira/epic.go
+++ b/pkg/jira/epic.go
@@ -87,3 +87,34 @@ func (c *Client) EpicIssuesAdd(key string, issues ...string) error {
 	}
 	return nil
 }
+
+// EpicIssuesRemove removes issues from epics.
+func (c *Client) EpicIssuesRemove(issues ...string) error {
+	path := "/epic/none/issue"
+
+	data := struct {
+		Issues []string `json:"issues"`
+	}{Issues: issues}
+
+	body, err := json.Marshal(&data)
+	if err != nil {
+		return err
+	}
+
+	res, err := c.PostV1(context.Background(), path, body, Header{
+		"Accept":       "application/json",
+		"Content-Type": "application/json",
+	})
+	if err != nil {
+		return err
+	}
+	if res == nil {
+		return ErrEmptyResponse
+	}
+	defer func() { _ = res.Body.Close() }()
+
+	if res.StatusCode != http.StatusNoContent {
+		return ErrUnexpectedStatusCode
+	}
+	return nil
+}


### PR DESCRIPTION
Main command `remove`, aliases `rm` and `unassign`.

```sh
$ jira epic remove ISSUE-1 ISSUE-2
$ jira epic rm ISSUE-1
$ jira epic unassign ISSUE-1 ISSUE-N
```
