### PR TITLE
feat: Add type on project listing

### DIFF
--- a/internal/view/project.go
+++ b/internal/view/project.go
@@ -46,7 +46,7 @@ func (p Project) Render() error {
 	p.printHeader()
 
 	for _, d := range p.data {
-		fmt.Fprintf(p.writer, "%s\t%s\t%s\n", d.Key, prepareTitle(d.Name), d.Lead.Name)
+		fmt.Fprintf(p.writer, "%s\t%s\t%s\t%s\n", d.Key, prepareTitle(d.Name), d.Type, d.Lead.Name)
 	}
 	if _, ok := p.writer.(*tabwriter.Writer); ok {
 		err := p.writer.(*tabwriter.Writer).Flush()
@@ -62,15 +62,17 @@ func (p Project) header() []string {
 	return []string{
 		"KEY",
 		"NAME",
+		"TYPE",
 		"LEAD",
 	}
 }
 
 func (p Project) printHeader() {
-	n := len(p.header())
-	for i, h := range p.header() {
+	headers := p.header()
+	end := len(headers) - 1
+	for i, h := range headers {
 		fmt.Fprintf(p.writer, "%s", h)
-		if i != n-1 {
+		if i != end {
 			fmt.Fprintf(p.writer, "\t")
 		}
 	}

--- a/internal/view/project_test.go
+++ b/internal/view/project_test.go
@@ -17,17 +17,17 @@ func TestProjectRender(t *testing.T) {
 	}
 
 	data := []*jira.Project{
-		{Key: "FRST", Name: "First", Lead: lead{Name: "Person A"}},
-		{Key: "SCND", Name: "[2] Second", Lead: lead{Name: "Person B"}},
-		{Key: "THIRD", Name: "Third", Lead: lead{Name: "Person C"}},
+		{Key: "FRST", Name: "First", Lead: lead{Name: "Person A"}, Type: jira.ProjectTypeClassic},
+		{Key: "SCND", Name: "[2] Second", Lead: lead{Name: "Person B"}, Type: jira.ProjectTypeNextGen},
+		{Key: "THIRD", Name: "Third", Lead: lead{Name: "Person C"}, Type: jira.ProjectTypeClassic},
 	}
 	board := NewProject(data, WithProjectWriter(&b))
 	assert.NoError(t, board.Render())
 
-	expected := `KEY	NAME	LEAD
-FRST	First	Person A
-SCND	⦗2⦘ Second	Person B
-THIRD	Third	Person C
+	expected := `KEY	NAME	TYPE	LEAD
+FRST	First	classic	Person A
+SCND	⦗2⦘ Second	next-gen	Person B
+THIRD	Third	classic	Person C
 `
 	assert.Equal(t, expected, b.String())
 }

--- a/pkg/jira/issue.go
+++ b/pkg/jira/issue.go
@@ -11,6 +11,8 @@ import (
 )
 
 const (
+	// IssueTypeEpic is an epic issue type.
+	IssueTypeEpic = "Epic"
 	// AssigneeNone is an empty assignee.
 	AssigneeNone = "none"
 	// AssigneeDefault is a default assignee.

--- a/pkg/jira/project.go
+++ b/pkg/jira/project.go
@@ -6,6 +6,13 @@ import (
 	"net/http"
 )
 
+const (
+	// ProjectTypeClassic is a classic project type.
+	ProjectTypeClassic = "classic"
+	// ProjectTypeNextGen is a next gen project type.
+	ProjectTypeNextGen = "next-gen"
+)
+
 // Project fetches response from /project endpoint.
 func (c *Client) Project() ([]*Project, error) {
 	res, err := c.GetV2(context.Background(), "/project?expand=lead", nil)

--- a/pkg/jira/types.go
+++ b/pkg/jira/types.go
@@ -4,8 +4,14 @@ import (
 	"encoding/json"
 )
 
-// IssueTypeEpic is an epic issue type.
-const IssueTypeEpic = "Epic"
+const (
+	// IssueTypeEpic is an epic issue type.
+	IssueTypeEpic = "Epic"
+	// ProjectTypeClassic is a classic project type.
+	ProjectTypeClassic = "classic"
+	// ProjectTypeNextGen is a next gen project type.
+	ProjectTypeNextGen = "next-gen"
+)
 
 // Project holds project info.
 type Project struct {

--- a/pkg/jira/types.go
+++ b/pkg/jira/types.go
@@ -14,6 +14,7 @@ type Project struct {
 	Lead struct {
 		Name string `json:"displayName"`
 	} `json:"lead"`
+	Type string `json:"style"`
 }
 
 // Board holds board info.

--- a/pkg/jira/types.go
+++ b/pkg/jira/types.go
@@ -4,15 +4,6 @@ import (
 	"encoding/json"
 )
 
-const (
-	// IssueTypeEpic is an epic issue type.
-	IssueTypeEpic = "Epic"
-	// ProjectTypeClassic is a classic project type.
-	ProjectTypeClassic = "classic"
-	// ProjectTypeNextGen is a next gen project type.
-	ProjectTypeNextGen = "next-gen"
-)
-
 // Project holds project info.
 type Project struct {
 	Key  string `json:"key"`


### PR DESCRIPTION
Jira cloud can have either a `classic` or a `next-gen` project. This PR adds a `TYPE` field when listing the project.

<img width="402" alt="Screen Shot 2021-11-12 at 9 39 10 PM" src="https://user-images.githubusercontent.com/2364546/141531782-eee318b5-feda-4c2e-a378-8377d980734f.png">
