### PR TITLE
:sparkles: Increased issue list project scope

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -316,10 +316,6 @@ github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FI
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.9.3 h1:zeC5b1GviRUyKYd6OJPvBU/mcVDVoL1OhT17FCt5dSQ=
 github.com/pelletier/go-toml v1.9.3/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
-github.com/pkg/browser v0.0.0-20210606212950-a7b7a6107d32 h1:K3WnH8Ka32vWygzmjKEhz1zAVqckNoWDqX3azMxuiSA=
-github.com/pkg/browser v0.0.0-20210606212950-a7b7a6107d32/go.mod h1:yvwcBfzEX4m+eTgxPBbNYytaWFv4PSQzBaeYjxp8Iik=
-github.com/pkg/browser v0.0.0-20210904010418-6d279e18f982 h1:TdFv+3Gr3GaghJ/o80aulO4ian7GHGWMdLBXoLZH1Is=
-github.com/pkg/browser v0.0.0-20210904010418-6d279e18f982/go.mod h1:HKlIX3XHQyzLZPlr7++PzdhaXEj94dEiJgZDTsxEqUI=
 github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8 h1:KoWmjvw+nsYOo29YJK9vDA65RGE3NrOnUtO7a+RF9HU=
 github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8/go.mod h1:HKlIX3XHQyzLZPlr7++PzdhaXEj94dEiJgZDTsxEqUI=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -577,7 +573,6 @@ golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210220050731-9a76102bfb43/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210305230114-8fe3ee5dd75b/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210315160823-c6e025ad8005/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210319071255-635bc2c9138d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210320140829-1e4c9ba3b0c4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210403161142-5e06dd20ab57/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/internal/cmd/issue/list/list.go
+++ b/internal/cmd/issue/list/list.go
@@ -150,6 +150,8 @@ func SetFlags(cmd *cobra.Command) {
 	cmd.Flags().Bool("no-headers", false, "Don't display table headers in plain mode. Works only with --plain")
 	cmd.Flags().Bool("no-truncate", false, "Show all available columns in plain mode. Works only with --plain")
 
+	cmd.Flags().StringArrayP("projects", "d", nil, "Add more projects into the issue list context.")
+
 	if cmd.HasParent() && cmd.Parent().Name() != "sprint" {
 		cmd.Flags().String("columns", "", "Comma separated list of columns to display in the plain mode.\n"+
 			fmt.Sprintf("Accepts: %s", strings.Join(view.ValidIssueColumns(), ", ")))

--- a/internal/query/issue.go
+++ b/internal/query/issue.go
@@ -29,7 +29,6 @@ func NewIssue(project string, flags FlagParser) (*Issue, error) {
 
 // Get returns constructed jql query.
 func (i *Issue) Get() string {
-
 	projects := []string{i.Project}
 	projects = append(projects, i.params.Projects...)
 

--- a/internal/query/issue.go
+++ b/internal/query/issue.go
@@ -30,11 +30,10 @@ func NewIssue(project string, flags FlagParser) (*Issue, error) {
 // Get returns constructed jql query.
 func (i *Issue) Get() string {
 
-	var projectsToProcess []string
-	projectsToProcess = append(projectsToProcess, i.Project)
-	projectsToProcess = append(projectsToProcess, i.params.Projects...)
+	projects := []string{i.Project}
+	projects = append(projects, i.params.Projects...)
 
-	q, obf := jql.NewJQL(projectsToProcess), "created"
+	q, obf := jql.NewJQL(projects), "created"
 	if (i.params.Updated != "" || i.params.UpdatedBefore != "" || i.params.UpdatedAfter != "") &&
 		(i.params.Created == "" && i.params.CreatedBefore == "" && i.params.CreatedAfter == "") {
 		obf = "updated"

--- a/internal/query/issue_test.go
+++ b/internal/query/issue_test.go
@@ -100,7 +100,6 @@ func (tfp issueFlagParser) GetString(name string) (string, error) {
 }
 
 func (tfp issueFlagParser) GetStringArray(name string) ([]string, error) {
-
 	switch name {
 
 	case "label":
@@ -111,7 +110,6 @@ func (tfp issueFlagParser) GetStringArray(name string) ([]string, error) {
 	default:
 		return []string{}, fmt.Errorf("oops! couldn't fetch flag")
 	}
-
 }
 
 func (tfp issueFlagParser) GetUint(string) (uint, error) { return 100, nil }

--- a/internal/query/issue_test.go
+++ b/internal/query/issue_test.go
@@ -23,6 +23,7 @@ type issueFlagParser struct {
 	orderDesc     bool
 	emptyType     bool
 	labels        []string
+	projects      []string
 	withCreated   bool
 	withUpdated   bool
 	created       string
@@ -99,10 +100,18 @@ func (tfp issueFlagParser) GetString(name string) (string, error) {
 }
 
 func (tfp issueFlagParser) GetStringArray(name string) ([]string, error) {
-	if tfp.err.labels && name == "label" {
-		return []string{}, fmt.Errorf("oops! couldn't fetch label flag")
+
+	switch name {
+
+	case "label":
+		return tfp.labels, nil
+	case "projects":
+		return tfp.projects, nil
+
+	default:
+		return []string{}, fmt.Errorf("oops! couldn't fetch flag")
 	}
-	return tfp.labels, nil
+
 }
 
 func (tfp issueFlagParser) GetUint(string) (uint, error) { return 100, nil }

--- a/pkg/jql/jql.go
+++ b/pkg/jql/jql.go
@@ -23,11 +23,23 @@ type JQL struct {
 }
 
 // NewJQL initializes jql query builder.
-func NewJQL(project string) *JQL {
-	return &JQL{
-		project: project,
-		filters: []string{fmt.Sprintf("project=\"%s\"", project)},
+func NewJQL(projects []string) *JQL {
+
+	//check if the jql context required to be expected
+	jql := &JQL{}
+
+	switch totalOfProjects := len(projects); {
+
+	case totalOfProjects > 1:
+		jql.project = projects[0]
+		jql.filters = []string{fmt.Sprintf("project in (%v)", strings.Join(projects, ","))}
+
+	default:
+		jql.project = projects[0]
+		jql.filters = []string{fmt.Sprintf("project=\"%s\"", projects[0])}
 	}
+
+	return jql
 }
 
 // History search through user issue history.

--- a/pkg/jql/jql.go
+++ b/pkg/jql/jql.go
@@ -24,8 +24,6 @@ type JQL struct {
 
 // NewJQL initializes jql query builder.
 func NewJQL(projects []string) *JQL {
-
-	//check if the jql context required to be expected
 	jql := &JQL{}
 
 	switch totalOfProjects := len(projects); {

--- a/pkg/jql/jql_test.go
+++ b/pkg/jql/jql_test.go
@@ -15,14 +15,14 @@ func TestJQL(t *testing.T) {
 		{
 			name: "filter is initialized",
 			initialize: func() *JQL {
-				return NewJQL("TEST")
+				return NewJQL([]string{"TEST"})
 			},
 			expected: "project=\"TEST\"",
 		},
 		{
 			name: "it sets order by",
 			initialize: func() *JQL {
-				jql := NewJQL("TEST")
+				jql := NewJQL([]string{"TEST"})
 				jql.OrderBy("updated", "DESC")
 				return jql
 			},
@@ -31,7 +31,7 @@ func TestJQL(t *testing.T) {
 		{
 			name: "it queries history",
 			initialize: func() *JQL {
-				jql := NewJQL("TEST")
+				jql := NewJQL([]string{"TEST"})
 				jql.History()
 				return jql
 			},
@@ -40,7 +40,7 @@ func TestJQL(t *testing.T) {
 		{
 			name: "it queries watched issues",
 			initialize: func() *JQL {
-				jql := NewJQL("TEST")
+				jql := NewJQL([]string{"TEST"})
 				jql.Watching()
 				return jql
 			},
@@ -49,7 +49,7 @@ func TestJQL(t *testing.T) {
 		{
 			name: "it queries history and watched issues in order",
 			initialize: func() *JQL {
-				jql := NewJQL("TEST")
+				jql := NewJQL([]string{"TEST"})
 				jql.And(func() {
 					jql.Watching().History()
 				})
@@ -60,7 +60,7 @@ func TestJQL(t *testing.T) {
 		{
 			name: "it queries with single field filters",
 			initialize: func() *JQL {
-				jql := NewJQL("TEST")
+				jql := NewJQL([]string{"TEST"})
 				jql.And(func() {
 					jql.FilterBy("type", "Story")
 				})
@@ -71,7 +71,7 @@ func TestJQL(t *testing.T) {
 		{
 			name: "it queries with multiple field filters",
 			initialize: func() *JQL {
-				jql := NewJQL("TEST")
+				jql := NewJQL([]string{"TEST"})
 				jql.And(func() {
 					jql.FilterBy("type", "Story").
 						FilterBy("resolution", "Done").
@@ -84,7 +84,7 @@ func TestJQL(t *testing.T) {
 		{
 			name: "it queries with not filter",
 			initialize: func() *JQL {
-				jql := NewJQL("TEST")
+				jql := NewJQL([]string{"TEST"})
 				jql.And(func() {
 					jql.FilterBy("type", "~Story").
 						FilterBy("assignee", "~x")
@@ -96,7 +96,7 @@ func TestJQL(t *testing.T) {
 		{
 			name: "it queries for unassigned issues",
 			initialize: func() *JQL {
-				jql := NewJQL("TEST")
+				jql := NewJQL([]string{"TEST"})
 				jql.And(func() {
 					jql.FilterBy("type", "Story").
 						FilterBy("resolution", "Done").
@@ -109,7 +109,7 @@ func TestJQL(t *testing.T) {
 		{
 			name: "it queries with function and field filters grouped in AND operator",
 			initialize: func() *JQL {
-				jql := NewJQL("TEST")
+				jql := NewJQL([]string{"TEST"})
 				jql.And(func() {
 					jql.History().
 						Watching().
@@ -125,7 +125,7 @@ func TestJQL(t *testing.T) {
 		{
 			name: "it queries with function and field filters grouped in OR operator",
 			initialize: func() *JQL {
-				jql := NewJQL("TEST")
+				jql := NewJQL([]string{"TEST"})
 				jql.Or(func() {
 					jql.History().
 						Watching().
@@ -141,7 +141,7 @@ func TestJQL(t *testing.T) {
 		{
 			name: "it queries with greater than filter",
 			initialize: func() *JQL {
-				jql := NewJQL("TEST")
+				jql := NewJQL([]string{"TEST"})
 				jql.And(func() {
 					jql.
 						FilterBy("type", "Story").
@@ -157,7 +157,7 @@ func TestJQL(t *testing.T) {
 		{
 			name: "it queries with greater than or equals filter",
 			initialize: func() *JQL {
-				jql := NewJQL("TEST")
+				jql := NewJQL([]string{"TEST"})
 				jql.And(func() {
 					jql.
 						FilterBy("type", "Story").
@@ -173,7 +173,7 @@ func TestJQL(t *testing.T) {
 		{
 			name: "it queries with less than filter",
 			initialize: func() *JQL {
-				jql := NewJQL("TEST")
+				jql := NewJQL([]string{"TEST"})
 				jql.And(func() {
 					jql.
 						FilterBy("type", "Story").
@@ -189,7 +189,7 @@ func TestJQL(t *testing.T) {
 		{
 			name: "it queries with IN and a single label",
 			initialize: func() *JQL {
-				jql := NewJQL("TEST")
+				jql := NewJQL([]string{"TEST"})
 				jql.FilterBy("type", "Story")
 				jql.And(func() {
 					jql.In("labels", "first")
@@ -201,7 +201,7 @@ func TestJQL(t *testing.T) {
 		{
 			name: "it queries with IN and multiple labels",
 			initialize: func() *JQL {
-				jql := NewJQL("TEST")
+				jql := NewJQL([]string{"TEST"})
 				jql.Or(func() {
 					jql.FilterBy("type", "Story").
 						In("labels", "first", "second", "third")
@@ -213,7 +213,7 @@ func TestJQL(t *testing.T) {
 		{
 			name: "it queries with raw jql",
 			initialize: func() *JQL {
-				jql := NewJQL("TEST")
+				jql := NewJQL([]string{"TEST"})
 				jql.And(func() {
 					jql.
 						FilterBy("type", "Story").
@@ -227,7 +227,7 @@ func TestJQL(t *testing.T) {
 		{
 			name: "it queries with raw jql and or filter",
 			initialize: func() *JQL {
-				jql := NewJQL("TEST")
+				jql := NewJQL([]string{"TEST"})
 				jql.Or(func() {
 					jql.FilterBy("type", "Story").
 						Raw("summary ~ cli")


### PR DESCRIPTION
1. Enabled the possibility to list issues from different projects.
2. Added a new flag called projects that increases the resulting scope.

In the current behavior, the issue is taken from the default project key we selected on the **init** command. It does not enable the user to merge the issue result using different projects.

### Actual Behavior
![issues-without-filter](https://user-images.githubusercontent.com/16035390/135744361-a045d39d-731a-4c35-96e0-c59685bbec54.gif)

With this PR, the sub-command provides the flag **projects** enables the user to increase the list context searching and render issues from multiples projects.

`jira issue list --projects DESK --projects PV`

![issues-with-filter](https://user-images.githubusercontent.com/16035390/135744432-6c4d8249-363e-4ad1-9cf6-4fae201f25cf.gif)


Also, if you want to omit the default project, you can replace it using the **project** flag

`jira issue list --projects DESK --project PV  --plain`
