### PR TITLE
cfg!: Rename field to name and add link field to epic

### DIFF
--- a/internal/cmd/epic/create/create.go
+++ b/internal/cmd/epic/create/create.go
@@ -134,7 +134,7 @@ func create(cmd *cobra.Command, _ []string) {
 			Priority:      params.priority,
 			Labels:        params.labels,
 			Components:    params.components,
-			EpicFieldName: viper.GetString("epic.field"),
+			EpicFieldName: viper.GetString("epic.name"),
 		}
 		if projectType != jira.ProjectTypeNextGen {
 			cr.Name = params.name

--- a/pkg/jira/epic.go
+++ b/pkg/jira/epic.go
@@ -8,6 +8,13 @@ import (
 	"net/url"
 )
 
+const (
+	// EpicFieldName represents epic name field in create metadata.
+	EpicFieldName = "Epic Name"
+	// EpicFieldLink represents epic link field in create metadata.
+	EpicFieldLink = "Epic Link"
+)
+
 // Epic fetches epics using the /search endpoint.
 func (c *Client) Epic(jql string) (*SearchResult, error) {
 	res, err := c.Get(context.Background(), "/search?jql="+url.QueryEscape(jql), nil)

--- a/pkg/jira/types.go
+++ b/pkg/jira/types.go
@@ -23,7 +23,8 @@ type Board struct {
 
 // Epic holds epic info.
 type Epic struct {
-	Field string `json:"field"`
+	Name string `json:"name"`
+	Link string `json:"link"`
 }
 
 // Issue holds issue info.


### PR DESCRIPTION
This PR:
- Renames `epic.field` to `epic.name`
- Adds `epic.link` field

*Requires config regeneration.