### PR TITLE
feat: Support markdown and template when adding comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,7 +271,9 @@ $ jira issue link ISSUE-1 ISSUE-2 Blocks
 The `comment` command provides a list of sub-commands to manage issue comments.
 
 ##### Add
-The `add` command lets you add comment to an issue. The command only supports plain text comment at the moment.
+The `add` command lets you add comment to an issue. The command supports both [Github-flavored](https://github.github.com/gfm/)
+and [Jira-flavored](https://jira.atlassian.com/secure/WikiRendererHelpAction.jspa?section=all) markdown for writing
+comment. You can load pre-defined templates using `--template` flag.
 
 ```sh
 # Add a comment using interactive prompt
@@ -280,8 +282,14 @@ $ jira issue comment add
 # Pass required parameters to skip prompt
 $ jira issue comment add ISSUE-1 "My comment body"
 
-# Supports multi-line comments
-$ jira issue comment add ISSUE-1 $'This comment has\n\nNew line'
+# Load comment from template file
+$ jira issue comment add ISSUE-1 --template /path/to/template.tmpl
+
+# Get comment from standard input
+$ jira issue comment add ISSUE-1 --template -
+
+# Or, use pipe to read input directly from standard input
+$ echo "Comment from stdin" | jira issue comment add ISSUE-1
 ```
 
 ### Epic

--- a/internal/cmd/issue/comment/add/add.go
+++ b/internal/cmd/issue/comment/add/add.go
@@ -43,6 +43,7 @@ func NewCmdCommentAdd() *cobra.Command {
 	}
 
 	cmd.Flags().Bool("web", false, "Open issue in web browser after adding comment")
+	cmd.Flags().StringP("template", "T", "", "Path to a file to read comment body from")
 
 	return &cmd
 }
@@ -54,6 +55,12 @@ func add(cmd *cobra.Command, args []string) {
 		client:    client,
 		linkTypes: nil,
 		params:    params,
+	}
+
+	if ac.isNonInteractive() && ac.isMandatoryParamsMissing() {
+		cmdutil.Errorf(
+			"\u001B[0;31m✗\u001B[0m `ISSUE_KEY` is mandatory when using a non-interactive mode",
+		)
 	}
 
 	cmdutil.ExitIfError(ac.setIssueKey())
@@ -102,6 +109,7 @@ func add(cmd *cobra.Command, args []string) {
 type addParams struct {
 	issueKey string
 	body     string
+	template string
 	debug    bool
 }
 
@@ -119,9 +127,13 @@ func parseArgsAndFlags(args []string, flags query.FlagParser) *addParams {
 	debug, err := flags.GetBool("debug")
 	cmdutil.ExitIfError(err)
 
+	template, err := flags.GetString("template")
+	cmdutil.ExitIfError(err)
+
 	return &addParams{
 		issueKey: issueKey,
 		body:     body,
+		template: template,
 		debug:    debug,
 	}
 }
@@ -162,11 +174,31 @@ func (ac *addCmd) getQuestions() []*survey.Question {
 			Validate: survey.Required,
 		})
 	}
+
+	var defaultBody string
+
+	if ac.params.template != "" || cmdutil.StdinHasData() {
+		b, err := cmdutil.ReadFile(ac.params.template)
+		if err != nil {
+			cmdutil.Errorf(fmt.Sprintf("\u001B[0;31m✗\u001B[0m Error: %s", err))
+		}
+		defaultBody = string(b)
+	}
+
+	if defaultBody != "" {
+		ac.params.body = defaultBody
+	}
+
 	if ac.params.body == "" {
 		qs = append(qs, &survey.Question{
 			Name: "body",
 			Prompt: &surveyext.JiraEditor{
-				Editor:       &survey.Editor{Message: "Comment body", HideDefault: true},
+				Editor: &survey.Editor{
+					Message:       "Comment body",
+					Default:       defaultBody,
+					HideDefault:   true,
+					AppendDefault: true,
+				},
 				BlankAllowed: false,
 			},
 		})
@@ -187,4 +219,12 @@ func (ac *addCmd) getNextAction() *survey.Question {
 		},
 		Validate: survey.Required,
 	}
+}
+
+func (ac *addCmd) isNonInteractive() bool {
+	return cmdutil.StdinHasData() || ac.params.template == "-"
+}
+
+func (ac *addCmd) isMandatoryParamsMissing() bool {
+	return ac.params.issueKey == ""
 }

--- a/internal/cmd/issue/create/create.go
+++ b/internal/cmd/issue/create/create.go
@@ -231,7 +231,9 @@ func (cc *createCmd) getQuestions() []*survey.Question {
 	}
 
 	if cc.params.noInput {
-		cc.params.body = defaultBody
+		if cc.params.body == "" {
+			cc.params.body = defaultBody
+		}
 		return qs
 	}
 

--- a/pkg/jira/issue_test.go
+++ b/pkg/jira/issue_test.go
@@ -244,14 +244,14 @@ func TestAddIssueComment(t *testing.T) {
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "POST", r.Method)
-		assert.Equal(t, "/rest/api/3/issue/TEST-1/comment", r.URL.Path)
+		assert.Equal(t, "/rest/api/2/issue/TEST-1/comment", r.URL.Path)
 		assert.Equal(t, "application/json", r.Header.Get("Accept"))
 		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
 
 		actualBody := new(strings.Builder)
 		_, _ = io.Copy(actualBody, r.Body)
 
-		expectedBody := `{"body":{"version":1,"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"comment"}]}]}}`
+		expectedBody := `{"body":"comment"}`
 
 		assert.Equal(t, expectedBody, actualBody.String())
 


### PR DESCRIPTION
This PR:
- Lets you write comments using Github/Jira flavored markdown.
- Provide support for templates when adding comments.

```sh
# Load comment from template file
$ jira issue comment add ISSUE-1 --template /path/to/template.tmpl

# Get comment from standard input
$ jira issue comment add ISSUE-1 --template -

# Or, use pipe to read input directly from standard input
$ echo "Comment from stdin" | jira issue comment add ISSUE-1
```

