### PR TITLE
Allow Tab to toggle focus between the sidebar and the contents screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ The lists are displayed in an interactive UI by default.
 - Hit `ENTER` to open the selected issue in the browser.
 - Press `c` to copy issue URL to the system clipboard. This requires `xclip` / `xsel` in linux.
 - Press `CTRL+K` to copy issue key to the system clipboard.
-- In an explorer view, press `w` to toggle focus between the sidebar and the contents screen.
+- In an explorer view, press `w` or `Tab` to toggle focus between the sidebar and the contents screen.
 - Press `q` / `ESC` / `CTRL+C` to quit.
 
 ## Commands

--- a/internal/view/helper.go
+++ b/internal/view/helper.go
@@ -26,7 +26,7 @@ const (
 	The layout contains 2 sections, viz: Sidebar and Contents screen.  
 	
 	You can use up and down arrow keys or 'j' and 'k' letters to navigate through the sidebar.
-	Press 'w' to toggle focus between the sidebar and the contents screen. 
+	Press 'w' or Tab to toggle focus between the sidebar and the contents screen.
 	
 	On contents screen:
 	  - Use arrow keys or 'j', 'k', 'h', and 'l' letters to navigate through the issue list.

--- a/pkg/tui/preview.go
+++ b/pkg/tui/preview.go
@@ -180,6 +180,10 @@ func (pv *Preview) initSidebar() {
 	pv.sidebar.
 		SetSelectable(true, false).
 		SetInputCapture(func(ev *tcell.EventKey) *tcell.EventKey {
+			if ev.Key() == tcell.KeyTab {
+				pv.screen.SetFocus(pv.contents.view)
+				pv.contents.view.SetSelectable(true, false).Select(1, 0)
+			}
 			if ev.Key() == tcell.KeyRune {
 				switch ev.Rune() {
 				case 'q':
@@ -211,6 +215,10 @@ func (pv *Preview) initContents() {
 				}
 				r, c := pv.contents.view.GetSelection()
 				pv.contents.copyKeyFunc(r, c, contents())
+			}
+			if ev.Key() == tcell.KeyTab {
+				pv.screen.SetFocus(pv.sidebar)
+				pv.contents.view.SetSelectable(false, false)
 			}
 			if ev.Key() == tcell.KeyRune {
 				switch ev.Rune() {


### PR DESCRIPTION
Using `Tab` feels quite intuitive. In this pull request I add it as an alternative for `w` key.