### PR TITLE
feat: Add additional info in view cmd

### DIFF
--- a/internal/view/issue.go
+++ b/internal/view/issue.go
@@ -6,12 +6,12 @@ import (
 	"os"
 	"strings"
 
-	"github.com/ankitpokhrel/jira-cli/pkg/md"
 	"github.com/charmbracelet/glamour"
 
 	"github.com/ankitpokhrel/jira-cli/internal/cmdutil"
 	"github.com/ankitpokhrel/jira-cli/pkg/adf"
 	"github.com/ankitpokhrel/jira-cli/pkg/jira"
+	"github.com/ankitpokhrel/jira-cli/pkg/md"
 	"github.com/ankitpokhrel/jira-cli/pkg/tui"
 )
 
@@ -72,12 +72,19 @@ func (i Issue) String() string {
 			desc = md.FromJiraMD(desc)
 		}
 	}
+	wch := fmt.Sprintf("%d watchers", i.Data.Fields.Watches.WatchCount)
+	if i.Data.Fields.Watches.WatchCount == 1 && i.Data.Fields.Watches.IsWatching {
+		wch = "You are watching"
+	} else if i.Data.Fields.Watches.IsWatching {
+		wch = fmt.Sprintf("You + %d watchers", i.Data.Fields.Watches.WatchCount-1)
+	}
 	return fmt.Sprintf(
-		"%s %s  %s %s  ⌛ %s  👷 %s  🔑️ %s\n# %s\n⏱️  %s  🔎 %s  🚀 %s  📦 %s  🏷️  %s\n\n-----------\n%s",
+		"%s %s  %s %s  ⌛ %s  👷 %s  🔑️ %s  💭 %d comments  \U0001F9F5 %d linked issues\n# %s\n⏱️  %s  🔎 %s  🚀 %s  📦 %s  🏷️  %s  👀 %s\n\n-----------\n%s",
 		iti, it, sti, st, cmdutil.FormatDateTimeHuman(i.Data.Fields.Updated, jira.RFC3339), as, i.Data.Key,
+		i.Data.Fields.Comment.Total, len(i.Data.Fields.IssueLinks),
 		i.Data.Fields.Summary,
 		cmdutil.FormatDateTimeHuman(i.Data.Fields.Created, jira.RFC3339), i.Data.Fields.Reporter.Name,
-		i.Data.Fields.Priority.Name, cmpt, lbl,
+		i.Data.Fields.Priority.Name, cmpt, lbl, wch,
 		desc,
 	)
 }

--- a/internal/view/issue_test.go
+++ b/internal/view/issue_test.go
@@ -51,6 +51,10 @@ func TestIssueDetailsRenderInPlainView(t *testing.T) {
 			Components: []struct {
 				Name string `json:"name"`
 			}{{Name: "BE"}, {Name: "FE"}},
+			Watches: struct {
+				IsWatching bool `json:"isWatching"`
+				WatchCount int  `json:"watchCount"`
+			}{IsWatching: true, WatchCount: 4},
 			Created: "2020-12-13T14:05:20.974+0100",
 			Updated: "2020-12-13T14:07:20.974+0100",
 		},
@@ -62,7 +66,7 @@ func TestIssueDetailsRenderInPlainView(t *testing.T) {
 	}
 	assert.NoError(t, issue.renderPlain(&b))
 
-	expected := "🐞 Bug  ✅ Done  ⌛ Sun, 13 Dec 20  👷 Person A  🔑️ TEST-1\n# This is a test\n⏱️  Sun, 13 Dec 20  🔎 Person Z  🚀 High  📦 BE, FE  🏷️  None\n\n-----------\nTest description\n\n"
+	expected := "🐞 Bug  ✅ Done  ⌛ Sun, 13 Dec 20  👷 Person A  🔑️ TEST-1  💭 0 comments  \U0001F9F5 0 linked issues\n# This is a test\n⏱️  Sun, 13 Dec 20  🔎 Person Z  🚀 High  📦 BE, FE  🏷️  None  👀 You + 3 watchers\n\n-----------\nTest description\n\n"
 	assert.Equal(t, tui.TextData(expected), issue.data())
 }
 
@@ -95,6 +99,12 @@ func TestIssueDetailsWithV2Description(t *testing.T) {
 			Components: []struct {
 				Name string `json:"name"`
 			}{{Name: "BE"}, {Name: "FE"}},
+			Comment: struct {
+				Total int `json:"total"`
+			}{Total: 3},
+			IssueLinks: []struct {
+				ID string `json:"id"`
+			}{{ID: "1001"}, {ID: "1002"}},
 			Created: "2020-12-13T14:05:20.974+0100",
 			Updated: "2020-12-13T14:07:20.974+0100",
 		},
@@ -106,6 +116,6 @@ func TestIssueDetailsWithV2Description(t *testing.T) {
 	}
 	assert.NoError(t, issue.renderPlain(&b))
 
-	expected := "🐞 Bug  ✅ Done  ⌛ Sun, 13 Dec 20  👷 Person A  🔑️ TEST-1\n# This is a test\n⏱️  Sun, 13 Dec 20  🔎 Person Z  🚀 High  📦 BE, FE  🏷️  None\n\n-----------\n# Title\n## Subtitle\nThis is a **bold** and _italic_ text with [a link](https://ankit.pl) in between.\n"
+	expected := "🐞 Bug  ✅ Done  ⌛ Sun, 13 Dec 20  👷 Person A  🔑️ TEST-1  💭 3 comments  \U0001F9F5 2 linked issues\n# This is a test\n⏱️  Sun, 13 Dec 20  🔎 Person Z  🚀 High  📦 BE, FE  🏷️  None  👀 0 watchers\n\n-----------\n# Title\n## Subtitle\nThis is a **bold** and _italic_ text with [a link](https://ankit.pl) in between.\n"
 	assert.Equal(t, tui.TextData(expected), issue.data())
 }

--- a/pkg/jira/types.go
+++ b/pkg/jira/types.go
@@ -63,6 +63,12 @@ type IssueFields struct {
 	Components []struct {
 		Name string `json:"name"`
 	} `json:"components"`
+	Comment struct {
+		Total int `json:"total"`
+	} `json:"comment"`
+	IssueLinks []struct {
+		ID string `json:"id"`
+	} `json:"issueLinks"`
 	Created string `json:"created"`
 	Updated string `json:"updated"`
 }


### PR DESCRIPTION
This PR adds following info in `jira issue view` command.
- Comments count
- Linked issues count
- Watchers count

<img width="415" alt="Screen Shot 2021-11-23 at 9 58 52 AM" src="https://user-images.githubusercontent.com/2364546/142995923-2c2f12d0-420a-4428-8a4f-915ba5dcbb25.png">
