### PR TITLE
feat: Show linked issues when viewing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/kentaro-m/blackfriday-confluence v0.0.0-20210619074151-1628b53c6f29
 	github.com/kr/text v0.2.0
+	github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8
 	github.com/rivo/tview v0.0.0-20211029142923-a4acb08f513e
@@ -38,7 +39,6 @@ require (
 	github.com/mattn/go-colorable v0.1.11 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect
 	github.com/mattn/go-runewidth v0.0.13 // indirect
-	github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d // indirect
 	github.com/microcosm-cc/bluemonday v1.0.16 // indirect
 	github.com/mitchellh/mapstructure v1.4.2 // indirect
 	github.com/muesli/reflow v0.3.0 // indirect

--- a/internal/view/helper.go
+++ b/internal/view/helper.go
@@ -3,12 +3,15 @@ package view
 import (
 	"fmt"
 	"io"
+	"os"
 	"strings"
 	"text/tabwriter"
 	"time"
 
 	"github.com/atotto/clipboard"
 	"github.com/charmbracelet/glamour"
+	"github.com/fatih/color"
+	"github.com/mgutz/ansi"
 	"github.com/pkg/browser"
 
 	"github.com/ankitpokhrel/jira-cli/pkg/tui"
@@ -154,4 +157,48 @@ func getKeyColumnIndex(cols []string) int {
 		}
 	}
 	return 1
+}
+
+func coloredOut(msg string, clr color.Attribute, attrs ...color.Attribute) string {
+	c := color.New(clr).Add(attrs...)
+	return c.Sprint(msg)
+}
+
+func xterm256() bool {
+	term := os.Getenv("TERM")
+	return strings.Contains(term, "-256color")
+}
+
+func gray(msg string) string {
+	if xterm256() {
+		return gray256(msg)
+	}
+	return ansi.ColorFunc("black+h")(msg)
+}
+
+func gray256(msg string) string {
+	return fmt.Sprintf("\x1b[38;5;242m%s\x1b[m", msg)
+}
+
+func shortenAndPad(msg string, limit int) string {
+	if limit >= 3 && len(msg) > limit {
+		return msg[0:limit-3] + "..."
+	}
+	return pad(msg, limit)
+}
+
+func pad(msg string, limit int) string {
+	var out strings.Builder
+	out.WriteString(msg)
+	for i := len(msg); i < limit; i++ {
+		out.WriteRune(' ')
+	}
+	return out.String()
+}
+
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
 }

--- a/internal/view/helper_test.go
+++ b/internal/view/helper_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestFormatDateTime(t *testing.T) {
+	t.Parallel()
+
 	cases := []struct {
 		name     string
 		format   func() string
@@ -58,6 +60,8 @@ func TestFormatDateTime(t *testing.T) {
 }
 
 func TestPrepareTitle(t *testing.T) {
+	t.Parallel()
+
 	cases := []struct {
 		name     string
 		input    string
@@ -92,6 +96,94 @@ func TestPrepareTitle(t *testing.T) {
 			t.Parallel()
 
 			assert.Equal(t, tc.expected, prepareTitle(tc.input))
+		})
+	}
+}
+
+func TestShortenAndPad(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		input    string
+		limit    int
+		expected string
+	}{
+		{
+			name:     "it returns full string for zero limit",
+			input:    "Some text",
+			limit:    0,
+			expected: "Some text",
+		},
+		{
+			name:     "it returns full string if limit is less than 3",
+			input:    "Some text",
+			limit:    2,
+			expected: "Some text",
+		},
+		{
+			name:     "it returns full string if limit is equal to string len",
+			input:    "Some text",
+			limit:    9,
+			expected: "Some text",
+		},
+		{
+			name:     "it returns shortened string",
+			input:    "Some text",
+			limit:    7,
+			expected: "Some...",
+		},
+		{
+			name:     "it adds padding if string is shorter than the limit",
+			input:    "Some text",
+			limit:    15,
+			expected: "Some text      ",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tc.expected, shortenAndPad(tc.input, tc.limit))
+		})
+	}
+}
+
+func TestMax(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		input    []int
+		expected int
+	}{
+		{
+			name:     "a > b",
+			input:    []int{5, 3},
+			expected: 5,
+		},
+		{
+			name:     "a < b",
+			input:    []int{-5, 5},
+			expected: 5,
+		},
+		{
+			name:     "a == b",
+			input:    []int{3, 3},
+			expected: 3,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tc.expected, max(tc.input[0], tc.input[1]))
 		})
 	}
 }

--- a/internal/view/issue_test.go
+++ b/internal/view/issue_test.go
@@ -177,43 +177,50 @@ func TestSeparator(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
-		name     string
-		body     string
-		plain    bool
-		expected string
+		name        string
+		body        string
+		plain       bool
+		expected    string
+		expected256 string
 	}{
 		{
-			name:     "it returns striaght horizontal bar for empty message",
-			body:     "",
-			expected: "\x1b[38;5;242m————————————————————————————————————————————————\x1b[m",
+			name:        "it returns striaght horizontal bar for empty message",
+			body:        "",
+			expected:    "\x1b[0;90m————————————————————————————————————————————————\x1b[0m",
+			expected256: "\x1b[38;5;242m————————————————————————————————————————————————\x1b[m",
 		},
 		{
-			name:     "it returns raw horizontal bar for empty message in plain output",
-			body:     "",
-			plain:    true,
-			expected: "------------------------------------------------",
+			name:        "it returns raw horizontal bar for empty message in plain output",
+			body:        "",
+			plain:       true,
+			expected:    "------------------------------------------------",
+			expected256: "------------------------------------------------",
 		},
 		{
-			name:     "it returns greyed out message wrapped in horizontal bar",
-			body:     "Some text",
-			expected: "\x1b[38;5;242m———————————————————————— Some text ————————————————————————\x1b[m",
+			name:        "it returns greyed out message wrapped in horizontal bar",
+			body:        "Some text",
+			expected:    "\x1b[0;90m———————————————————————— Some text ————————————————————————\x1b[0m",
+			expected256: "\x1b[38;5;242m———————————————————————— Some text ————————————————————————\x1b[m",
 		},
 		{
-			name:     "it returns greyed out message wrapped in raw horizontal bar for plain output",
-			body:     "Some text",
-			plain:    true,
-			expected: "------------------------ Some text ------------------------",
+			name:        "it returns greyed out message wrapped in raw horizontal bar for plain output",
+			body:        "Some text",
+			plain:       true,
+			expected:    "------------------------ Some text ------------------------",
+			expected256: "------------------------ Some text ------------------------",
 		},
 		{
-			name:     "it doesn't trim spaces",
-			body:     "  ",
-			expected: "\x1b[38;5;242m————————————————————————    ————————————————————————\x1b[m",
+			name:        "it doesn't trim spaces",
+			body:        "  ",
+			expected:    "\x1b[0;90m————————————————————————    ————————————————————————\x1b[0m",
+			expected256: "\x1b[38;5;242m————————————————————————    ————————————————————————\x1b[m",
 		},
 		{
-			name:     "it doesn't trim spaces for plain output",
-			body:     "  ",
-			plain:    true,
-			expected: "------------------------    ------------------------",
+			name:        "it doesn't trim spaces for plain output",
+			body:        "  ",
+			plain:       true,
+			expected:    "------------------------    ------------------------",
+			expected256: "------------------------    ------------------------",
 		},
 	}
 
@@ -230,7 +237,11 @@ func TestSeparator(t *testing.T) {
 				Display: DisplayFormat{Plain: tc.plain},
 			}
 
-			assert.Equal(t, tc.expected, issue.separator(tc.body))
+			if xterm256() {
+				assert.Equal(t, tc.expected256, issue.separator(tc.body))
+			} else {
+				assert.Equal(t, tc.expected, issue.separator(tc.body))
+			}
 		})
 	}
 }

--- a/internal/view/issue_test.go
+++ b/internal/view/issue_test.go
@@ -109,8 +109,53 @@ func TestIssueDetailsWithV2Description(t *testing.T) {
 				Total int `json:"total"`
 			}{Total: 3},
 			IssueLinks: []struct {
-				ID string `json:"id"`
-			}{{ID: "1001"}, {ID: "1002"}},
+				LinkType struct {
+					Name    string `json:"name"`
+					Inward  string `json:"inward"`
+					Outward string `json:"outward"`
+				} `json:"type"`
+				InwardIssue  *jira.Issue `json:"inwardIssue,omitempty"`
+				OutwardIssue *jira.Issue `json:"outwardIssue,omitempty"`
+			}{
+				{
+					LinkType: struct {
+						Name    string `json:"name"`
+						Inward  string `json:"inward"`
+						Outward string `json:"outward"`
+					}{Name: "blocks", Inward: "blocks", Outward: "is blocked by"},
+					InwardIssue: &jira.Issue{
+						Key: "TEST-2",
+						Fields: jira.IssueFields{
+							Summary: "Something is broken", IssueType: struct {
+								Name string `json:"name"`
+							}{Name: "Bug"}, Priority: struct {
+								Name string `json:"name"`
+							}{Name: "High"}, Status: struct {
+								Name string `json:"name"`
+							}{Name: "TO DO"},
+						},
+					},
+				},
+				{
+					LinkType: struct {
+						Name    string `json:"name"`
+						Inward  string `json:"inward"`
+						Outward string `json:"outward"`
+					}{Name: "relates", Inward: "relates", Outward: "relates to"},
+					OutwardIssue: &jira.Issue{
+						Key: "TEST-3",
+						Fields: jira.IssueFields{
+							Summary: "Everything is on fire", IssueType: struct {
+								Name string `json:"name"`
+							}{Name: "Bug"}, Priority: struct {
+								Name string `json:"name"`
+							}{Name: "Urgent"}, Status: struct {
+								Name string `json:"name"`
+							}{Name: "Done"},
+						},
+					},
+				},
+			},
 			Created: "2020-12-13T14:05:20.974+0100",
 			Updated: "2020-12-13T14:07:20.974+0100",
 		},
@@ -122,7 +167,7 @@ func TestIssueDetailsWithV2Description(t *testing.T) {
 	}
 	assert.NoError(t, issue.renderPlain(&b))
 
-	expected := "🐞 Bug  ✅ Done  ⌛ Sun, 13 Dec 20  👷 Person A  🔑️ TEST-1  💭 3 comments  \U0001F9F5 2 linked issues\n# This is a test\n⏱️  Sun, 13 Dec 20  🔎 Person Z  🚀 High  📦 BE, FE  🏷️  None  👀 0 watchers\n\n------------------------ Description ------------------------\n\n# Title\n## Subtitle\nThis is a **bold** and _italic_ text with [a link](https://ankit.pl) in between.\n"
+	expected := "🐞 Bug  ✅ Done  ⌛ Sun, 13 Dec 20  👷 Person A  🔑️ TEST-1  💭 3 comments  \U0001F9F5 2 linked issues\n# This is a test\n⏱️  Sun, 13 Dec 20  🔎 Person Z  🚀 High  📦 BE, FE  🏷️  None  👀 0 watchers\n\n------------------------ Description ------------------------\n\n# Title\n## Subtitle\nThis is a **bold** and _italic_ text with [a link](https://ankit.pl) in between.\n\n\n------------------------ Linked Issues ------------------------\n\n\n  BLOCKS\n\n    TEST-2 Something is broken   • Bug • High   • TO DO\n\n  RELATES TO\n\n    TEST-3 Everything is on fire • Bug • Urgent • Done \n\n"
 	actual := issue.String()
 
 	assert.Equal(t, tui.TextData(expected), tui.TextData(actual))
@@ -140,7 +185,7 @@ func TestSeparator(t *testing.T) {
 		{
 			name:     "it returns striaght horizontal bar for empty message",
 			body:     "",
-			expected: "————————————————————————————————————————————————",
+			expected: "\x1b[38;5;242m————————————————————————————————————————————————\x1b[m",
 		},
 		{
 			name:     "it returns raw horizontal bar for empty message in plain output",
@@ -151,7 +196,7 @@ func TestSeparator(t *testing.T) {
 		{
 			name:     "it returns greyed out message wrapped in horizontal bar",
 			body:     "Some text",
-			expected: "———————————————————————— Some text ————————————————————————",
+			expected: "\x1b[38;5;242m———————————————————————— Some text ————————————————————————\x1b[m",
 		},
 		{
 			name:     "it returns greyed out message wrapped in raw horizontal bar for plain output",
@@ -162,7 +207,7 @@ func TestSeparator(t *testing.T) {
 		{
 			name:     "it doesn't trim spaces",
 			body:     "  ",
-			expected: "————————————————————————    ————————————————————————",
+			expected: "\x1b[38;5;242m————————————————————————    ————————————————————————\x1b[m",
 		},
 		{
 			name:     "it doesn't trim spaces for plain output",

--- a/pkg/jira/types.go
+++ b/pkg/jira/types.go
@@ -67,7 +67,13 @@ type IssueFields struct {
 		Total int `json:"total"`
 	} `json:"comment"`
 	IssueLinks []struct {
-		ID string `json:"id"`
+		LinkType struct {
+			Name    string `json:"name"`
+			Inward  string `json:"inward"`
+			Outward string `json:"outward"`
+		} `json:"type"`
+		InwardIssue  *Issue `json:"inwardIssue,omitempty"`
+		OutwardIssue *Issue `json:"outwardIssue,omitempty"`
 	} `json:"issueLinks"`
 	Created string `json:"created"`
 	Updated string `json:"updated"`


### PR DESCRIPTION
`jira issue view` now displays linked issues if there is any.

This is how it looks in the screen.

**Dark mode (iterm2)**
![Screen Shot 2021-12-05 at 11 23 05 AM](https://user-images.githubusercontent.com/2364546/144743949-79896d70-7996-46c7-915c-094cf15898c4.png)

**Light mode (macOS terminal)**
![Screen Shot 2021-12-05 at 11 25 39 AM](https://user-images.githubusercontent.com/2364546/144743974-630a4ca5-7af4-4a43-83d6-b352a05dcbf2.png)


