### PR TITLE
feat: Allow to create sub-task

### DIFF
--- a/internal/cmd/issue/create/create.go
+++ b/internal/cmd/issue/create/create.go
@@ -187,7 +187,7 @@ func (cc *createCmd) getIssueType() *survey.Question {
 		qs = &survey.Question{
 			Name: "issueType",
 			Prompt: &survey.Select{
-				Message: "Issue type:",
+				Message: "Issue type",
 				Options: options,
 			},
 			Validate: survey.Required,

--- a/internal/cmdcommon/create.go
+++ b/internal/cmdcommon/create.go
@@ -22,6 +22,7 @@ func SetCreateFlags(cmd *cobra.Command, prefix string) {
 		cmd.Flags().StringP("name", "n", "", "Epic name")
 	} else {
 		cmd.Flags().StringP("type", "t", "", "Issue type")
+		cmd.Flags().StringP("parent", "P", "", "Parent issue key (Valid only if issue type is sub-task)")
 	}
 	cmd.Flags().StringP("summary", "s", "", prefix+" summary or title")
 	cmd.Flags().StringP("body", "b", "", prefix+" description")

--- a/internal/cmdutil/utils_test.go
+++ b/internal/cmdutil/utils_test.go
@@ -66,6 +66,8 @@ func TestGetConfigHome(t *testing.T) {
 	userHome, err := homedir.Dir()
 	assert.NoError(t, err)
 
+	os.Clearenv()
+
 	configHome, err := GetConfigHome()
 	assert.NoError(t, err)
 	assert.Equal(t, userHome+"/.config", configHome)

--- a/pkg/jira/create.go
+++ b/pkg/jira/create.go
@@ -72,7 +72,7 @@ type createFields struct {
 	} `json:"issuetype"`
 	Parent *struct {
 		Key string `json:"key"`
-	} `json:"parent"`
+	} `json:"parent,omitempty"`
 	Name        string `json:"name,omitempty"`
 	Summary     string `json:"summary"`
 	Description string `json:"description,omitempty"`

--- a/pkg/jira/create.go
+++ b/pkg/jira/create.go
@@ -16,14 +16,16 @@ type CreateResponse struct {
 
 // CreateRequest struct holds request data for create request.
 type CreateRequest struct {
-	Project    string
-	Name       string
-	IssueType  string
-	Summary    string
-	Body       string
-	Priority   string
-	Labels     []string
-	Components []string
+	Project   string
+	Name      string
+	IssueType string
+	// ParentIssueKey is required for sub-task.
+	ParentIssueKey string
+	Summary        string
+	Body           string
+	Priority       string
+	Labels         []string
+	Components     []string
 	// EpicFieldName is the dynamic epic field name
 	// that changes per jira installation.
 	EpicFieldName string
@@ -68,6 +70,9 @@ type createFields struct {
 	IssueType struct {
 		Name string `json:"name"`
 	} `json:"issuetype"`
+	Parent *struct {
+		Key string `json:"key"`
+	} `json:"parent"`
 	Name        string `json:"name,omitempty"`
 	Summary     string `json:"summary"`
 	Description string `json:"description,omitempty"`
@@ -132,6 +137,11 @@ func (c *Client) getRequestData(req *CreateRequest) *createRequest {
 		}},
 	}
 
+	if req.ParentIssueKey != "" {
+		data.Fields.M.Parent = &struct {
+			Key string `json:"key"`
+		}{Key: req.ParentIssueKey}
+	}
 	if req.Priority != "" {
 		data.Fields.M.Priority = &struct {
 			Name string `json:"name,omitempty"`


### PR DESCRIPTION
Jira issue create will now allow to create sub-tasks as well.

```sh
# Parent issue key '-P' is only valid if issue type is sub-task
$ jira issue create -t"Sub-task" -PISSUE-X
```

