### PR TITLE
feat: Auto project context

### DIFF
--- a/internal/cmd/issue/clone/clone.go
+++ b/internal/cmd/issue/clone/clone.go
@@ -56,7 +56,7 @@ func clone(cmd *cobra.Command, args []string) {
 		params: params,
 	}
 
-	key := args[0]
+	key := cmdutil.GetJiraIssueKey(project, args[0])
 	issue := func() *jira.Issue {
 		s := cmdutil.Info("Fetching issue details...")
 		defer s.Stop()

--- a/internal/cmd/issue/comment/add/add.go
+++ b/internal/cmd/issue/comment/add/add.go
@@ -2,7 +2,6 @@ package add
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/spf13/cobra"
@@ -126,7 +125,7 @@ func parseArgsAndFlags(args []string, flags query.FlagParser) *addParams {
 
 	nargs := len(args)
 	if nargs >= 1 {
-		issueKey = strings.ToUpper(args[0])
+		issueKey = cmdutil.GetJiraIssueKey(viper.GetString("project"), args[0])
 	}
 	if nargs >= 2 {
 		body = args[1]
@@ -171,7 +170,7 @@ func (ac *addCmd) setIssueKey() error {
 	if err := survey.Ask([]*survey.Question{qs}, &ans); err != nil {
 		return err
 	}
-	ac.params.issueKey = ans
+	ac.params.issueKey = cmdutil.GetJiraIssueKey(viper.GetString("project"), ans)
 
 	return nil
 }

--- a/internal/cmd/issue/view/view.go
+++ b/internal/cmd/issue/view/view.go
@@ -2,6 +2,7 @@ package view
 
 import (
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 
 	"github.com/ankitpokhrel/jira-cli/api"
 	"github.com/ankitpokhrel/jira-cli/internal/cmdutil"
@@ -38,7 +39,7 @@ func view(cmd *cobra.Command, args []string) {
 	debug, err := cmd.Flags().GetBool("debug")
 	cmdutil.ExitIfError(err)
 
-	key := args[0]
+	key := cmdutil.GetJiraIssueKey(viper.GetString("project"), args[0])
 	issue := func() *jira.Issue {
 		s := cmdutil.Info("Fetching issue details...")
 		defer s.Stop()

--- a/internal/cmd/open/open.go
+++ b/internal/cmd/open/open.go
@@ -34,13 +34,14 @@ func NewCmdOpen() *cobra.Command {
 
 func open(_ *cobra.Command, args []string) {
 	server := viper.GetString("server")
+	project := viper.GetString("project")
 
 	var url string
 
 	if len(args) == 0 {
-		url = fmt.Sprintf("%s/browse/%s", server, viper.GetString("project"))
+		url = fmt.Sprintf("%s/browse/%s", server, project)
 	} else {
-		url = fmt.Sprintf("%s/browse/%s", server, args[0])
+		url = fmt.Sprintf("%s/browse/%s", server, cmdutil.GetJiraIssueKey(project, args[0]))
 	}
 
 	cmdutil.ExitIfError(browser.OpenURL(url))

--- a/internal/cmdutil/utils.go
+++ b/internal/cmdutil/utils.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/briandowns/spinner"
@@ -118,4 +120,15 @@ func ReadFile(filePath string) ([]byte, error) {
 		return b, err
 	}
 	return []byte(""), nil
+}
+
+// GetJiraIssueKey constructs actual issue key based on given key.
+func GetJiraIssueKey(project, key string) string {
+	if project == "" {
+		return key
+	}
+	if _, err := strconv.Atoi(key); err != nil {
+		return strings.ToUpper(key)
+	}
+	return fmt.Sprintf("%s-%s", project, key)
 }

--- a/internal/cmdutil/utils_test.go
+++ b/internal/cmdutil/utils_test.go
@@ -78,3 +78,61 @@ func TestGetConfigHome(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "./test", configHome)
 }
+
+func TestGetJiraIssueKey(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		project  string
+		input    string
+		expected string
+	}{
+		{
+			name:     "full key on same project",
+			project:  "ANK",
+			input:    "ANK-11",
+			expected: "ANK-11",
+		},
+		{
+			name:     "full key on different project",
+			project:  "POK",
+			input:    "ANK-11",
+			expected: "ANK-11",
+		},
+		{
+			name:     "key number only",
+			project:  "ANK",
+			input:    "11",
+			expected: "ANK-11",
+		},
+		{
+			name:     "text only key",
+			project:  "POK",
+			input:    "ANK",
+			expected: "ANK",
+		},
+		{
+			name:     "invalid key format",
+			project:  "POK",
+			input:    "ANK-",
+			expected: "ANK-",
+		},
+		{
+			name:     "empty project and numeric key",
+			project:  "",
+			input:    "11",
+			expected: "11",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tc.expected, GetJiraIssueKey(tc.project, tc.input))
+		})
+	}
+}


### PR DESCRIPTION
This PR makes changes to append project context automatically to issue keys so that we can just use key numbers instead of typing full key. The change is applied to all commands that requires issue key. 

For instance:

```sh
$ jira epic add 11 12 13 14
```

Above command will expand to `jira epic add ISS-11 ISS-12 ISS-13 ISS-14` if current configured project key is `ISS`.