### PR TITLE
feat: Support init cmd for on-premise jira installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The tool is only tested with the latest Jira cloud since that's what I usually w
 
 | Platform | <a href="#"><img alt="Software License" src="https://img.shields.io/badge/linux-%E2%9C%93-dark--green?logo=linux&style=flat-square" /></a><a href="#"><img alt="Software License" src="https://img.shields.io/badge/macOS-%E2%9C%93-dark--green?logo=macos&style=flat-square" /></a><a href="#"><img alt="Software License" src="https://img.shields.io/badge/windows-partial-yellow?logo=windows&style=flat-square" /></a> |
 | :------------- | :----------: |
-| **Jira**  | <a href="#"><img alt="Software License" src="https://img.shields.io/badge/jira cloud-%E2%9C%93-dark--green?logo=jira&style=flat-square" /></a><a href="#"><img alt="Software License" src="https://img.shields.io/badge/jira server-✗-red?logo=jira&style=flat-square" /></a> |
+| **Jira**  | <a href="#"><img alt="Software License" src="https://img.shields.io/badge/jira cloud-%E2%9C%93-dark--green?logo=jira&style=flat-square" /></a><a href="#"><img alt="Software License" src="https://img.shields.io/badge/jira%20server-WIP-orange?logo=jira&style=flat-square" /></a> |
 
 ## Installation
 `jira-cli` is available as a downloadable binary for Linux, macOS, and Windows from the [releases page](https://github.com/ankitpokhrel/jira-cli/releases).
@@ -68,9 +68,21 @@ go get github.com/ankitpokhrel/jira-cli/cmd/jira
 See [releases page](https://github.com/ankitpokhrel/jira-cli/releases) for more info. Other installation options will be available later.
 
 ## Getting started
-1. [Get a Jira API token](https://id.atlassian.com/manage-profile/security/api-tokens) and export it to your shell as a `JIRA_API_TOKEN` variable.
-    Add it to your shell configuration file, for instance, `$HOME/.bashrc`, so that the variable is always available.
-2. Run `jira init` to generate a config file required for the tool.
+
+#### Cloud server
+
+1. [Get a Jira API token](https://id.atlassian.com/manage-profile/security/api-tokens) and export it to your shell as
+   a `JIRA_API_TOKEN` variable. Add it to your shell configuration file, for instance, `$HOME/.bashrc`, so that the
+   variable is always available.
+2. Run `jira init`, select installation type as `Cloud`, and provide required details to generate a config file required
+   for the tool.
+
+#### On-premise Installation
+
+1. Export the password you use to login to Jira as a `JIRA_API_TOKEN` variable. Add it to your shell configuration file,
+   for instance, `$HOME/.bashrc`, so that the variable is always available.
+2. Run `jira init`, select installation type as `Local`, and provide required details to generate a config file required
+   for the tool.
 
 #### Shell completion
 Check `jira completion --help` for more info on setting up a bash/zsh shell completion.

--- a/pkg/jira/createmeta.go
+++ b/pkg/jira/createmeta.go
@@ -39,7 +39,7 @@ func (c *Client) GetCreateMeta(req *CreateMetaRequest) (*CreateMetaResponse, err
 		path += fmt.Sprintf("&issuetypeNames=%s", req.IssueTypeNames)
 	}
 
-	res, err := c.Get(context.Background(), path, nil)
+	res, err := c.GetV2(context.Background(), path, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/jira/createmeta_test.go
+++ b/pkg/jira/createmeta_test.go
@@ -14,7 +14,7 @@ func TestGetCreateMeta(t *testing.T) {
 	var unexpectedStatusCode bool
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "/rest/api/3/issue/createmeta", r.URL.Path)
+		assert.Equal(t, "/rest/api/2/issue/createmeta", r.URL.Path)
 
 		qs := r.URL.Query()
 

--- a/pkg/jira/me.go
+++ b/pkg/jira/me.go
@@ -14,7 +14,7 @@ type Me struct {
 
 // Me fetches response from /myself endpoint.
 func (c *Client) Me() (*Me, error) {
-	res, err := c.Get(context.Background(), "/myself", nil)
+	res, err := c.GetV2(context.Background(), "/myself", nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/jira/me_test.go
+++ b/pkg/jira/me_test.go
@@ -13,7 +13,7 @@ func TestMe(t *testing.T) {
 	var unexpectedStatusCode bool
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "/rest/api/3/myself", r.URL.Path)
+		assert.Equal(t, "/rest/api/2/myself", r.URL.Path)
 
 		if unexpectedStatusCode {
 			w.WriteHeader(400)

--- a/pkg/jira/project.go
+++ b/pkg/jira/project.go
@@ -8,7 +8,7 @@ import (
 
 // Project fetches response from /project endpoint.
 func (c *Client) Project() ([]*Project, error) {
-	res, err := c.Get(context.Background(), "/project?expand=lead", nil)
+	res, err := c.GetV2(context.Background(), "/project?expand=lead", nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/jira/project_test.go
+++ b/pkg/jira/project_test.go
@@ -14,7 +14,7 @@ func TestProjects(t *testing.T) {
 	var unexpectedStatusCode bool
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "/rest/api/3/project", r.URL.Path)
+		assert.Equal(t, "/rest/api/2/project", r.URL.Path)
 
 		qs := r.URL.Query()
 


### PR DESCRIPTION
This PR provides a base to test the tool in on-premise jira installation. It fixes `jira init` command to work with both cloud and local jira installations.