### PR TITLE
fix: Description can be nil in v2 version of the API

### DIFF
--- a/internal/cmd/issue/clone/clone.go
+++ b/internal/cmd/issue/clone/clone.go
@@ -182,11 +182,18 @@ func (cc *cloneCmd) getActualCreateParams(issue *jira.Issue) *createParams {
 		cp.components = cc.params.components
 	}
 
-	var body interface{}
+	var (
+		body  interface{}
+		isADF bool
+	)
 
-	body, isADF := issue.Fields.Description.(*adf.ADF)
-	if !isADF {
-		body = issue.Fields.Description.(string)
+	if issue.Fields.Description != nil {
+		body, isADF = issue.Fields.Description.(*adf.ADF)
+		if !isADF {
+			body = issue.Fields.Description.(string)
+		}
+	} else {
+		body = ""
 	}
 
 	if cc.params.replace != "" {


### PR DESCRIPTION
If there is no description added when creating an issue, the `clone` command panics because `Description` field is returned as `nil` instead of empty string.

```sh
$ jira issue clone ISS-220
⠦ Fetching issue details... panic: interface conversion: interface {} is nil, not string

goroutine 1 [running]:
github.com/kmdpl/jira-cli/internal/cmd/issue/clone.(*cloneCmd).getActualCreateParams(0xc0005bfd28, 0xc0002500f0)
	/Users/kmdpl/go/src/github.com/kmdpl/jira-cli/internal/cmd/issue/clone/clone.go:189 +0x4f1
github.com/kmdpl/jira-cli/internal/cmd/issue/clone.clone(0xc0005ef400, {0xc0004a2580, 0x1, 0x1})
	/Users/kmdpl/go/src/github.com/kmdpl/jira-cli/internal/cmd/issue/clone/clone.go:70 +0x1c5
github.com/spf13/cobra.(*Command).execute(0xc0005ef400, {0xc0004a2560, 0x1, 0x1})
	/Users/kmdpl/go/pkg/mod/github.com/spf13/cobra@v1.1.3/command.go:856 +0x5f8
github.com/spf13/cobra.(*Command).ExecuteC(0xc000021400)
	/Users/kmdpl/go/pkg/mod/github.com/spf13/cobra@v1.1.3/command.go:960 +0x3ad
main.main()
	/Users/kmdpl/go/src/github.com/kmdpl/jira-cli/cmd/jira/main.go:12 +0x1e
```