### PR TITLE
feat: Support raw JQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,11 @@ $ jira issue list -s"To Do"
 
 # List recent issues in plain mode 
 $ jira issue list --plain
+
+# You can execute raw JQL within a given project context using `--jql/-q` option.
+# For instance, the following command will list issues in current project whose
+# summary has a word cli.
+$ jira issue list -q "summary ~ cli"
 ```
 
 Check some more examples/use-cases below.

--- a/internal/cmd/issue/list/list.go
+++ b/internal/cmd/issue/list/list.go
@@ -140,6 +140,7 @@ func SetFlags(cmd *cobra.Command) {
 	cmd.Flags().String("updated-after", "", "Filter by issues updated after certain date")
 	cmd.Flags().String("created-before", "", "Filter by issues created before certain date")
 	cmd.Flags().String("updated-before", "", "Filter by issues updated before certain date")
+	cmd.Flags().StringP("jql", "q", "", "Run a raw JQL query in a given project context")
 	cmd.Flags().Bool("reverse", false, "Reverse the display order (default is DESC)")
 	cmd.Flags().Uint("limit", 100, "Number of results to return")
 	cmd.Flags().Bool("plain", false, "Display output in plain mode")

--- a/internal/query/issue.go
+++ b/internal/query/issue.go
@@ -66,6 +66,9 @@ func (i *Issue) Get() string {
 	if i.params.debug {
 		fmt.Printf("JQL: %s\n", q.String())
 	}
+	if i.params.jql != "" {
+		q.And(func() { q.Raw(i.params.jql) })
+	}
 	return q.String()
 }
 
@@ -137,6 +140,7 @@ type IssueParams struct {
 	UpdatedAfter  string
 	CreatedBefore string
 	UpdatedBefore string
+	jql           string
 	Labels        []string
 	Reverse       bool
 	Limit         uint
@@ -150,6 +154,7 @@ func (ip *IssueParams) init(flags FlagParser) error {
 	stringParams := []string{
 		"resolution", "type", "status", "priority", "reporter", "assignee", "component",
 		"created", "created-after", "created-before", "updated", "updated-after", "updated-before",
+		"jql",
 	}
 
 	boolParamsMap := make(map[string]bool)
@@ -227,6 +232,8 @@ func (ip *IssueParams) setStringParams(paramsMap map[string]string) {
 			ip.UpdatedAfter = v
 		case "updated-before":
 			ip.UpdatedBefore = v
+		case "jql":
+			ip.jql = v
 		}
 	}
 }

--- a/pkg/jql/jql.go
+++ b/pkg/jql/jql.go
@@ -156,6 +156,15 @@ func (j *JQL) Or(fn GroupFunc) *JQL {
 	return j
 }
 
+// Raw sets the passed JQL query along with project context.
+func (j *JQL) Raw(q string) *JQL {
+	if q == "" {
+		return j
+	}
+	j.filters = append(j.filters, q)
+	return j
+}
+
 // String returns the constructed query.
 func (j *JQL) String() string {
 	return j.compile()

--- a/pkg/jql/jql_test.go
+++ b/pkg/jql/jql_test.go
@@ -210,6 +210,32 @@ func TestJQL(t *testing.T) {
 			},
 			expected: "project=\"TEST\" OR type=\"Story\" OR labels IN (\"first\", \"second\", \"third\")",
 		},
+		{
+			name: "it queries with raw jql",
+			initialize: func() *JQL {
+				jql := NewJQL("TEST")
+				jql.And(func() {
+					jql.
+						FilterBy("type", "Story").
+						FilterBy("resolution", "Done").
+						Raw("summary !~ cli AND priority = high")
+				})
+				return jql
+			},
+			expected: "project=\"TEST\" AND type=\"Story\" AND resolution=\"Done\" AND summary !~ cli AND priority = high",
+		},
+		{
+			name: "it queries with raw jql and or filter",
+			initialize: func() *JQL {
+				jql := NewJQL("TEST")
+				jql.Or(func() {
+					jql.FilterBy("type", "Story").
+						Raw("summary ~ cli")
+				})
+				return jql
+			},
+			expected: "project=\"TEST\" OR type=\"Story\" OR summary ~ cli",
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
You can execute raw JQL within a given project context using `--jql/-q` option. For instance, the following command will list issues in current project whose summary has a word `cli`.

```sh
$ jira issue list -q "summary ~ cli"
```

