### PR TITLE
fix(tui): Link/key copy is broken for altered key col

### DIFF
--- a/internal/view/helper.go
+++ b/internal/view/helper.go
@@ -99,7 +99,7 @@ func issueKeyFromTuiData(r int, d interface{}) string {
 
 	switch data := d.(type) {
 	case tui.TableData:
-		path = data[r][1]
+		path = data[r][getKeyColumnIndex(data[0])]
 	case tui.PreviewData:
 		path = data.Key
 	}


### PR DESCRIPTION
Link and key copying with `c` and `ctrl+k` is broken if key column is altered in the tui.

Related: #202 #199