### PR TITLE
feat: Support template for description during issue creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,9 +190,23 @@ $ jira issue create -tBug -s"New Bug" -yHigh -lbug -lurgent -b"Bug description"
 
 ![Create an issue](.github/assets/create.gif)
 
-The create command supports [Github](https://github.github.com/gfm/) and/or [Jira flavored markdown](https://jira.atlassian.com/secure/WikiRendererHelpAction.jspa?section=all) for writing description.
+The command supports [Github-flavored](https://github.github.com/gfm/)
+and/or [Jira-flavored](https://jira.atlassian.com/secure/WikiRendererHelpAction.jspa?section=all) markdown for writing
+description. You can load pre-defined templates using `--template` flag.
+
+```sh
+# Load description from template file
+$ jira issue create --template /path/to/template.tmpl
+
+# Get description from standard input
+$ jira issue create --template -
+
+# Or, use pipe to read input directly from standard input
+$ echo "Description from stdin" | jira issue create -s"Summary" -tTask
+```
 
 ![Markdown render preview](.github/assets/markdown.jpg)
+> The preview above shows markdown template passed in Jira CLI and how it is rendered in the Jira UI.
 
 #### Assign
 The `assign` command lets you assign user to an issue.

--- a/README.md
+++ b/README.md
@@ -190,8 +190,8 @@ $ jira issue create -tBug -s"New Bug" -yHigh -lbug -lurgent -b"Bug description"
 
 ![Create an issue](.github/assets/create.gif)
 
-The command supports [Github-flavored](https://github.github.com/gfm/)
-and/or [Jira-flavored](https://jira.atlassian.com/secure/WikiRendererHelpAction.jspa?section=all) markdown for writing
+The command supports both [Github-flavored](https://github.github.com/gfm/)
+and [Jira-flavored](https://jira.atlassian.com/secure/WikiRendererHelpAction.jspa?section=all) markdown for writing
 description. You can load pre-defined templates using `--template` flag.
 
 ```sh

--- a/internal/cmd/epic/create/create.go
+++ b/internal/cmd/epic/create/create.go
@@ -180,10 +180,10 @@ func (cc *createCmd) getQuestions() []*survey.Question {
 
 	var defaultBody string
 
-	if cc.params.bodyFile != "" {
-		b, err := cmdutil.ReadFile(cc.params.bodyFile)
+	if cc.params.template != "" {
+		b, err := cmdutil.ReadFile(cc.params.template)
 		if err != nil {
-			b = []byte(fmt.Sprintf("Unable to load body from file: %s", cc.params.bodyFile))
+			cmdutil.Errorf(fmt.Sprintf("\u001B[0;31m✗\u001B[0m Error: %s", err))
 		}
 		defaultBody = string(b)
 	}
@@ -218,7 +218,7 @@ type createCmd struct {
 }
 
 func (cc *createCmd) isNonInteractive() bool {
-	return cmdutil.StdinHasData() || cc.params.bodyFile == "-"
+	return cmdutil.StdinHasData() || cc.params.template == "-"
 }
 
 func (cc *createCmd) isMandatoryParamsMissing() bool {
@@ -233,7 +233,7 @@ type createParams struct {
 	assignee   string
 	labels     []string
 	components []string
-	bodyFile   string
+	template   string
 	noInput    bool
 	debug      bool
 }
@@ -260,7 +260,7 @@ func parseFlags(flags query.FlagParser) *createParams {
 	components, err := flags.GetStringArray("component")
 	cmdutil.ExitIfError(err)
 
-	bodyFile, err := flags.GetString("template")
+	template, err := flags.GetString("template")
 	cmdutil.ExitIfError(err)
 
 	noInput, err := flags.GetBool("no-input")
@@ -277,7 +277,7 @@ func parseFlags(flags query.FlagParser) *createParams {
 		assignee:   assignee,
 		labels:     labels,
 		components: components,
-		bodyFile:   bodyFile,
+		template:   template,
 		noInput:    noInput,
 		debug:      debug,
 	}

--- a/internal/cmd/epic/create/create.go
+++ b/internal/cmd/epic/create/create.go
@@ -59,7 +59,7 @@ func create(cmd *cobra.Command, _ []string) {
 
 		if cc.isMandatoryParamsMissing() {
 			cmdutil.Errorf(
-				"\u001B[0;31m✗\u001B[0m Mandatory params `--summary` and `--name` is required when using non-interactive mode",
+				"\u001B[0;31m✗\u001B[0m Params `--summary` and `--name` is mandatory when using a non-interactive mode",
 			)
 		}
 	}
@@ -180,7 +180,7 @@ func (cc *createCmd) getQuestions() []*survey.Question {
 
 	var defaultBody string
 
-	if cc.params.template != "" {
+	if cc.params.template != "" || cmdutil.StdinHasData() {
 		b, err := cmdutil.ReadFile(cc.params.template)
 		if err != nil {
 			cmdutil.Errorf(fmt.Sprintf("\u001B[0;31m✗\u001B[0m Error: %s", err))

--- a/internal/cmd/epic/create/create.go
+++ b/internal/cmd/epic/create/create.go
@@ -260,7 +260,7 @@ func parseFlags(flags query.FlagParser) *createParams {
 	components, err := flags.GetStringArray("component")
 	cmdutil.ExitIfError(err)
 
-	bodyFile, err := flags.GetString("body-file")
+	bodyFile, err := flags.GetString("template")
 	cmdutil.ExitIfError(err)
 
 	noInput, err := flags.GetBool("no-input")

--- a/internal/cmd/issue/create/create.go
+++ b/internal/cmd/issue/create/create.go
@@ -59,7 +59,7 @@ func create(cmd *cobra.Command, _ []string) {
 
 		if cc.isMandatoryParamsMissing() {
 			cmdutil.Errorf(
-				"\u001B[0;31m✗\u001B[0m Mandatory params `--summary` and `--type` is required when using non-interactive mode",
+				"\u001B[0;31m✗\u001B[0m Params `--summary` and `--type` is mandatory when using a non-interactive mode",
 			)
 		}
 	}
@@ -222,7 +222,7 @@ func (cc *createCmd) getQuestions() []*survey.Question {
 
 	var defaultBody string
 
-	if cc.params.template != "" {
+	if cc.params.template != "" || cmdutil.StdinHasData() {
 		b, err := cmdutil.ReadFile(cc.params.template)
 		if err != nil {
 			cmdutil.Errorf(fmt.Sprintf("\u001B[0;31m✗\u001B[0m Error: %s", err))

--- a/internal/cmd/issue/create/create.go
+++ b/internal/cmd/issue/create/create.go
@@ -222,10 +222,10 @@ func (cc *createCmd) getQuestions() []*survey.Question {
 
 	var defaultBody string
 
-	if cc.params.bodyFile != "" {
-		b, err := cmdutil.ReadFile(cc.params.bodyFile)
+	if cc.params.template != "" {
+		b, err := cmdutil.ReadFile(cc.params.template)
 		if err != nil {
-			b = []byte(fmt.Sprintf("Unable to load body from file: %s", cc.params.bodyFile))
+			cmdutil.Errorf(fmt.Sprintf("\u001B[0;31m✗\u001B[0m Error: %s", err))
 		}
 		defaultBody = string(b)
 	}
@@ -254,7 +254,7 @@ func (cc *createCmd) getQuestions() []*survey.Question {
 }
 
 func (cc *createCmd) isNonInteractive() bool {
-	return cmdutil.StdinHasData() || cc.params.bodyFile == "-"
+	return cmdutil.StdinHasData() || cc.params.template == "-"
 }
 
 func (cc *createCmd) isMandatoryParamsMissing() bool {
@@ -269,7 +269,7 @@ type createParams struct {
 	assignee   string
 	labels     []string
 	components []string
-	bodyFile   string
+	template   string
 	noInput    bool
 	debug      bool
 }
@@ -296,7 +296,7 @@ func parseFlags(flags query.FlagParser) *createParams {
 	components, err := flags.GetStringArray("component")
 	cmdutil.ExitIfError(err)
 
-	bodyFile, err := flags.GetString("template")
+	template, err := flags.GetString("template")
 	cmdutil.ExitIfError(err)
 
 	noInput, err := flags.GetBool("no-input")
@@ -313,7 +313,7 @@ func parseFlags(flags query.FlagParser) *createParams {
 		assignee:   assignee,
 		labels:     labels,
 		components: components,
-		bodyFile:   bodyFile,
+		template:   template,
 		noInput:    noInput,
 		debug:      debug,
 	}

--- a/internal/cmd/issue/create/create.go
+++ b/internal/cmd/issue/create/create.go
@@ -296,7 +296,7 @@ func parseFlags(flags query.FlagParser) *createParams {
 	components, err := flags.GetStringArray("component")
 	cmdutil.ExitIfError(err)
 
-	bodyFile, err := flags.GetString("body-file")
+	bodyFile, err := flags.GetString("template")
 	cmdutil.ExitIfError(err)
 
 	noInput, err := flags.GetBool("no-input")

--- a/internal/cmdcommon/create.go
+++ b/internal/cmdcommon/create.go
@@ -29,7 +29,7 @@ func SetCreateFlags(cmd *cobra.Command, prefix string) {
 	cmd.Flags().StringP("assignee", "a", "", prefix+" assignee (email or display name)")
 	cmd.Flags().StringArrayP("label", "l", []string{}, prefix+" labels")
 	cmd.Flags().StringArrayP("component", "C", []string{}, prefix+" components")
-	cmd.Flags().StringP("body-file", "F", "", "Path to a file to read body/description from")
+	cmd.Flags().StringP("template", "T", "", "Path to a file to read body/description from")
 	cmd.Flags().Bool("web", false, "Open in web browser after successful creation")
 	cmd.Flags().Bool("no-input", false, "Disable prompt for non-required fields")
 }

--- a/internal/cmdcommon/create.go
+++ b/internal/cmdcommon/create.go
@@ -29,6 +29,7 @@ func SetCreateFlags(cmd *cobra.Command, prefix string) {
 	cmd.Flags().StringP("assignee", "a", "", prefix+" assignee (email or display name)")
 	cmd.Flags().StringArrayP("label", "l", []string{}, prefix+" labels")
 	cmd.Flags().StringArrayP("component", "C", []string{}, prefix+" components")
+	cmd.Flags().StringP("body-file", "F", "", "Path to a file to read body/description from")
 	cmd.Flags().Bool("web", false, "Open in web browser after successful creation")
 	cmd.Flags().Bool("no-input", false, "Disable prompt for non-required fields")
 }

--- a/internal/cmdutil/utils.go
+++ b/internal/cmdutil/utils.go
@@ -2,6 +2,7 @@ package cmdutil
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
 	"time"
 
@@ -79,4 +80,26 @@ func GetConfigHome() (string, error) {
 		return "", err
 	}
 	return home + "/.config", nil
+}
+
+// StdinHasData checks if standard input has any data to be processed.
+func StdinHasData() bool {
+	fi, err := os.Stdin.Stat()
+	if err != nil {
+		return false
+	}
+	if fi.Mode()&os.ModeNamedPipe == 0 {
+		return false
+	}
+	return true
+}
+
+// ReadFile reads contents of the given file.
+func ReadFile(filePath string) ([]byte, error) {
+	if filePath == "-" {
+		b, err := ioutil.ReadAll(os.Stdin)
+		_ = os.Stdin.Close()
+		return b, err
+	}
+	return ioutil.ReadFile(filePath)
 }

--- a/internal/cmdutil/utils.go
+++ b/internal/cmdutil/utils.go
@@ -96,10 +96,13 @@ func StdinHasData() bool {
 
 // ReadFile reads contents of the given file.
 func ReadFile(filePath string) ([]byte, error) {
-	if filePath == "-" {
+	if filePath != "-" && filePath != "" {
+		return ioutil.ReadFile(filePath)
+	}
+	if filePath == "-" || StdinHasData() {
 		b, err := ioutil.ReadAll(os.Stdin)
 		_ = os.Stdin.Close()
 		return b, err
 	}
-	return ioutil.ReadFile(filePath)
+	return []byte(""), nil
 }


### PR DESCRIPTION
This PR adds an ability to load description from pre-defined template. It adds an option called `--template` that can be used to pass pre-defined templates. The template supports [Github flavored](https://github.github.com/gfm/) and/or [Jira flavored markdown](https://jira.atlassian.com/secure/WikiRendererHelpAction.jspa?section=all).

- Create issue using a pre-defined template. The template will be loaded to screen in interactive mode.
	```sh
	$ jira issue create -s"Testing Template 101" -tTask --template /path/to/template.tmpl
	? Description <Received>
	? What's next? Submit 
	✓ Issue created
	https://antiklabs.atlassian.net/browse/ANK-169
	```

- Create issue directly using a pre-defined template.
	```sh
	$ jira issue create -s"Testing Template 101" -tTask --template ~/Desktop/desc.tmpl --no-input
	✓ Issue created
	https://antiklabs.atlassian.net/browse/ANK-170
	```

- Make sure to pass mandatory params when piping through stdin.
	```sh
	$ echo "stdin" | jira issue create -s"Testing Markdown 101"
	✗ Params `--summary` and `--type` is mandatory when using a non-interactive mode
	```

- Use `-` for interactive stdin input
	```sh
	$ jira issue create -s"Testing Markdown 101" -tTask --template -
	This is a template from stdin
	✓ Issue created
	https://antiklabs.atlassian.net/browse/ANK-168
	```