### PR TITLE
Improve debug mode

### DIFF
--- a/internal/cmd/root/root.go
+++ b/internal/cmd/root/root.go
@@ -90,6 +90,7 @@ func NewCmdRoot() *cobra.Command {
 
 	_ = viper.BindPFlag("config", cmd.PersistentFlags().Lookup("config"))
 	_ = viper.BindPFlag("project", cmd.PersistentFlags().Lookup("project"))
+	_ = viper.BindPFlag("debug", cmd.PersistentFlags().Lookup("debug"))
 
 	addChildCommands(&cmd)
 

--- a/internal/config/generator.go
+++ b/internal/config/generator.go
@@ -168,6 +168,7 @@ func (c *JiraCLIConfig) verifyLoginDetails(server, login string) error {
 	c.jiraClient = api.Client(jira.Config{
 		Server: server,
 		Login:  login,
+		Debug:  viper.GetBool("debug"),
 	})
 	if _, err := c.jiraClient.Me(); err != nil {
 		return err


### PR DESCRIPTION
Fixes #95 

Debug mode now dumps all request and response details (except for the response body).

```sh
$ jira init --debug

REQUEST DETAILS
------------------------------------------------------------

GET /rest/api/3/myself HTTP/1.1
Host: example.atlassian.net
Authorization: Basic <token>



RESPONSE DETAILS
------------------------------------------------------------

HTTP/1.1 401 Unauthorized
Transfer-Encoding: chunked
Atl-Traceid: b21117d7a37cefa4
Cache-Control: no-transform
Connection: keep-alive
Content-Type: application/xml;charset=UTF-8
Date: Sat, 15 May 2021 11:35:38 GMT
Expect-Ct: report-uri="https://web-security-reports.services.atlassian.com/expect-ct-report/global-proxy", enforce, max-age=86400
Server: AtlassianProxy/1.19.3.1
Set-Cookie: atlassian.xsrf.token=afdc4ce5-c887-4abd-ab4e-9dda4de51094_436dd28e9dcc90ce543c13fc41c2939dae0260b0_lout; Path=/; Secure
Set-Cookie: jsd.portal.language.anonymous=en-US; Expires=Sat, 15-May-2021 11:36:37 GMT; Path=/
Strict-Transport-Security: max-age=315360000; includeSubDomains; preload
Timing-Allow-Origin: *
Vary: Accept
Www-Authenticate: OAuth realm="https%3A%2F%2Fexample.atlassian.net"
X-Arequestid: 1a9eb7bc-de9a-4a08-a41b-e851ebed58a0
X-Content-Type-Options: nosniff
X-Envoy-Upstream-Service-Time: 32
X-Xss-Protection: 1; mode=block


✗ Received unexpected status code from jira. Please try again.
```