### PR TITLE
feat: Improve error reporting

### DIFF
--- a/internal/cmd/init/init.go
+++ b/internal/cmd/init/init.go
@@ -27,8 +27,8 @@ func initialize(*cobra.Command, []string) {
 	c := jiraConfig.NewJiraCLIConfig()
 
 	if err := c.Generate(); err != nil {
-		if _, ok := err.(*jira.ErrUnexpectedResponse); ok {
-			cmdutil.Errorf("\n\033[0;31m✗\033[0m Received unexpected status code from jira. Please try again.")
+		if e, ok := err.(*jira.ErrUnexpectedResponse); ok {
+			cmdutil.Errorf("\n\033[0;31m✗\033[0m Received unexpected response '%s' from jira. Please try again.", e.Status)
 		} else {
 			switch err {
 			case jiraConfig.ErrSkip:

--- a/internal/cmd/init/init.go
+++ b/internal/cmd/init/init.go
@@ -27,15 +27,17 @@ func initialize(*cobra.Command, []string) {
 	c := jiraConfig.NewJiraCLIConfig()
 
 	if err := c.Generate(); err != nil {
-		switch err {
-		case jiraConfig.ErrSkip:
-			fmt.Printf("\033[0;32m✓\033[0m Skipping config generation. Current config: %s\n", viper.ConfigFileUsed())
-		case jira.ErrUnexpectedStatusCode:
+		if _, ok := err.(*jira.ErrUnexpectedResponse); ok {
 			cmdutil.Errorf("\n\033[0;31m✗\033[0m Received unexpected status code from jira. Please try again.")
-		case jiraConfig.ErrUnexpectedResponseFormat:
-			cmdutil.Errorf("\n\033[0;31m✗\033[0m Got response in unexpected format when fetching metadata. Please try again.")
-		default:
-			cmdutil.Errorf("\n\033[0;31m✗\033[0m Unable to generate configuration: %s", err.Error())
+		} else {
+			switch err {
+			case jiraConfig.ErrSkip:
+				fmt.Printf("\033[0;32m✓\033[0m Skipping config generation. Current config: %s\n", viper.ConfigFileUsed())
+			case jiraConfig.ErrUnexpectedResponseFormat:
+				cmdutil.Errorf("\n\033[0;31m✗\033[0m Got response in unexpected format when fetching metadata. Please try again.")
+			default:
+				cmdutil.Errorf("\n\033[0;31m✗\033[0m Unable to generate configuration: %s", err.Error())
+			}
 		}
 		os.Exit(1)
 	}

--- a/internal/cmdutil/utils.go
+++ b/internal/cmdutil/utils.go
@@ -29,7 +29,10 @@ func ExitIfError(err error) {
 	var msg string
 
 	if e, ok := err.(*jira.ErrUnexpectedResponse); ok {
-		dm := "jira: Received unexpected response.\nPlease check the parameters you supplied and try again."
+		dm := fmt.Sprintf(
+			"jira: Received unexpected response '%s'.\nPlease check the parameters you supplied and try again.",
+			e.Status,
+		)
 		bd := e.Error()
 
 		msg = dm
@@ -41,11 +44,11 @@ func ExitIfError(err error) {
 		case jira.ErrEmptyResponse:
 			msg = "jira: Received empty response.\nPlease try again."
 		default:
-			msg = err.Error()
+			msg = fmt.Sprintf("Error: %s", err.Error())
 		}
 	}
 
-	Errorf("\n%s", msg)
+	Errorf("%s", msg)
 }
 
 // Info displays spinner.

--- a/internal/cmdutil/utils.go
+++ b/internal/cmdutil/utils.go
@@ -22,20 +22,30 @@ func Errorf(msg string, a ...interface{}) {
 
 // ExitIfError exists with error message if err is not nil.
 func ExitIfError(err error) {
-	if err != nil {
-		var msg string
+	if err == nil {
+		return
+	}
 
+	var msg string
+
+	if e, ok := err.(*jira.ErrUnexpectedResponse); ok {
+		dm := "jira: Received unexpected response.\nPlease check the parameters you supplied and try again."
+		bd := e.Error()
+
+		msg = dm
+		if len(bd) > 0 {
+			msg = fmt.Sprintf("%s\n%s", bd, dm)
+		}
+	} else {
 		switch err {
-		case jira.ErrUnexpectedStatusCode:
-			msg = "jira: Received unexpected response.\nPlease check the parameters you supplied and try again."
 		case jira.ErrEmptyResponse:
 			msg = "jira: Received empty response.\nPlease try again."
 		default:
 			msg = err.Error()
 		}
-
-		Errorf("\nError: %s", msg)
 	}
+
+	Errorf("\n%s", msg)
 }
 
 // Info displays spinner.

--- a/pkg/jira/board.go
+++ b/pkg/jira/board.go
@@ -38,7 +38,7 @@ func (c *Client) Boards(project, boardType string) (*BoardResult, error) {
 	defer func() { _ = res.Body.Close() }()
 
 	if res.StatusCode != http.StatusOK {
-		return nil, ErrUnexpectedStatusCode
+		return nil, formatUnexpectedResponse(res)
 	}
 
 	var out BoardResult

--- a/pkg/jira/board_test.go
+++ b/pkg/jira/board_test.go
@@ -38,7 +38,7 @@ func TestBoards(t *testing.T) {
 	client := NewClient(Config{Server: server.URL}, WithTimeout(3))
 
 	_, err := client.Boards("BAD", "scrum")
-	assert.Error(t, ErrUnexpectedStatusCode, err)
+	assert.Error(t, &ErrUnexpectedResponse{}, err)
 
 	actual, err := client.Boards("TEST", "scrum")
 	assert.NoError(t, err)

--- a/pkg/jira/client.go
+++ b/pkg/jira/client.go
@@ -3,6 +3,7 @@ package jira
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"net"
 	"net/http"
@@ -25,9 +26,44 @@ var (
 	ErrNoResult = fmt.Errorf("jira: no result")
 	// ErrEmptyResponse denotes empty response from the server.
 	ErrEmptyResponse = fmt.Errorf("jira: empty response from server")
-	// ErrUnexpectedStatusCode denotes response code other than 200.
-	ErrUnexpectedStatusCode = fmt.Errorf("jira: unexpected status code")
 )
+
+// ErrUnexpectedResponse denotes response code other than the expected one.
+type ErrUnexpectedResponse struct {
+	Body       Errors
+	Status     string
+	StatusCode int
+}
+
+func (e *ErrUnexpectedResponse) Error() string {
+	return e.Body.String()
+}
+
+// Errors is a jira error type.
+type Errors struct {
+	ErrorMessages   []string
+	WarningMessages []string
+}
+
+func (e Errors) String() string {
+	var out strings.Builder
+
+	if len(e.ErrorMessages) > 0 {
+		out.WriteString("Error:\n")
+		for _, v := range e.ErrorMessages {
+			out.WriteString(fmt.Sprintf("  - %s\n", v))
+		}
+	}
+
+	if len(e.WarningMessages) > 0 {
+		out.WriteString("\nWarning:\n")
+		for _, v := range e.WarningMessages {
+			out.WriteString(fmt.Sprintf("  - %s\n", v))
+		}
+	}
+
+	return out.String()
+}
 
 // Header is a key, value pair for request headers.
 type Header map[string]string
@@ -169,4 +205,17 @@ func prettyPrintDump(heading string, data []byte) {
 	fmt.Printf("\n\n%s", strings.ToUpper(heading))
 	fmt.Printf(fmt.Sprintf("\n%s\n\n", strings.Repeat("-", 60)))
 	fmt.Print(string(data))
+}
+
+func formatUnexpectedResponse(res *http.Response) *ErrUnexpectedResponse {
+	var b Errors
+
+	// We don't care about decoding error here.
+	_ = json.NewDecoder(res.Body).Decode(&b)
+
+	return &ErrUnexpectedResponse{
+		Body:       b,
+		Status:     res.Status,
+		StatusCode: res.StatusCode,
+	}
 }

--- a/pkg/jira/client.go
+++ b/pkg/jira/client.go
@@ -41,6 +41,7 @@ func (e *ErrUnexpectedResponse) Error() string {
 
 // Errors is a jira error type.
 type Errors struct {
+	Errors          map[string]string
 	ErrorMessages   []string
 	WarningMessages []string
 }
@@ -48,10 +49,13 @@ type Errors struct {
 func (e Errors) String() string {
 	var out strings.Builder
 
-	if len(e.ErrorMessages) > 0 {
-		out.WriteString("Error:\n")
+	if len(e.ErrorMessages) > 0 || len(e.Errors) > 0 {
+		out.WriteString("\nError:\n")
 		for _, v := range e.ErrorMessages {
 			out.WriteString(fmt.Sprintf("  - %s\n", v))
+		}
+		for k, v := range e.Errors {
+			out.WriteString(fmt.Sprintf("  - %s: %s\n", k, v))
 		}
 	}
 

--- a/pkg/jira/create.go
+++ b/pkg/jira/create.go
@@ -51,7 +51,7 @@ func (c *Client) Create(req *CreateRequest) (*CreateResponse, error) {
 	defer func() { _ = res.Body.Close() }()
 
 	if res.StatusCode != http.StatusCreated {
-		return nil, ErrUnexpectedStatusCode
+		return nil, formatUnexpectedResponse(res)
 	}
 
 	var out CreateResponse

--- a/pkg/jira/create_test.go
+++ b/pkg/jira/create_test.go
@@ -74,7 +74,7 @@ func TestCreate(t *testing.T) {
 	testServer.statusCode(400)
 
 	_, err = client.Create(&requestData)
-	assert.Error(t, ErrUnexpectedStatusCode, err)
+	assert.Error(t, &ErrUnexpectedResponse{}, err)
 }
 
 func TestCreateEpic(t *testing.T) {
@@ -106,5 +106,5 @@ func TestCreateEpic(t *testing.T) {
 	testServer.statusCode(400)
 
 	_, err = client.Create(&requestData)
-	assert.Error(t, ErrUnexpectedStatusCode, err)
+	assert.Error(t, &ErrUnexpectedResponse{}, err)
 }

--- a/pkg/jira/createmeta.go
+++ b/pkg/jira/createmeta.go
@@ -49,7 +49,7 @@ func (c *Client) GetCreateMeta(req *CreateMetaRequest) (*CreateMetaResponse, err
 	defer func() { _ = res.Body.Close() }()
 
 	if res.StatusCode != http.StatusOK {
-		return nil, ErrUnexpectedStatusCode
+		return nil, formatUnexpectedResponse(res)
 	}
 
 	var out CreateMetaResponse

--- a/pkg/jira/createmeta_test.go
+++ b/pkg/jira/createmeta_test.go
@@ -88,5 +88,5 @@ func TestGetCreateMeta(t *testing.T) {
 		IssueTypeNames: "Epic",
 		Expand:         "projects.issuetypes.fields",
 	})
-	assert.Error(t, ErrUnexpectedStatusCode, err)
+	assert.Error(t, &ErrUnexpectedResponse{}, err)
 }

--- a/pkg/jira/epic.go
+++ b/pkg/jira/epic.go
@@ -20,7 +20,7 @@ func (c *Client) Epic(jql string) (*SearchResult, error) {
 	defer func() { _ = res.Body.Close() }()
 
 	if res.StatusCode != http.StatusOK {
-		return nil, ErrUnexpectedStatusCode
+		return nil, formatUnexpectedResponse(res)
 	}
 
 	var out SearchResult
@@ -47,7 +47,7 @@ func (c *Client) EpicIssues(key, jql string, limit uint) (*SearchResult, error) 
 	defer func() { _ = res.Body.Close() }()
 
 	if res.StatusCode != http.StatusOK {
-		return nil, ErrUnexpectedStatusCode
+		return nil, formatUnexpectedResponse(res)
 	}
 
 	var out SearchResult
@@ -83,7 +83,7 @@ func (c *Client) EpicIssuesAdd(key string, issues ...string) error {
 	defer func() { _ = res.Body.Close() }()
 
 	if res.StatusCode != http.StatusNoContent {
-		return ErrUnexpectedStatusCode
+		return formatUnexpectedResponse(res)
 	}
 	return nil
 }
@@ -114,7 +114,7 @@ func (c *Client) EpicIssuesRemove(issues ...string) error {
 	defer func() { _ = res.Body.Close() }()
 
 	if res.StatusCode != http.StatusNoContent {
-		return ErrUnexpectedStatusCode
+		return formatUnexpectedResponse(res)
 	}
 	return nil
 }

--- a/pkg/jira/epic_test.go
+++ b/pkg/jira/epic_test.go
@@ -105,7 +105,7 @@ func TestEpic(t *testing.T) {
 	unexpectedStatusCode = true
 
 	_, err = client.Epic("project=TEST")
-	assert.Error(t, ErrUnexpectedStatusCode, err)
+	assert.Error(t, &ErrUnexpectedResponse{}, err)
 }
 
 func TestEpicIssues(t *testing.T) {
@@ -232,7 +232,7 @@ func TestEpicIssues(t *testing.T) {
 	unexpectedStatusCode = true
 
 	_, err = client.EpicIssues("TEST-0", "project=TEST", 100)
-	assert.Error(t, ErrUnexpectedStatusCode, err)
+	assert.Error(t, &ErrUnexpectedResponse{}, err)
 }
 
 func TestEpicIssuesAdd(t *testing.T) {
@@ -267,7 +267,7 @@ func TestEpicIssuesAdd(t *testing.T) {
 	unexpectedStatusCode = true
 
 	err = client.EpicIssuesAdd("TEST-0", "TEST-1")
-	assert.Error(t, ErrUnexpectedStatusCode, err)
+	assert.Error(t, &ErrUnexpectedResponse{}, err)
 }
 
 func TestEpicIssuesRemove(t *testing.T) {
@@ -302,5 +302,5 @@ func TestEpicIssuesRemove(t *testing.T) {
 	unexpectedStatusCode = true
 
 	err = client.EpicIssuesRemove("TEST-1", "TEST-2")
-	assert.Error(t, ErrUnexpectedStatusCode, err)
+	assert.Error(t, &ErrUnexpectedResponse{}, err)
 }

--- a/pkg/jira/issue.go
+++ b/pkg/jira/issue.go
@@ -35,7 +35,7 @@ func (c *Client) GetIssue(key string) (*Issue, error) {
 	defer func() { _ = res.Body.Close() }()
 
 	if res.StatusCode != http.StatusOK {
-		return nil, ErrUnexpectedStatusCode
+		return nil, formatUnexpectedResponse(res)
 	}
 
 	var out Issue
@@ -77,7 +77,7 @@ func (c *Client) AssignIssue(key, accountID string) error {
 	defer func() { _ = res.Body.Close() }()
 
 	if res.StatusCode != http.StatusNoContent {
-		return ErrUnexpectedStatusCode
+		return formatUnexpectedResponse(res)
 	}
 	return nil
 }
@@ -94,7 +94,7 @@ func (c *Client) GetIssueLinkTypes() ([]*IssueLinkType, error) {
 	defer func() { _ = res.Body.Close() }()
 
 	if res.StatusCode != http.StatusOK {
-		return nil, ErrUnexpectedStatusCode
+		return nil, formatUnexpectedResponse(res)
 	}
 
 	var out struct {
@@ -150,7 +150,7 @@ func (c *Client) LinkIssue(inwardIssue, outwardIssue, linkType string) error {
 	defer func() { _ = res.Body.Close() }()
 
 	if res.StatusCode != http.StatusCreated {
-		return ErrUnexpectedStatusCode
+		return formatUnexpectedResponse(res)
 	}
 	return nil
 }
@@ -181,7 +181,7 @@ func (c *Client) AddIssueComment(key, comment string) error {
 	defer func() { _ = res.Body.Close() }()
 
 	if res.StatusCode != http.StatusCreated {
-		return ErrUnexpectedStatusCode
+		return formatUnexpectedResponse(res)
 	}
 	return nil
 }

--- a/pkg/jira/issue_test.go
+++ b/pkg/jira/issue_test.go
@@ -79,7 +79,7 @@ func TestGetIssue(t *testing.T) {
 	unexpectedStatusCode = true
 
 	_, err = client.GetIssue("TEST-1")
-	assert.Error(t, ErrUnexpectedStatusCode, err)
+	assert.Error(t, &ErrUnexpectedResponse{}, err)
 }
 
 func TestGetIssueWithoutDescription(t *testing.T) {
@@ -159,7 +159,7 @@ func TestAssignIssue(t *testing.T) {
 	unexpectedStatusCode = true
 
 	err = client.AssignIssue("TEST-1", "default")
-	assert.Error(t, ErrUnexpectedStatusCode, err)
+	assert.Error(t, &ErrUnexpectedResponse{}, err)
 }
 
 func TestGetIssueLinkTypes(t *testing.T) {
@@ -209,7 +209,7 @@ func TestGetIssueLinkTypes(t *testing.T) {
 	unexpectedStatusCode = true
 
 	_, err = client.GetIssueLinkTypes()
-	assert.Error(t, ErrUnexpectedStatusCode, err)
+	assert.Error(t, &ErrUnexpectedResponse{}, err)
 }
 
 func TestLinkIssue(t *testing.T) {
@@ -236,7 +236,7 @@ func TestLinkIssue(t *testing.T) {
 	unexpectedStatusCode = true
 
 	err = client.LinkIssue("TEST-1", "TEST-2", "invalid")
-	assert.Error(t, ErrUnexpectedStatusCode, err)
+	assert.Error(t, &ErrUnexpectedResponse{}, err)
 }
 
 func TestAddIssueComment(t *testing.T) {
@@ -271,5 +271,5 @@ func TestAddIssueComment(t *testing.T) {
 	unexpectedStatusCode = true
 
 	err = client.AddIssueComment("TEST-1", "comment")
-	assert.Error(t, ErrUnexpectedStatusCode, err)
+	assert.Error(t, &ErrUnexpectedResponse{}, err)
 }

--- a/pkg/jira/me.go
+++ b/pkg/jira/me.go
@@ -22,7 +22,7 @@ func (c *Client) Me() (*Me, error) {
 		defer func() { _ = res.Body.Close() }()
 	}
 	if res.StatusCode != http.StatusOK {
-		return nil, ErrUnexpectedStatusCode
+		return nil, formatUnexpectedResponse(res)
 	}
 
 	var me Me

--- a/pkg/jira/me_test.go
+++ b/pkg/jira/me_test.go
@@ -42,5 +42,5 @@ func TestMe(t *testing.T) {
 	unexpectedStatusCode = true
 
 	_, err = client.Me()
-	assert.Error(t, ErrUnexpectedStatusCode, err)
+	assert.Error(t, &ErrUnexpectedResponse{}, err)
 }

--- a/pkg/jira/project.go
+++ b/pkg/jira/project.go
@@ -18,7 +18,7 @@ func (c *Client) Project() ([]*Project, error) {
 	defer func() { _ = res.Body.Close() }()
 
 	if res.StatusCode != http.StatusOK {
-		return nil, ErrUnexpectedStatusCode
+		return nil, formatUnexpectedResponse(res)
 	}
 
 	var out []*Project

--- a/pkg/jira/project_test.go
+++ b/pkg/jira/project_test.go
@@ -68,5 +68,5 @@ func TestProjects(t *testing.T) {
 	unexpectedStatusCode = true
 
 	_, err = client.Project()
-	assert.Error(t, ErrUnexpectedStatusCode, err)
+	assert.Error(t, &ErrUnexpectedResponse{}, err)
 }

--- a/pkg/jira/search.go
+++ b/pkg/jira/search.go
@@ -30,7 +30,7 @@ func (c *Client) Search(jql string, limit uint) (*SearchResult, error) {
 	defer func() { _ = res.Body.Close() }()
 
 	if res.StatusCode != http.StatusOK {
-		return nil, ErrUnexpectedStatusCode
+		return nil, formatUnexpectedResponse(res)
 	}
 
 	var out SearchResult

--- a/pkg/jira/search_test.go
+++ b/pkg/jira/search_test.go
@@ -135,5 +135,5 @@ func TestSearch(t *testing.T) {
 	unexpectedStatusCode = true
 
 	_, err = client.Search("project=TEST", 100)
-	assert.Error(t, ErrUnexpectedStatusCode, err)
+	assert.Error(t, &ErrUnexpectedResponse{}, err)
 }

--- a/pkg/jira/sprint.go
+++ b/pkg/jira/sprint.go
@@ -41,7 +41,7 @@ func (c *Client) Sprints(boardID int, qp string, startAt, max int) (*SprintResul
 	defer func() { _ = res.Body.Close() }()
 
 	if res.StatusCode != http.StatusOK {
-		return nil, ErrUnexpectedStatusCode
+		return nil, formatUnexpectedResponse(res)
 	}
 
 	var out SprintResult
@@ -109,7 +109,7 @@ func (c *Client) SprintIssues(boardID, sprintID int, jql string, limit uint) (*S
 	defer func() { _ = res.Body.Close() }()
 
 	if res.StatusCode != http.StatusOK {
-		return nil, ErrUnexpectedStatusCode
+		return nil, formatUnexpectedResponse(res)
 	}
 
 	var out SearchResult

--- a/pkg/jira/sprint_test.go
+++ b/pkg/jira/sprint_test.go
@@ -98,7 +98,7 @@ func TestSprints(t *testing.T) {
 	unexpectedStatusCode = true
 
 	_, err = client.Sprints(2, "state=active,closed", 0, 10)
-	assert.Error(t, ErrUnexpectedStatusCode, err)
+	assert.Error(t, &ErrUnexpectedResponse{}, err)
 }
 
 func TestSprintsInBoards(t *testing.T) {
@@ -307,5 +307,5 @@ func TestSprintIssues(t *testing.T) {
 	unexpectedStatusCode = true
 
 	_, err = client.SprintIssues(1, 2, "project=TEST", 100)
-	assert.Error(t, ErrUnexpectedStatusCode, err)
+	assert.Error(t, &ErrUnexpectedResponse{}, err)
 }

--- a/pkg/jira/transition.go
+++ b/pkg/jira/transition.go
@@ -37,7 +37,7 @@ func (c *Client) Transitions(key string) ([]*Transition, error) {
 	defer func() { _ = res.Body.Close() }()
 
 	if res.StatusCode != http.StatusOK {
-		return nil, ErrUnexpectedStatusCode
+		return nil, formatUnexpectedResponse(res)
 	}
 
 	var out transitionResponse
@@ -69,7 +69,7 @@ func (c *Client) Transition(key string, data *TransitionRequest) (int, error) {
 	defer func() { _ = res.Body.Close() }()
 
 	if res.StatusCode != http.StatusNoContent {
-		return res.StatusCode, ErrUnexpectedStatusCode
+		return res.StatusCode, formatUnexpectedResponse(res)
 	}
 	return res.StatusCode, nil
 }

--- a/pkg/jira/transition_test.go
+++ b/pkg/jira/transition_test.go
@@ -58,7 +58,7 @@ func TestTransitions(t *testing.T) {
 	unexpectedStatusCode = true
 
 	_, err = client.Transitions("TEST")
-	assert.Error(t, ErrUnexpectedStatusCode, err)
+	assert.Error(t, &ErrUnexpectedResponse{}, err)
 }
 
 func TestTransition(t *testing.T) {

--- a/pkg/jira/user.go
+++ b/pkg/jira/user.go
@@ -59,7 +59,7 @@ func (c *Client) UserSearch(opt *UserSearchOptions) ([]*User, error) {
 	defer func() { _ = res.Body.Close() }()
 
 	if res.StatusCode != http.StatusOK {
-		return nil, ErrUnexpectedStatusCode
+		return nil, formatUnexpectedResponse(res)
 	}
 
 	var out []*User

--- a/pkg/jira/user_test.go
+++ b/pkg/jira/user_test.go
@@ -73,5 +73,5 @@ func TestUserSearch(t *testing.T) {
 	_, err = client.UserSearch(&UserSearchOptions{
 		Username: "doe",
 	})
-	assert.Error(t, ErrUnexpectedStatusCode, err)
+	assert.Error(t, &ErrUnexpectedResponse{}, err)
 }


### PR DESCRIPTION
This PR improves error reporting to include errors and warnings from Jira API response.

**Before**
```sh
$ jira issue list -tasdf -yasdf -rsdf

jira: Received unexpected response.
Please check the parameters you supplied and try again.
```
**After**
```sh
$ jira issue list -tasdf -yasdf -rsdf

Error:
  - The value 'asdf' does not exist for the field 'type'.
  - The value 'asdf' does not exist for the field 'priority'.

Warning:
  - The value 'sdf' does not exist for the field 'reporter'.

jira: Received unexpected response '400 Bad Request'.
Please check the parameters you supplied and try again.
```