### PR TITLE
fix #243: reproducible builds

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -15,8 +15,8 @@ builds:
       ldflags:
         - -s -w
         - -X github.com/ankitpokhrel/jira-cli/internal/version.Version={{.Version}}
-        - -X github.com/ankitpokhrel/jira-cli/internal/version.GitCommit={{.Commit}}
-        - -X github.com/ankitpokhrel/jira-cli/internal/version.BuildDate={{time "2006-01-02"}}
+        - -X github.com/ankitpokhrel/jira-cli/internal/version.GitCommit={{.FullCommit}}
+        - -X github.com/ankitpokhrel/jira-cli/internal/version.SourceDateEpoch={{.CommitTimestamp}}
       env:
         - CGO_ENABLED=0
     id: macOS

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -3,22 +3,33 @@ package version
 import (
 	"fmt"
 	"runtime"
+	"strconv"
+	"time"
 )
 
 // Build information is populated at build-time.
 var (
-	Version   = "dev"
-	GitCommit string
-	BuildDate string
-	GoVersion = runtime.Version()
-	Compiler  = runtime.Compiler
-	Platform  = fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH)
+	Version         = "dev"
+	GitCommit       = "ffffffffffffffffffffffffffffffffffffffff"
+	SourceDateEpoch = "-1"
+	GoVersion       = runtime.Version()
+	Compiler        = runtime.Compiler
+	Platform        = fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH)
 )
 
 // Info returns version and build information.
 func Info() string {
+	i, err := strconv.ParseInt(SourceDateEpoch, 10, 64) //nolint:gomnd
+	if err != nil {
+		panic(err)
+	}
+	// https://pkg.go.dev/time#Time.Format
+	//
+	//     $ TZ=MST date -Iseconds -d"Jan 2 15:04:05 2006 MST"
+	//     2006-01-02T15:04:05-07:00
+	sourceDate := time.Unix(i, 0).UTC().Format("2006-01-02T15:04:05-07:00")
 	return fmt.Sprintf(
-		"(Version=\"%s\", GitCommit=\"%s\", GoVersion=\"%s\", BuildDate=\"%s\", Compiler=\"%s\", Platform=\"%s\")",
-		Version, GitCommit, GoVersion, BuildDate, Compiler, Platform,
+		"(Version=\"%s\", GitCommit=\"%s\", SourceDate=\"%s\", GoVersion=\"%s\", Compiler=\"%s\", Platform=\"%s\")",
+		Version, GitCommit, sourceDate, GoVersion, Compiler, Platform,
 	)
 }


### PR DESCRIPTION
Reproducible builds are good. https://reproducible-builds.org/

* edit `.goreleaser.yml` ldflags:

  * change `GitCommit={{.Commit}}` to `GitCommit={{.FullCommit}}` because a
    full hash is better than a short hash --- and the `Makefile` was already
    using the full hash

  * remove `BuildDate`, add `SourceDateEpoch={{.CommitTimestamp}}`

* edit `Makefile` build vars:

  * change the `GIT_COMMIT` detection: if the worktree is dirty, then the sha1
    is a "stash entry", else the sha1 is the current HEAD; allow envvar
    override

  * remove `build_date`, add `SOURCE_DATE_EPOCH` that defaults to the Unix
    timestamp of the `GIT_COMMIT`; allow envvar override

  * change `LDFLAGS` assignment from immediate (`:=`) to successive appends
    (`+=`) such that we can accumulate envvar overrides from the `make` caller;
    to the `LDFLAGS`, add `-s` (disable symbol table) and `-w` (disable DWARF
    generation) --- because the `.goreleaser.yml` was already doing this

  * add default `CGO_ENABLED=0` but allow envvar override; remove
    `CGO_ENABLED=0` from the targets `build` and `install`; add `CGO_ENABLED=1`
    to the target `test` because `go test -race` requires it

* edit `internal/version/version.go`:

  * replace var `BuildDate` with `SourceDateEpoch`

  * "poison" default for `GitCommit`: `ffffffffffffffffffffffffffffffffffffffff`

  * "poison" default for `SourceDateEpoch`: `-1`

  * modify `func Info` to parse the `SourceDateEpoch` string into
    `int64`-represented Unix timestamp and generate an UTC-zoned,
    ISO-8601-formatted string; replace the printed `BuildDate` with
    `SourceDate`; change the ordering such that `SourceDate` follows
    `GitCommit` and precedes `GoVersion`