### PR TITLE
feat: Allow to filter by parent

### DIFF
--- a/internal/cmd/issue/list/list.go
+++ b/internal/cmd/issue/list/list.go
@@ -66,6 +66,12 @@ func List(cmd *cobra.Command, _ []string) {
 	debug, err := cmd.Flags().GetBool("debug")
 	cmdutil.ExitIfError(err)
 
+	pk, err := cmd.Flags().GetString("parent")
+	cmdutil.ExitIfError(err)
+
+	err = cmd.Flags().Set("parent", cmdutil.GetJiraIssueKey(project, pk))
+	cmdutil.ExitIfError(err)
+
 	issues, total, err := func() ([]*jira.Issue, int, error) {
 		s := cmdutil.Info("Fetching issues...")
 		defer s.Stop()
@@ -135,6 +141,7 @@ func SetFlags(cmd *cobra.Command) {
 	cmd.Flags().StringP("assignee", "a", "", "Filter issues by assignee (email or display name)")
 	cmd.Flags().StringP("component", "C", "", "Filter issues by component")
 	cmd.Flags().StringArrayP("label", "l", []string{}, "Filter issues by label")
+	cmd.Flags().StringP("parent", "P", "", "Filter issues by parent")
 	cmd.Flags().Bool("history", false, "Issues you accessed recently")
 	cmd.Flags().BoolP("watching", "w", false, "Issues you are watching")
 	cmd.Flags().String("created", "", "Filter issues by created date\n"+

--- a/internal/query/issue.go
+++ b/internal/query/issue.go
@@ -49,7 +49,8 @@ func (i *Issue) Get() string {
 			FilterBy("priority", i.params.Priority).
 			FilterBy("reporter", i.params.Reporter).
 			FilterBy("assignee", i.params.Assignee).
-			FilterBy("component", i.params.Component)
+			FilterBy("component", i.params.Component).
+			FilterBy("parent", i.params.Parent)
 
 		i.setCreatedFilters(q)
 		i.setUpdatedFilters(q)
@@ -129,6 +130,7 @@ type IssueParams struct {
 	Watching      bool
 	Resolution    string
 	IssueType     string
+	Parent        string
 	Status        string
 	Priority      string
 	Reporter      string
@@ -152,7 +154,7 @@ func (ip *IssueParams) init(flags FlagParser) error {
 
 	boolParams := []string{"history", "watching", "reverse", "debug"}
 	stringParams := []string{
-		"resolution", "type", "status", "priority", "reporter", "assignee", "component",
+		"resolution", "type", "parent", "status", "priority", "reporter", "assignee", "component",
 		"created", "created-after", "created-before", "updated", "updated-after", "updated-before",
 		"jql",
 	}
@@ -210,6 +212,8 @@ func (ip *IssueParams) setStringParams(paramsMap map[string]string) {
 			ip.Resolution = v
 		case "type":
 			ip.IssueType = v
+		case "parent":
+			ip.Parent = v
 		case "status":
 			ip.Status = v
 		case "priority":

--- a/internal/query/issue_test.go
+++ b/internal/query/issue_test.go
@@ -123,7 +123,7 @@ func TestIssueGet(t *testing.T) {
 			},
 			expected: `project="TEST" AND issue IN issueHistory() AND issue IN watchedIssues() AND ` +
 				`type="test" AND resolution="test" AND status="test" AND priority="test" AND reporter="test" ` +
-				`AND assignee="test" AND component="test" ORDER BY lastViewed ASC`,
+				`AND assignee="test" AND component="test" AND parent="test" ORDER BY lastViewed ASC`,
 		},
 		{
 			name: "query without issue history parameter",
@@ -134,7 +134,7 @@ func TestIssueGet(t *testing.T) {
 			},
 			expected: `project="TEST" AND issue IN watchedIssues() AND ` +
 				`type="test" AND resolution="test" AND status="test" AND priority="test" AND reporter="test" ` +
-				`AND assignee="test" AND component="test" ORDER BY created ASC`,
+				`AND assignee="test" AND component="test" AND parent="test" ORDER BY created ASC`,
 		},
 		{
 			name: "query only with fields filter",
@@ -145,7 +145,7 @@ func TestIssueGet(t *testing.T) {
 			},
 			expected: `project="TEST" AND ` +
 				`type="test" AND resolution="test" AND status="test" AND priority="test" AND reporter="test" ` +
-				`AND assignee="test" AND component="test" ORDER BY created ASC`,
+				`AND assignee="test" AND component="test" AND parent="test" ORDER BY created ASC`,
 		},
 		{
 			name: "query with error when fetching history flag",
@@ -211,7 +211,7 @@ func TestIssueGet(t *testing.T) {
 			},
 			expected: `project="TEST" AND issue IN issueHistory() AND issue IN watchedIssues() AND ` +
 				`resolution="test" AND status="test" AND priority="test" AND reporter="test" AND assignee="test" ` +
-				`AND component="test" ORDER BY lastViewed ASC`,
+				`AND component="test" AND parent="test" ORDER BY lastViewed ASC`,
 		},
 		{
 			name: "query with reverse set to true",
@@ -222,7 +222,7 @@ func TestIssueGet(t *testing.T) {
 			},
 			expected: `project="TEST" AND issue IN issueHistory() AND issue IN watchedIssues() AND ` +
 				`type="test" AND resolution="test" AND status="test" AND priority="test" AND reporter="test" ` +
-				`AND assignee="test" AND component="test" ORDER BY lastViewed DESC`,
+				`AND assignee="test" AND component="test" AND parent="test" ORDER BY lastViewed DESC`,
 		},
 		{
 			name: "query with labels",
@@ -233,7 +233,7 @@ func TestIssueGet(t *testing.T) {
 			},
 			expected: `project="TEST" AND issue IN issueHistory() AND issue IN watchedIssues() AND ` +
 				`type="test" AND resolution="test" AND status="test" AND priority="test" AND reporter="test" AND assignee="test" ` +
-				`AND component="test" AND labels IN ("first", "second", "third") ORDER BY lastViewed ASC`,
+				`AND component="test" AND parent="test" AND labels IN ("first", "second", "third") ORDER BY lastViewed ASC`,
 		},
 		{
 			name: "query with created and updated today filter",
@@ -244,7 +244,7 @@ func TestIssueGet(t *testing.T) {
 			},
 			expected: `project="TEST" AND issue IN issueHistory() AND issue IN watchedIssues() AND ` +
 				`type="test" AND resolution="test" AND status="test" AND priority="test" AND reporter="test" AND assignee="test" ` +
-				`AND component="test" AND createdDate>=startOfDay() AND updatedDate>=startOfDay() ORDER BY lastViewed ASC`,
+				`AND component="test" AND parent="test" AND createdDate>=startOfDay() AND updatedDate>=startOfDay() ORDER BY lastViewed ASC`,
 		},
 		{
 			name: "query with created and updated week filter",
@@ -255,7 +255,7 @@ func TestIssueGet(t *testing.T) {
 			},
 			expected: `project="TEST" AND issue IN issueHistory() AND issue IN watchedIssues() AND ` +
 				`type="test" AND resolution="test" AND status="test" AND priority="test" AND reporter="test" AND assignee="test" ` +
-				`AND component="test" AND createdDate>=startOfWeek() AND updatedDate>=startOfWeek() ORDER BY lastViewed ASC`,
+				`AND component="test" AND parent="test" AND createdDate>=startOfWeek() AND updatedDate>=startOfWeek() ORDER BY lastViewed ASC`,
 		},
 		{
 			name: "query with created and updated month filter",
@@ -266,7 +266,7 @@ func TestIssueGet(t *testing.T) {
 			},
 			expected: `project="TEST" AND issue IN issueHistory() AND issue IN watchedIssues() AND ` +
 				`type="test" AND resolution="test" AND status="test" AND priority="test" AND reporter="test" AND assignee="test" ` +
-				`AND component="test" AND createdDate>=startOfMonth() AND updatedDate>=startOfMonth() ORDER BY lastViewed ASC`,
+				`AND component="test" AND parent="test" AND createdDate>=startOfMonth() AND updatedDate>=startOfMonth() ORDER BY lastViewed ASC`,
 		},
 		{
 			name: "query with created and updated year filter",
@@ -277,7 +277,7 @@ func TestIssueGet(t *testing.T) {
 			},
 			expected: `project="TEST" AND issue IN issueHistory() AND issue IN watchedIssues() AND ` +
 				`type="test" AND resolution="test" AND status="test" AND priority="test" AND reporter="test" AND assignee="test" ` +
-				`AND component="test" AND createdDate>=startOfYear() AND updatedDate>=startOfYear() ORDER BY lastViewed ASC`,
+				`AND component="test" AND parent="test" AND createdDate>=startOfYear() AND updatedDate>=startOfYear() ORDER BY lastViewed ASC`,
 		},
 		{
 			name: "query with created and updated filter",
@@ -288,7 +288,7 @@ func TestIssueGet(t *testing.T) {
 			},
 			expected: `project="TEST" AND issue IN issueHistory() AND issue IN watchedIssues() AND ` +
 				`type="test" AND resolution="test" AND status="test" AND priority="test" AND reporter="test" AND assignee="test" AND component="test" ` +
-				`AND createdDate>="2020-12-31" AND createdDate<"2021-01-01" AND updatedDate>="2020-12-31" AND updatedDate<"2021-01-01" ` +
+				`AND parent="test" AND createdDate>="2020-12-31" AND createdDate<"2021-01-01" AND updatedDate>="2020-12-31" AND updatedDate<"2021-01-01" ` +
 				`ORDER BY lastViewed ASC`,
 		},
 		{
@@ -300,7 +300,7 @@ func TestIssueGet(t *testing.T) {
 			},
 			expected: `project="TEST" AND issue IN issueHistory() AND issue IN watchedIssues() AND ` +
 				`type="test" AND resolution="test" AND status="test" AND priority="test" AND reporter="test" AND assignee="test" ` +
-				`AND component="test" AND createdDate>="2020-15-31" AND updatedDate>="2020-12-31 10:30:30" ORDER BY lastViewed ASC`,
+				`AND component="test" AND parent="test" AND createdDate>="2020-15-31" AND updatedDate>="2020-12-31 10:30:30" ORDER BY lastViewed ASC`,
 		},
 		{
 			name: "query with created-after and created-before filter",
@@ -311,7 +311,7 @@ func TestIssueGet(t *testing.T) {
 			},
 			expected: `project="TEST" AND issue IN issueHistory() AND issue IN watchedIssues() AND ` +
 				`type="test" AND resolution="test" AND status="test" AND priority="test" AND reporter="test" AND assignee="test" ` +
-				`AND component="test" AND createdDate>"2020-12-01" AND createdDate<"2020-12-31" ORDER BY lastViewed ASC`,
+				`AND component="test" AND parent="test" AND createdDate>"2020-12-01" AND createdDate<"2020-12-31" ORDER BY lastViewed ASC`,
 		},
 		{
 			name: "query with updated-after and updated-before filter",
@@ -322,7 +322,7 @@ func TestIssueGet(t *testing.T) {
 			},
 			expected: `project="TEST" AND issue IN issueHistory() AND issue IN watchedIssues() AND ` +
 				`type="test" AND resolution="test" AND status="test" AND priority="test" AND reporter="test" AND assignee="test" ` +
-				`AND component="test" AND updatedDate>"2020-12-01" AND updatedDate<"2020-12-31" ORDER BY lastViewed ASC`,
+				`AND component="test" AND parent="test" AND updatedDate>"2020-12-01" AND updatedDate<"2020-12-31" ORDER BY lastViewed ASC`,
 		},
 		{
 			name: "created and updated flags gets precedence",
@@ -340,7 +340,7 @@ func TestIssueGet(t *testing.T) {
 			},
 			expected: `project="TEST" AND issue IN issueHistory() AND issue IN watchedIssues() AND ` +
 				`type="test" AND resolution="test" AND status="test" AND priority="test" AND reporter="test" AND assignee="test" ` +
-				`AND component="test" AND createdDate>="2020-11-01" AND createdDate<"2020-11-02" AND updatedDate>="-10d" ` +
+				`AND component="test" AND parent="test" AND createdDate>="2020-11-01" AND createdDate<"2020-11-02" AND updatedDate>="-10d" ` +
 				`ORDER BY lastViewed ASC`,
 		},
 		{
@@ -360,7 +360,7 @@ func TestIssueGet(t *testing.T) {
 			},
 			expected: `project="TEST" AND issue IN watchedIssues() AND type="test" AND resolution="test" ` +
 				`AND status="test" AND priority="test" AND reporter="test" AND assignee="test" AND component="test" ` +
-				`AND createdDate>="2020-11-01" AND createdDate<"2020-11-02" AND updatedDate>="-10d" ` +
+				`AND parent="test" AND createdDate>="2020-11-01" AND createdDate<"2020-11-02" AND updatedDate>="-10d" ` +
 				`ORDER BY created ASC`,
 		},
 		{
@@ -378,7 +378,7 @@ func TestIssueGet(t *testing.T) {
 			},
 			expected: `project="TEST" AND issue IN watchedIssues() AND type="test" AND resolution="test" ` +
 				`AND status="test" AND priority="test" AND reporter="test" AND assignee="test" AND component="test" ` +
-				`AND updatedDate>"2020-11-31" AND updatedDate<"2020-12-31" ` +
+				`AND parent="test" AND updatedDate>"2020-11-31" AND updatedDate<"2020-12-31" ` +
 				`ORDER BY updated ASC`,
 		},
 		{
@@ -390,7 +390,7 @@ func TestIssueGet(t *testing.T) {
 			},
 			expected: `project="TEST" AND issue IN issueHistory() AND issue IN watchedIssues() AND ` +
 				`type="test" AND resolution="test" AND status="test" AND priority="test" AND reporter="test" ` +
-				`AND assignee="test" AND component="test" AND summary ~ cli OR x = y ORDER BY lastViewed ASC`,
+				`AND assignee="test" AND component="test" AND parent="test" AND summary ~ cli OR x = y ORDER BY lastViewed ASC`,
 		},
 	}
 


### PR DESCRIPTION
This PR adds filter by parent when fetching issues. This can be used to list sub-tasks in a story or epic issues in a next-gen project.

```sh
$ jira issue list -P ISS-10
```

