### PR TITLE
cfg!: Expand config to include project type

### DIFF
--- a/internal/cmd/board/board.go
+++ b/internal/cmd/board/board.go
@@ -25,7 +25,7 @@ func NewCmdBoard() *cobra.Command {
 }
 
 func board(cmd *cobra.Command, _ []string) {
-	project := viper.GetString("project")
+	project := viper.GetString("project.key")
 
 	debug, err := cmd.Flags().GetBool("debug")
 	cmdutil.ExitIfError(err)

--- a/internal/cmd/epic/add/add.go
+++ b/internal/cmd/epic/add/add.go
@@ -36,7 +36,7 @@ func NewCmdAdd() *cobra.Command {
 
 func add(cmd *cobra.Command, args []string) {
 	server := viper.GetString("server")
-	project := viper.GetString("project")
+	project := viper.GetString("project.key")
 	params := parseFlags(cmd.Flags(), args, project)
 	client := api.Client(jira.Config{Debug: params.debug})
 

--- a/internal/cmd/epic/create/create.go
+++ b/internal/cmd/epic/create/create.go
@@ -46,7 +46,7 @@ func SetFlags(cmd *cobra.Command) {
 // TODO: Reduce cyclomatic complexity.
 func create(cmd *cobra.Command, _ []string) {
 	server := viper.GetString("server")
-	project := viper.GetString("project")
+	project := viper.GetString("project.key")
 
 	params := parseFlags(cmd.Flags())
 	client := api.Client(jira.Config{Debug: params.debug})

--- a/internal/cmd/epic/list/list.go
+++ b/internal/cmd/epic/list/list.go
@@ -77,7 +77,7 @@ func SetFlags(cmd *cobra.Command) {
 
 func epicList(cmd *cobra.Command, args []string) {
 	server := viper.GetString("server")
-	project := viper.GetString("project")
+	project := viper.GetString("project.key")
 
 	debug, err := cmd.Flags().GetBool("debug")
 	cmdutil.ExitIfError(err)

--- a/internal/cmd/epic/remove/remove.go
+++ b/internal/cmd/epic/remove/remove.go
@@ -34,7 +34,7 @@ func NewCmdRemove() *cobra.Command {
 }
 
 func remove(cmd *cobra.Command, args []string) {
-	project := viper.GetString("project")
+	project := viper.GetString("project.key")
 	params := parseFlags(cmd.Flags(), args, project)
 	client := api.Client(jira.Config{Debug: params.debug})
 

--- a/internal/cmd/issue/assign/assign.go
+++ b/internal/cmd/issue/assign/assign.go
@@ -59,7 +59,7 @@ ASSIGNEE	Email or display name of the user to assign the issue to`,
 }
 
 func assign(cmd *cobra.Command, args []string) {
-	project := viper.GetString("project")
+	project := viper.GetString("project.key")
 	params := parseArgsAndFlags(cmd.Flags(), args, project)
 	client := api.Client(jira.Config{Debug: params.debug})
 	ac := assignCmd{

--- a/internal/cmd/issue/clone/clone.go
+++ b/internal/cmd/issue/clone/clone.go
@@ -47,7 +47,7 @@ func NewCmdClone() *cobra.Command {
 
 func clone(cmd *cobra.Command, args []string) {
 	server := viper.GetString("server")
-	project := viper.GetString("project")
+	project := viper.GetString("project.key")
 
 	params := parseFlags(cmd.Flags())
 	client := api.Client(jira.Config{Debug: params.debug})

--- a/internal/cmd/issue/comment/add/add.go
+++ b/internal/cmd/issue/comment/add/add.go
@@ -123,7 +123,7 @@ func parseArgsAndFlags(args []string, flags query.FlagParser) *addParams {
 
 	nargs := len(args)
 	if nargs >= 1 {
-		issueKey = cmdutil.GetJiraIssueKey(viper.GetString("project"), args[0])
+		issueKey = cmdutil.GetJiraIssueKey(viper.GetString("project.key"), args[0])
 	}
 	if nargs >= 2 {
 		body = args[1]
@@ -168,7 +168,7 @@ func (ac *addCmd) setIssueKey() error {
 	if err := survey.Ask([]*survey.Question{qs}, &ans); err != nil {
 		return err
 	}
-	ac.params.issueKey = cmdutil.GetJiraIssueKey(viper.GetString("project"), ans)
+	ac.params.issueKey = cmdutil.GetJiraIssueKey(viper.GetString("project.key"), ans)
 
 	return nil
 }

--- a/internal/cmd/issue/create/create.go
+++ b/internal/cmd/issue/create/create.go
@@ -45,7 +45,7 @@ func SetFlags(cmd *cobra.Command) {
 
 func create(cmd *cobra.Command, _ []string) {
 	server := viper.GetString("server")
-	project := viper.GetString("project")
+	project := viper.GetString("project.key")
 
 	params := parseFlags(cmd.Flags())
 	client := api.Client(jira.Config{Debug: params.debug})

--- a/internal/cmd/issue/edit/edit.go
+++ b/internal/cmd/issue/edit/edit.go
@@ -52,7 +52,7 @@ func NewCmdEdit() *cobra.Command {
 
 func edit(cmd *cobra.Command, args []string) {
 	server := viper.GetString("server")
-	project := viper.GetString("project")
+	project := viper.GetString("project.key")
 
 	params := parseArgsAndFlags(cmd.Flags(), args, project)
 	client := api.Client(jira.Config{Debug: params.debug})

--- a/internal/cmd/issue/link/link.go
+++ b/internal/cmd/issue/link/link.go
@@ -43,7 +43,7 @@ func NewCmdLink() *cobra.Command {
 }
 
 func link(cmd *cobra.Command, args []string) {
-	project := viper.GetString("project")
+	project := viper.GetString("project.key")
 	params := parseArgsAndFlags(cmd.Flags(), args, project)
 	client := api.Client(jira.Config{Debug: params.debug})
 	lc := linkCmd{

--- a/internal/cmd/issue/list/list.go
+++ b/internal/cmd/issue/list/list.go
@@ -61,7 +61,7 @@ func NewCmdList() *cobra.Command {
 // List displays a list view.
 func List(cmd *cobra.Command, _ []string) {
 	server := viper.GetString("server")
-	project := viper.GetString("project")
+	project := viper.GetString("project.key")
 
 	debug, err := cmd.Flags().GetBool("debug")
 	cmdutil.ExitIfError(err)

--- a/internal/cmd/issue/move/move.go
+++ b/internal/cmd/issue/move/move.go
@@ -44,7 +44,7 @@ STATE		State you want to transition the issue to`,
 }
 
 func move(cmd *cobra.Command, args []string) {
-	project := viper.GetString("project")
+	project := viper.GetString("project.key")
 	installation := viper.GetString("installation")
 	params := parseArgsAndFlags(cmd.Flags(), args, project)
 	client := api.Client(jira.Config{Debug: params.debug})

--- a/internal/cmd/issue/view/view.go
+++ b/internal/cmd/issue/view/view.go
@@ -39,7 +39,7 @@ func view(cmd *cobra.Command, args []string) {
 	debug, err := cmd.Flags().GetBool("debug")
 	cmdutil.ExitIfError(err)
 
-	key := cmdutil.GetJiraIssueKey(viper.GetString("project"), args[0])
+	key := cmdutil.GetJiraIssueKey(viper.GetString("project.key"), args[0])
 	issue, err := func() (*jira.Issue, error) {
 		s := cmdutil.Info("Fetching issue details...")
 		defer s.Stop()

--- a/internal/cmd/open/open.go
+++ b/internal/cmd/open/open.go
@@ -34,7 +34,7 @@ func NewCmdOpen() *cobra.Command {
 
 func open(_ *cobra.Command, args []string) {
 	server := viper.GetString("server")
-	project := viper.GetString("project")
+	project := viper.GetString("project.key")
 
 	var url string
 

--- a/internal/cmd/root/root.go
+++ b/internal/cmd/root/root.go
@@ -98,7 +98,7 @@ func NewCmdRoot() *cobra.Command {
 	cmd.SetHelpFunc(helpFunc)
 
 	_ = viper.BindPFlag("config", cmd.PersistentFlags().Lookup("config"))
-	_ = viper.BindPFlag("project", cmd.PersistentFlags().Lookup("project"))
+	_ = viper.BindPFlag("project.key", cmd.PersistentFlags().Lookup("project"))
 	_ = viper.BindPFlag("debug", cmd.PersistentFlags().Lookup("debug"))
 
 	addChildCommands(&cmd)

--- a/internal/cmd/sprint/list/list.go
+++ b/internal/cmd/sprint/list/list.go
@@ -70,7 +70,7 @@ func SetFlags(cmd *cobra.Command) {
 
 func sprintList(cmd *cobra.Command, args []string) {
 	server := viper.GetString("server")
-	project := viper.GetString("project")
+	project := viper.GetString("project.key")
 	boardID := viper.GetInt("board.id")
 
 	debug, err := cmd.Flags().GetBool("debug")


### PR DESCRIPTION
This change require regenerating the config file.

**Before**
```sh
project: ANK
```

**After**
```sh
project:
  key: ANK
  type: classic
```

Partially relates to #186 