### PR TITLE
feat: Basic support for view command for on-premise jira installation 

### DIFF
--- a/internal/cmd/issue/view/view.go
+++ b/internal/cmd/issue/view/view.go
@@ -44,7 +44,8 @@ func view(cmd *cobra.Command, args []string) {
 		s := cmdutil.Info("Fetching issue details...")
 		defer s.Stop()
 
-		issue, err := api.Client(jira.Config{Debug: debug}).GetIssue(key)
+		client := api.Client(jira.Config{Debug: debug})
+		issue, err := api.ProxyGetIssue(client, key)
 		cmdutil.ExitIfError(err)
 
 		return issue

--- a/internal/view/issue.go
+++ b/internal/view/issue.go
@@ -6,10 +6,10 @@ import (
 	"os"
 	"strings"
 
-	"github.com/ankitpokhrel/jira-cli/pkg/adf"
 	"github.com/charmbracelet/glamour"
 
 	"github.com/ankitpokhrel/jira-cli/internal/cmdutil"
+	"github.com/ankitpokhrel/jira-cli/pkg/adf"
 	"github.com/ankitpokhrel/jira-cli/pkg/jira"
 	"github.com/ankitpokhrel/jira-cli/pkg/tui"
 )

--- a/internal/view/issue.go
+++ b/internal/view/issue.go
@@ -6,10 +6,10 @@ import (
 	"os"
 	"strings"
 
+	"github.com/ankitpokhrel/jira-cli/pkg/adf"
 	"github.com/charmbracelet/glamour"
 
 	"github.com/ankitpokhrel/jira-cli/internal/cmdutil"
-	"github.com/ankitpokhrel/jira-cli/pkg/adf"
 	"github.com/ankitpokhrel/jira-cli/pkg/jira"
 	"github.com/ankitpokhrel/jira-cli/pkg/tui"
 )
@@ -66,8 +66,12 @@ func (i Issue) String() string {
 	}
 	desc := ""
 	if i.Data.Fields.Description != nil {
-		tr := adf.NewTranslator(i.Data.Fields.Description.(*adf.ADF), adf.NewMarkdownTranslator())
-		desc = tr.Translate()
+		if adfNode, ok := i.Data.Fields.Description.(*adf.ADF); ok {
+			desc = adf.NewTranslator(adfNode, adf.NewMarkdownTranslator()).Translate()
+		} else {
+			desc = i.Data.Fields.Description.(string)
+			desc = strings.ReplaceAll(desc, "\n", "\n\n")
+		}
 	}
 	return fmt.Sprintf(
 		"%s %s  %s %s  ⌛ %s  👷 %s  🔑️ %s\n# %s\n⏱️  %s  🔎 %s  🚀 %s  📦 %s  🏷️  %s\n\n-----------\n%s",

--- a/internal/view/issue_test.go
+++ b/internal/view/issue_test.go
@@ -65,3 +65,47 @@ func TestIssueDetailsRenderInPlainView(t *testing.T) {
 	expected := "🐞 Bug  ✅ Done  ⌛ Sun, 13 Dec 20  👷 Person A  🔑️ TEST-1\n# This is a test\n⏱️  Sun, 13 Dec 20  🔎 Person Z  🚀 High  📦 BE, FE  🏷️  None\n\n-----------\nTest description\n\n"
 	assert.Equal(t, tui.TextData(expected), issue.data())
 }
+
+func TestIssueDetailsWithV2Description(t *testing.T) {
+	var b bytes.Buffer
+
+	data := &jira.Issue{
+		Key: "TEST-1",
+		Fields: jira.IssueFields{
+			Summary: "This is a test",
+			Resolution: struct {
+				Name string `json:"name"`
+			}{Name: "Fixed"},
+			Description: "h1. Title\nh2. Subtitle",
+			IssueType: struct {
+				Name string `json:"name"`
+			}{Name: "Bug"},
+			Assignee: struct {
+				Name string `json:"displayName"`
+			}{Name: "Person A"},
+			Priority: struct {
+				Name string `json:"name"`
+			}{Name: "High"},
+			Reporter: struct {
+				Name string `json:"displayName"`
+			}{Name: "Person Z"},
+			Status: struct {
+				Name string `json:"name"`
+			}{Name: "Done"},
+			Components: []struct {
+				Name string `json:"name"`
+			}{{Name: "BE"}, {Name: "FE"}},
+			Created: "2020-12-13T14:05:20.974+0100",
+			Updated: "2020-12-13T14:07:20.974+0100",
+		},
+	}
+
+	issue := Issue{
+		Data:    data,
+		Display: DisplayFormat{Plain: true},
+	}
+	assert.NoError(t, issue.renderPlain(&b))
+
+	expected := "🐞 Bug  ✅ Done  ⌛ Sun, 13 Dec 20  👷 Person A  🔑️ TEST-1\n# This is a test\n⏱️  Sun, 13 Dec 20  🔎 Person Z  🚀 High  📦 BE, FE  🏷️  None\n\n-----------\nh1. Title\n\nh2. Subtitle"
+	assert.Equal(t, tui.TextData(expected), issue.data())
+}


### PR DESCRIPTION
This PR adds basic support for view command when using on-premise jira installation. The description text is displayed as it is and might not look great in the CLI at the moment. This will be improved in the upcoming PRs.