### PR TITLE
feat: Implement jirawiki to markdown parser

### DIFF
--- a/internal/view/issue.go
+++ b/internal/view/issue.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/ankitpokhrel/jira-cli/pkg/md"
 	"github.com/charmbracelet/glamour"
 
 	"github.com/ankitpokhrel/jira-cli/internal/cmdutil"
@@ -68,7 +69,7 @@ func (i Issue) String() string {
 			desc = adf.NewTranslator(adfNode, adf.NewMarkdownTranslator()).Translate()
 		} else {
 			desc = i.Data.Fields.Description.(string)
-			desc = strings.ReplaceAll(desc, "\n", "\n\n")
+			desc = md.FromJiraMD(desc)
 		}
 	}
 	return fmt.Sprintf(

--- a/internal/view/issue_test.go
+++ b/internal/view/issue_test.go
@@ -76,7 +76,7 @@ func TestIssueDetailsWithV2Description(t *testing.T) {
 			Resolution: struct {
 				Name string `json:"name"`
 			}{Name: "Fixed"},
-			Description: "h1. Title\nh2. Subtitle",
+			Description: "h1. Title\nh2. Subtitle\n\nThis is a *bold* and _italic_ text with [a link|https://ankit.pl] in between.",
 			IssueType: struct {
 				Name string `json:"name"`
 			}{Name: "Bug"},
@@ -106,6 +106,6 @@ func TestIssueDetailsWithV2Description(t *testing.T) {
 	}
 	assert.NoError(t, issue.renderPlain(&b))
 
-	expected := "🐞 Bug  ✅ Done  ⌛ Sun, 13 Dec 20  👷 Person A  🔑️ TEST-1\n# This is a test\n⏱️  Sun, 13 Dec 20  🔎 Person Z  🚀 High  📦 BE, FE  🏷️  None\n\n-----------\nh1. Title\n\nh2. Subtitle"
+	expected := "🐞 Bug  ✅ Done  ⌛ Sun, 13 Dec 20  👷 Person A  🔑️ TEST-1\n# This is a test\n⏱️  Sun, 13 Dec 20  🔎 Person Z  🚀 High  📦 BE, FE  🏷️  None\n\n-----------\n# Title\n## Subtitle\nThis is a **bold** and __italic__ text with [a link](https://ankit.pl) in between.\n"
 	assert.Equal(t, tui.TextData(expected), issue.data())
 }

--- a/internal/view/issue_test.go
+++ b/internal/view/issue_test.go
@@ -106,6 +106,6 @@ func TestIssueDetailsWithV2Description(t *testing.T) {
 	}
 	assert.NoError(t, issue.renderPlain(&b))
 
-	expected := "🐞 Bug  ✅ Done  ⌛ Sun, 13 Dec 20  👷 Person A  🔑️ TEST-1\n# This is a test\n⏱️  Sun, 13 Dec 20  🔎 Person Z  🚀 High  📦 BE, FE  🏷️  None\n\n-----------\n# Title\n## Subtitle\nThis is a **bold** and __italic__ text with [a link](https://ankit.pl) in between.\n"
+	expected := "🐞 Bug  ✅ Done  ⌛ Sun, 13 Dec 20  👷 Person A  🔑️ TEST-1\n# This is a test\n⏱️  Sun, 13 Dec 20  🔎 Person Z  🚀 High  📦 BE, FE  🏷️  None\n\n-----------\n# Title\n## Subtitle\nThis is a **bold** and _italic_ text with [a link](https://ankit.pl) in between.\n"
 	assert.Equal(t, tui.TextData(expected), issue.data())
 }

--- a/pkg/md/doc.go
+++ b/pkg/md/doc.go
@@ -1,5 +1,5 @@
-// Package md translates jira flavored markdown to github flavored markdown.
+// Package md translates Jira flavored markdown to CommonMark markdown and viceversa.
 //
 // See: https://jira.atlassian.com/secure/WikiRendererHelpAction.jspa?section=all
-// See: https://github.github.com/gfm/
+// See: https://spec.commonmark.org/current/
 package md

--- a/pkg/md/jirawiki/parser.go
+++ b/pkg/md/jirawiki/parser.go
@@ -25,14 +25,14 @@ const (
 	TagTable         = "||"
 
 	// Let's group tags based on their behavior.
-	typeTagTextEffect      = "text-effect"
-	typeTagList            = "list"
-	typeTagHeading         = "heading"
-	typeTagTextEffectQuote = "inline-quote"
-	typeTagReferenceLink   = "link"
-	typeTagFencedCode      = "code"
-	typeTagTable           = "table"
-	typeTagOther           = "other"
+	typeTagTextEffect    = "text-effect"
+	typeTagList          = "list"
+	typeTagHeading       = "heading"
+	typeTagInlineQuote   = "inline-quote"
+	typeTagReferenceLink = "link"
+	typeTagFencedCode    = "code"
+	typeTagTable         = "table"
+	typeTagOther         = "other"
 
 	// Supported attributes.
 	attrTitle = "title"
@@ -148,7 +148,7 @@ func secondPass(lines []string) string {
 					end = token.handleTextEffects(line, &out)
 				case typeTagHeading:
 					end = token.handleHeadings(line, &out)
-				case typeTagTextEffectQuote:
+				case typeTagInlineQuote:
 					end = token.handleInlineBlockQuote(line, &out)
 				case typeTagList:
 					end = token.handleList(line, &out)
@@ -220,7 +220,13 @@ out:
 			for end < len(line) && line[end] != line[beg] {
 				end++
 			}
-			word := line[beg : end+1]
+
+			var word string
+			if end < size-1 {
+				word = line[beg : end+1]
+			} else {
+				word = line[beg:end]
+			}
 
 			tokens = append(tokens, &Token{
 				tag:      word,
@@ -231,7 +237,7 @@ out:
 			end++
 		case typeTagHeading:
 			fallthrough
-		case typeTagTextEffectQuote:
+		case typeTagInlineQuote:
 			end = beg + 1
 			for end < len(line) && line[end] != '.' {
 				end++
@@ -510,7 +516,7 @@ func getTagType(line string, beg int) string {
 		return typeTagHeading
 	}
 	if isInlineBlockQuote(beg, line) {
-		return typeTagTextEffectQuote
+		return typeTagInlineQuote
 	}
 	if isReferenceLink(beg, line) {
 		return typeTagReferenceLink

--- a/pkg/md/jirawiki/parser.go
+++ b/pkg/md/jirawiki/parser.go
@@ -434,11 +434,7 @@ func (t *Token) handleFencedCodeBlock(idx int, lines []string, out *strings.Buil
 
 		// Write everything as is.
 		out.WriteString(lines[i])
-
-		// Add a blank line if this is already not an empty line.
-		if len(line) > 0 {
-			out.WriteRune(newLine)
-		}
+		out.WriteRune(newLine)
 	}
 	out.WriteString(replacements[t.tag])
 

--- a/pkg/md/jirawiki/parser.go
+++ b/pkg/md/jirawiki/parser.go
@@ -1,0 +1,529 @@
+package jirawiki
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+)
+
+/*
+	TODO:
+		- Tables
+		- Colors (?)
+*/
+
+// Supported Jira wiki tags.
+const (
+	TagHeading1      = "h1."
+	TagHeading2      = "h2."
+	TagHeading3      = "h3."
+	TagHeading4      = "h4."
+	TagHeading5      = "h5."
+	TagHeading6      = "h6."
+	TagBlockQuote    = "bq."
+	TagQuote         = "{quote}"
+	TagPanel         = "{panel}"
+	TagCodeBlock     = "{code}"
+	TagNoFormat      = "{noformat}"
+	TagLink          = "["
+	TagOrderedList   = "#"
+	TagUnorderedList = "*" // '*' can be either be bold or an unordered list 🤦.
+	TagBold          = "*"
+	TagItalic        = "_"
+	TagUnderline     = "+"
+
+	// Let's group tags based on their behavior.
+	typeTagTextEffect      = "text-effect"
+	typeTagList            = "list"
+	typeTagHeading         = "heading"
+	typeTagTextEffectQuote = "inline-quote"
+	typeTagReferenceLink   = "link"
+	typeTagFencedCode      = "code"
+	typeTagOther           = "other"
+
+	// Supported attributes.
+	attrTitle = "title"
+
+	// Line feeds.
+	newLine        = '\n'
+	carriageReturn = '\r'
+)
+
+var validTags = []string{
+	TagHeading1,
+	TagHeading2,
+	TagHeading3,
+	TagHeading4,
+	TagHeading5,
+	TagHeading6,
+	TagBlockQuote,
+	TagQuote,
+	TagPanel,
+	TagCodeBlock,
+	TagNoFormat,
+	TagLink,
+	TagOrderedList,
+	TagUnorderedList,
+	TagBold,
+	TagItalic,
+	TagUnderline,
+}
+
+var replacements = map[string]string{
+	TagHeading1:    "#",  // '#' can be either be a h1 tag or an ordered list 🤷.
+	TagHeading2:    "##", // '##' could mean a h2 tag or indentation for an ordered list 😑.
+	TagHeading3:    "###",
+	TagHeading4:    "####",
+	TagHeading5:    "#####",
+	TagHeading6:    "######",
+	TagQuote:       "> ",
+	TagPanel:       "---",
+	TagBlockQuote:  ">",
+	TagCodeBlock:   "```",
+	TagNoFormat:    "```",
+	TagOrderedList: "-",
+	TagBold:        "**",
+	TagItalic:      "__",
+	TagUnderline:   "~",
+}
+
+// Parse converts input string to Jira markdown.
+func Parse(input string) string {
+	return secondPass(firstPass(input))
+}
+
+/*
+	First pass:
+		- Fetch lines from the input while ignoring additional carriage return or new line.
+*/
+func firstPass(input string) []string {
+	var (
+		beg   = 0
+		size  = len(input)
+		lines = make([]string, 0)
+	)
+
+	for beg < size {
+		end := beg
+		for end < size && input[end] != newLine && input[end] != carriageReturn {
+			end++
+		}
+		lines = append(lines, input[beg:end])
+
+		beg = end + 1
+	}
+
+	return lines
+}
+
+/*
+	Second pass: actual rendering.
+		- Process each line to search and mark tags.
+		- Use replacements to prepare markdown.
+*/
+func secondPass(lines []string) string {
+	var (
+		out     bytes.Buffer
+		lineNum int
+	)
+
+	for lineNum < len(lines) {
+		line := lines[lineNum]
+		tokens := tokenize(line)
+
+		if len(tokens) == 0 {
+			out.WriteString(line)
+			lineNum++
+			continue
+		}
+
+		var beg int
+
+	out:
+		for beg < len(line) {
+			end := beg
+
+			if token, ok := tokenStarts(beg, tokens); ok {
+				switch token.family {
+				case typeTagTextEffect:
+					end = token.handleTextEffects(line, &out)
+				case typeTagHeading:
+					end = token.handleHeadings(line, &out)
+				case typeTagTextEffectQuote:
+					end = token.handleInlineBlockQuote(line, &out)
+				case typeTagList:
+					end = token.handleList(line, &out)
+				case typeTagFencedCode:
+					lineNum = token.handleFencedCodeBlock(lineNum, lines, &out)
+					break out
+				case typeTagReferenceLink:
+					end = token.handleReferenceLink(line, &out)
+				case typeTagOther:
+					if token.tag == TagQuote {
+						// If end is same as size of the input, it implies that
+						// we've found a closing token, and we will ignore it.
+						if token.endIdx != len(line)-1 {
+							out.WriteString(fmt.Sprintf("\n%s", replacements[token.tag]))
+						}
+					} else {
+						out.WriteString(fmt.Sprintf("\n%s", replacements[token.tag]))
+					}
+
+					if token.tag == TagPanel {
+						if t, ok := token.attrs[attrTitle]; ok {
+							out.WriteString(fmt.Sprintf("\n**%s**\n", t))
+						}
+
+						if token.endIdx != len(line)-1 {
+							out.WriteRune(newLine)
+						}
+					}
+
+					end = token.endIdx
+				}
+			} else {
+				out.WriteRune(rune(line[beg]))
+			}
+
+			end++
+			beg = end
+		}
+
+		lineNum++
+		out.WriteRune(newLine)
+	}
+
+	return out.String()
+}
+
+// Parse the line and convert to commonmark markdown.
+// We are not expecting any line feeds at this point.
+func tokenize(line string) []*Token { //nolint:gocyclo
+	line = strings.TrimSpace(line)
+
+	var (
+		tokens []*Token
+		beg    = 0
+		size   = len(line)
+	)
+
+out:
+	for beg < size-1 {
+		var (
+			end     int
+			tagType = getTagType(line, beg)
+		)
+
+		switch tagType {
+		case typeTagTextEffect:
+			end = beg + 1
+			for end < len(line) && line[end] != line[beg] {
+				end++
+			}
+			word := line[beg : end+1]
+
+			tokens = append(tokens, &Token{
+				tag:      word,
+				family:   typeTagTextEffect,
+				startIdx: beg,
+				endIdx:   end,
+			})
+			end++
+		case typeTagHeading:
+			fallthrough
+		case typeTagTextEffectQuote:
+			end = beg + 1
+			for end < len(line) && line[end] != '.' {
+				end++
+			}
+			word := line[beg : end+1]
+
+			tokens = append(tokens, &Token{
+				tag:      word,
+				family:   tagType,
+				startIdx: beg,
+				endIdx:   end,
+			})
+			break out
+		case typeTagList:
+			end = beg + 1
+			for end < len(line) && line[end] == line[beg] {
+				end++
+			}
+			word := line[beg:end]
+
+			tokens = append(tokens, &Token{
+				tag:      word,
+				family:   typeTagList,
+				startIdx: beg,
+				endIdx:   end,
+			})
+			end++
+		case typeTagReferenceLink:
+			end = beg + 1
+			for end < len(line) && line[end] != ']' {
+				end++
+			}
+			word := line[beg : end+1]
+
+			tokens = append(tokens, &Token{
+				tag:      word,
+				family:   typeTagReferenceLink,
+				startIdx: beg,
+				endIdx:   end,
+			})
+		default:
+			end = beg + 1
+			for end < size && line[end] != '*' && line[end] != '_' && line[end] != '{' && line[end] != '}' && line[end] != '[' && line[end] != ']' {
+				end++
+			}
+
+			if end != size && line[end] != '*' && line[end] != '_' && line[end] != '{' && line[end] != '[' {
+				end++
+			}
+
+			word := line[beg:end]
+			word, attrs := extractAttributes(word)
+
+			if isToken(word) {
+				fam := typeTagOther
+				if word == TagCodeBlock || word == TagNoFormat {
+					fam = typeTagFencedCode
+				}
+
+				tokens = append(tokens, &Token{
+					tag:      word,
+					family:   fam,
+					attrs:    attrs,
+					startIdx: beg,
+					endIdx:   end - 1,
+				})
+			}
+		}
+
+		beg = end
+	}
+
+	return tokens
+}
+
+func extractAttributes(token string) (string, map[string]string) {
+	attrs := make(map[string]string)
+
+	if token[0] != '{' || !strings.Contains(token, ":") {
+		return token, attrs
+	}
+
+	pieces := strings.Split(token, ":")
+
+	tag := pieces[0] + "}"
+	meta := pieces[1][0 : len(pieces[1])-1]
+
+	// We only support title attribute at the moment.
+	validAttr := attrTitle
+
+	pieces = strings.Split(meta, "|")
+	for _, m := range pieces {
+		props := strings.Split(m, "=")
+		if len(props) == 1 {
+			attrs[validAttr] = props[0]
+		} else {
+			key, val := props[0], props[1]
+			if key == validAttr {
+				attrs[key] = val
+			}
+		}
+	}
+
+	return tag, attrs
+}
+
+// Token represents jira tags in a given string.
+type Token struct {
+	tag      string
+	family   string
+	attrs    map[string]string
+	startIdx int
+	endIdx   int
+}
+
+func (t *Token) handleTextEffects(line string, out *bytes.Buffer) int {
+	word := line[t.startIdx+1 : t.endIdx]
+
+	out.WriteString(replacements[string(line[t.startIdx])])
+	out.WriteString(word)
+	out.WriteString(replacements[string(line[t.startIdx])])
+
+	return t.endIdx
+}
+
+func (t *Token) handleHeadings(line string, out *bytes.Buffer) int {
+	word := line[t.endIdx+1:]
+
+	out.WriteString(replacements[t.tag])
+	out.WriteString(word)
+
+	return t.endIdx + len(word)
+}
+
+func (t *Token) handleInlineBlockQuote(line string, out *bytes.Buffer) int {
+	word := line[t.endIdx+1:]
+
+	out.WriteString(fmt.Sprintf("\n%s", replacements[t.tag]))
+	out.WriteString(word)
+
+	return t.endIdx + len(word)
+}
+
+func (t *Token) handleList(line string, out *bytes.Buffer) int {
+	end := t.endIdx + 1
+
+	for i := t.startIdx; i < t.endIdx-1; i++ {
+		out.WriteRune('\t')
+	}
+
+	rem := strings.TrimSpace(line[end:])
+	out.WriteString(fmt.Sprintf("- %s", rem))
+
+	end += len(rem) + 1
+
+	return end
+}
+
+func (t *Token) handleFencedCodeBlock(idx int, lines []string, out *bytes.Buffer) int {
+	if idx == len(lines)-1 {
+		return t.endIdx
+	}
+
+	out.WriteString(fmt.Sprintf("\n%s", replacements[t.tag]))
+	if t, ok := t.attrs[attrTitle]; ok {
+		pieces := strings.Split(t, ".")
+		if len(pieces) == 2 {
+			out.WriteString(pieces[1])
+		} else {
+			out.WriteString(t)
+		}
+	}
+	out.WriteRune(newLine)
+
+	i := idx + 1
+	for ; i < len(lines); i++ {
+		line := strings.TrimSpace(lines[i])
+		if line == TagCodeBlock || line == TagNoFormat {
+			break
+		}
+
+		// Write everything as is.
+		out.WriteString(lines[i])
+
+		// Add a blank line if this is already not an empty line.
+		if len(line) > 0 {
+			out.WriteRune(newLine)
+		}
+	}
+	out.WriteString(replacements[t.tag])
+
+	return i + 1
+}
+
+func (t *Token) handleReferenceLink(line string, out *bytes.Buffer) int {
+	if len(line) < 2 {
+		return t.endIdx
+	}
+
+	body := line[t.startIdx+1 : t.endIdx]
+	pieces := strings.Split(body, "|")
+
+	var link string
+
+	if len(pieces) == 2 {
+		link = fmt.Sprintf("[%s](%s)", pieces[0], pieces[1])
+	} else {
+		link = fmt.Sprintf("[](%s)", pieces[0])
+	}
+
+	out.WriteString(link)
+
+	return t.endIdx
+}
+
+func isToken(inp string) bool {
+	for _, tag := range validTags {
+		if inp == tag {
+			return true
+		}
+	}
+	return false
+}
+
+func tokenStarts(idx int, tokens []*Token) (*Token, bool) {
+	for _, token := range tokens {
+		if idx == token.startIdx {
+			return token, true
+		}
+	}
+	return nil, false
+}
+
+func getTagType(line string, beg int) string {
+	if isInlineTag(line[beg], line[beg+1]) {
+		return typeTagTextEffect
+	}
+	if isListTag(line[beg], line[beg+1]) {
+		return typeTagList
+	}
+	if isHeadingsTag(beg, line) {
+		return typeTagHeading
+	}
+	if isInlineBlockQuote(beg, line) {
+		return typeTagTextEffectQuote
+	}
+	if isReferenceLink(beg, line) {
+		return typeTagReferenceLink
+	}
+	return typeTagOther
+}
+
+func isInlineTag(beg, next uint8) bool {
+	s := string(beg)
+	return (s == TagBold || s == TagItalic || s == TagUnderline) && (next != ' ' && next != beg)
+}
+
+func isListTag(beg, next uint8) bool {
+	s := string(beg)
+	return (s == TagOrderedList || s == TagUnorderedList) && (next == ' ' || next == beg)
+}
+
+func isHeadingsTag(beg int, line string) bool {
+	size := len(line)
+	if size < 3 {
+		return false
+	}
+	return line[beg] == 'h' && line[2] == '.'
+}
+
+func isInlineBlockQuote(beg int, line string) bool {
+	size := len(line)
+	if size < 3 {
+		return false
+	}
+	return line[beg] == 'b' && line[2] == '.'
+}
+
+func isReferenceLink(beg int, line string) bool {
+	if line[beg] != '[' {
+		return false
+	}
+
+	var end int
+
+	for beg < len(line) {
+		end = beg + 1
+		for end < len(line) && line[end] != ']' {
+			end++
+		}
+		break
+	}
+
+	return end < len(line) && line[end] == ']'
+}

--- a/pkg/md/jirawiki/parser.go
+++ b/pkg/md/jirawiki/parser.go
@@ -415,6 +415,7 @@ func (t *Token) handleFencedCodeBlock(idx int, lines []string, out *strings.Buil
 	}
 
 	out.WriteString(fmt.Sprintf("\n%s", replacements[t.tag]))
+
 	if t, ok := t.attrs[attrTitle]; ok {
 		pieces := strings.Split(t, ".")
 		if len(pieces) == 2 {
@@ -423,6 +424,7 @@ func (t *Token) handleFencedCodeBlock(idx int, lines []string, out *strings.Buil
 			out.WriteString(t)
 		}
 	}
+
 	out.WriteRune(newLine)
 
 	i := idx + 1

--- a/pkg/md/jirawiki/parser_test.go
+++ b/pkg/md/jirawiki/parser_test.go
@@ -209,6 +209,16 @@ func TestParseReferenceLinks(t *testing.T) {
 			expected: "[](https://ankit.pl)\n",
 		},
 		{
+			name:     "mailto link",
+			input:    "[mailto:hi@ankit.pl]",
+			expected: "[](mailto:hi@ankit.pl)\n",
+		},
+		{
+			name:     "anchor link",
+			input:    "[#somewhere]",
+			expected: "[](#somewhere)\n",
+		},
+		{
 			name:     "valid link wrapped around texts",
 			input:    "A text with [a link|https://ankit.pl] in between.",
 			expected: "A text with [a link](https://ankit.pl) in between.\n",

--- a/pkg/md/jirawiki/parser_test.go
+++ b/pkg/md/jirawiki/parser_test.go
@@ -73,7 +73,7 @@ h6. Heading 6`,
 	}
 }
 
-func TestParseInlineTags(t *testing.T) {
+func TestParseTextEffectTags(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
@@ -84,17 +84,12 @@ func TestParseInlineTags(t *testing.T) {
 		{
 			name:     "bold",
 			input:    "*bold*",
-			expected: "**bold**\n",
-		},
-		{
-			name:     "italic",
-			input:    "_italic_",
-			expected: "__italic__\n",
+			expected: "**bold**\n\n",
 		},
 		{
 			name:     "bold and italic",
-			input:    "Line with *bold* and _italic_ text.",
-			expected: "Line with **bold** and __italic__ text.\n",
+			input:    "Line with *bold*, _italic_ and -strikethrought- text.",
+			expected: "Line with **bold**, _italic_ and -strikethrought- text.\n",
 		},
 	}
 
@@ -189,9 +184,9 @@ func TestParseReferenceLinks(t *testing.T) {
 			expected: "A text with [a link](https://ankit.pl) in between.\n",
 		},
 		{
-			name:     "valid link mixed with bold and italic text",
-			input:    "A *bold* and _italic_ text with [a link|https://ankit.pl] in between.",
-			expected: "A **bold** and __italic__ text with [a link](https://ankit.pl) in between.\n",
+			name:     "valid link mixed with bold, italic and strikethrough text",
+			input:    "A *bold*, _italic_ and -strikethrough- text with [a link|https://ankit.pl] in between.",
+			expected: "A **bold**, _italic_ and -strikethrough- text with [a link](https://ankit.pl) in between.\n",
 		},
 		{
 			name:     "invalid link",
@@ -259,12 +254,14 @@ func TestParsePanels(t *testing.T) {
 		{
 			name: "panel",
 			input: `{panel}
-Panel description.
+This is a panel description.
+And, a new line.
 {panel}
 `,
 			expected: `
 ---
-Panel description.
+This is a panel description.
+And, a new line.
 ---
 `,
 		},
@@ -324,7 +321,8 @@ Panel description.
 Panel description.
 {panel}
 `,
-			expected: `{panelPanel description.
+			expected: `{panel
+Panel description.
 ---
 `,
 		},

--- a/pkg/md/jirawiki/parser_test.go
+++ b/pkg/md/jirawiki/parser_test.go
@@ -87,9 +87,9 @@ func TestParseTextEffectTags(t *testing.T) {
 			expected: "**bold**\n\n",
 		},
 		{
-			name:     "bold and italic",
-			input:    "Line with *bold*, _italic_ and -strikethrought- text.",
-			expected: "Line with **bold**, _italic_ and -strikethrought- text.\n",
+			name:     "bold, italic and strikethrough",
+			input:    "Line with *bold*, _italic_ and -strikethrough- text. And _italics with *bold* text in it_.",
+			expected: "Line with **bold**, _italic_ and -strikethrough- text. And _italics with **bold** text in it_.\n",
 		},
 	}
 
@@ -398,6 +398,62 @@ func main() {
 	fmt.Println("Hello, world!")
 }
 ` + "```\n",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tc.expected, Parse(tc.input))
+		})
+	}
+}
+
+func TestTables(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name: "valid table",
+			input: `||heading 1||heading 2||heading 3||
+|col A1|col A2|col A3|
+|col B1|col B2|col B3|`,
+			expected: `|heading 1|heading 2|heading 3|
+|---|---|---|
+|col A1|col A2|col A3|
+|col B1|col B2|col B3|
+`,
+		},
+		{
+			name:  "valid table with no rows",
+			input: `||heading 1||heading 2||heading 3||`,
+			expected: `|heading 1|heading 2|heading 3|
+|---|---|---|
+`,
+		},
+		{
+			name: "valid table with no headers",
+			input: `||||
+|col A1|
+|col B1|`,
+			expected: `||
+|---|
+|col A1|
+|col B1|
+`,
+		},
+		{
+			name: "invalid table",
+			input: `||heading 1||heading 2||heading 3
+|col A1|col A2|col A3|`,
+			expected: "||heading 1||heading 2||heading 3|col A1|col A2|col A3|\n",
 		},
 	}
 

--- a/pkg/md/jirawiki/parser_test.go
+++ b/pkg/md/jirawiki/parser_test.go
@@ -60,6 +60,11 @@ h6. Heading 6`,
 ###### Heading 6
 `,
 		},
+		{
+			name:     "empty heading",
+			input:    "h3.",
+			expected: "###\n",
+		},
 	}
 
 	for _, tc := range cases {
@@ -90,6 +95,21 @@ func TestParseTextEffectTags(t *testing.T) {
 			name:     "bold, italic and strikethrough",
 			input:    "Line with *bold*, _italic_ and -strikethrough- text. And _italics with *bold* text in it_.",
 			expected: "Line with **bold**, _italic_ and -strikethrough- text. And _italics with **bold** text in it_.\n",
+		},
+		{
+			name:     "bold",
+			input:    "*bold",
+			expected: "**bold**\n",
+		},
+		{
+			name:     "partially closed bold tag in a sentence",
+			input:    "Line with *bold and _italic_ text.",
+			expected: "Line with **bold and _italic_ text.**\n",
+		},
+		{
+			name:     "partially closed bold and italic in a sentence",
+			input:    "Line with *bold and _italic text.",
+			expected: "Line with **bold and _italic text.**\n",
 		},
 	}
 
@@ -140,6 +160,16 @@ func TestParseListTags(t *testing.T) {
 	- Ordered list subitem 1
 	- Ordered list subitem 2
 		- Ordered list subitem 2 item 1
+`,
+		},
+		{
+			name: "empty list",
+			input: `* Item 1
+ ** Subitem 1
+ **`,
+			expected: `- Item 1
+	- Subitem 1
+	- 
 `,
 		},
 	}
@@ -193,6 +223,11 @@ func TestParseReferenceLinks(t *testing.T) {
 			input:    "This is a [Link|https://ankit.pl, and some texts.",
 			expected: "This is a [Link|https://ankit.pl, and some texts.",
 		},
+		{
+			name:     "empty link",
+			input:    "This link is empty []",
+			expected: "This link is empty []()\n",
+		},
 	}
 
 	for _, tc := range cases {
@@ -226,9 +261,19 @@ func TestParseBlockQuote(t *testing.T) {
 			expected: "\n> Blockquote {without} ending new line\n",
 		},
 		{
+			name:     "unclosed blockquote",
+			input:    "{quote}Blockquote {without} closing and a *bold* text",
+			expected: "\n> Blockquote {without} closing and a **bold** text\n",
+		},
+		{
 			name:     "inline blockquote",
 			input:    "bq. Inline blockquote",
 			expected: "\n> Inline blockquote\n",
+		},
+		{
+			name:     "empty inline blockquote",
+			input:    "bq.",
+			expected: "\n>\n",
 		},
 	}
 

--- a/pkg/md/jirawiki/parser_test.go
+++ b/pkg/md/jirawiki/parser_test.go
@@ -419,7 +419,9 @@ func main() {
 {code}`,
 			expected: "\n```go" + `
 package main
+
 import "fmt"
+
 func main() {
 	fmt.Println("Hello, world!")
 }
@@ -438,7 +440,9 @@ func main() {
 {code}`,
 			expected: "\n```go" + `
 package main
+
 import "fmt"
+
 func main() {
 	fmt.Println("Hello, world!")
 }

--- a/pkg/md/md.go
+++ b/pkg/md/md.go
@@ -20,7 +20,5 @@ func ToJiraMD(md string) string {
 
 // FromJiraMD translates Jira flavored markdown to CommonMark.
 func FromJiraMD(jfm string) string {
-	out := jirawiki.Parse(jfm)
-
-	return out
+	return jirawiki.Parse(jfm)
 }

--- a/pkg/md/md.go
+++ b/pkg/md/md.go
@@ -1,6 +1,7 @@
 package md
 
 import (
+	"github.com/ankitpokhrel/jira-cli/pkg/md/jirawiki"
 	cf "github.com/kentaro-m/blackfriday-confluence"
 	bf "github.com/russross/blackfriday/v2"
 )
@@ -19,5 +20,7 @@ func ToJiraMD(md string) string {
 
 // FromJiraMD translates Jira flavored markdown to CommonMark.
 func FromJiraMD(jfm string) string {
-	return jfm
+	out := jirawiki.Parse(jfm)
+
+	return out
 }

--- a/pkg/md/md.go
+++ b/pkg/md/md.go
@@ -6,13 +6,18 @@ import (
 )
 
 // ToJiraMD translates CommonMark to Jira flavored markdown.
-func ToJiraMD(jfm string) string {
-	if jfm == "" {
-		return jfm
+func ToJiraMD(md string) string {
+	if md == "" {
+		return md
 	}
 
 	renderer := &cf.Renderer{Flags: cf.IgnoreMacroEscaping}
 	r := bf.New(bf.WithRenderer(renderer), bf.WithExtensions(bf.CommonExtensions))
 
-	return string(renderer.Render(r.Parse([]byte(jfm))))
+	return string(renderer.Render(r.Parse([]byte(md))))
+}
+
+// FromJiraMD translates Jira flavored markdown to CommonMark.
+func FromJiraMD(jfm string) string {
+	return jfm
 }


### PR DESCRIPTION
This PR implements a multi-pass parser to convert [jirawiki or jira flavored markdown](https://jira.atlassian.com/secure/WikiRendererHelpAction.jspa?section=all) to a [commonmark markdown](https://spec.commonmark.org/current/). 

The conversion happens in 2 pass:
1. First pass simply fetches lines we are interested in from the input.
2. Second pass finds and mark the token + use replacements to prepare the markdown.

Not all of the jirawiki tags are supported at the moment.

#### Given the following description in older version of Jira.

<details><summary>Jira wiki markdown of the UI below</summary>

```
h1. This is the task heading
{quote}This is a subtitle in a blockquote
{quote}
 

*A list of tasks*
 * Task 1
 * Task 2
 ** Subtask 1
 ** Subtask 2
 *** Subtask 2 item 1
 * Task 3
 * Task 4

 
{panel:title=Acceptance Criteria}
This *shit* should work as expected.
{panel}
{code:go}
// ReplaceAll replaces all occurrences of an old string
// in a text node with a new one.
func (a *ADF) ReplaceAll(old, new string) {
	if a == nil || len(a.Content) == 0 {
		return
	}
	for _, parent := range a.Content {
		a.replace(parent, old, new)
	}
}

func (a *ADF) replace(n *Node, old, new string) {
	for _, child := range n.Content {
		a.replace(child, old, new)
	}
	if n.NodeType == ChildNodeText {
		n.Text = strings.ReplaceAll(n.Text, old, new)
	}
}
{code}
 

Hello, this is a normal paragraph, with [a link|http://ankit.pl] and some texts around it.

{noformat}
And, this is a pre-formatted text.
{noformat}
```
</details>

<img width="864" alt="Screen Shot 2021-10-24 at 12 47 44 PM" src="https://user-images.githubusercontent.com/2364546/138590710-835d10e9-613c-4802-8c7a-3e62a7febda4.png">


#### The jirawiki markdown above will get converted to a commonmark markdown and rendered in the CLI as below

<img width="752" alt="Screen Shot 2021-10-24 at 12 49 33 PM" src="https://user-images.githubusercontent.com/2364546/138590869-b566c8e3-69ee-4026-9c26-93c283d2dd3f.png">

