### PR TITLE
build: Prepare for initial release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,6 @@
 .idea/
 
 dist/
+bin/
 coverage/
 vendor/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,60 @@
+project_name: jira
+
+release:
+  prerelease: auto
+  name_template: "Jira CLI {{.Version}}"
+
+before:
+  hooks:
+    - go mod tidy
+
+builds:
+  - <<: &build_defaults
+      binary: bin/jira
+      main: ./cmd/jira
+      ldflags:
+        - -X github.com/ankitpokhrel/jira-cli/internal/version.Version={{.Version}}
+        - -X github.com/ankitpokhrel/jira-cli/internal/version.GitCommit={{.Commit}}
+        - -X github.com/ankitpokhrel/jira-cli/internal/version.BuildDate={{time "2006-01-02"}}"
+      env:
+        - CGO_ENABLED=0
+        - GO111MODULE=on
+    id: macOS
+    goos: [darwin]
+    goarch: [amd64, arm64]
+
+  - <<: *build_defaults
+    id: linux
+    goos: [linux]
+    goarch: [386, arm, amd64, arm64]
+
+  - <<: *build_defaults
+    id: windows
+    goos: [windows]
+    goarch: [386, amd64]
+
+archives:
+  - id: nix
+    builds: [macos, linux]
+    <<: &archive_defaults
+      name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
+    wrap_in_directory: true
+    replacements:
+      darwin: macOS
+      386: i386
+      amd64: x86_64
+    format: tar.gz
+    files:
+      - LICENSE
+
+  - id: windows
+    builds: [windows]
+    <<: *archive_defaults
+    wrap_in_directory: false
+    format: zip
+    files:
+      - LICENSE
+
+checksum:
+  name_template: 'checksums.txt'
+  algorithm: sha256


### PR DESCRIPTION
This PR adds [goreleaser](https://goreleaser.com/) config to build binary for:
- macOS/darwin [amd64, arm64]
- linux [386, arm, amd64, arm64]
- windows [386, amd64]