### PR TITLE
build: Initialize version using runtime build info

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,10 +61,10 @@ brew install jira-cli
 ```
 
 #### Manual
-You can also install the runnable binary to your `$GOPATH/bin`.
+You can also install the runnable binary to your `$GOPATH/bin` (go1.16+).
 
 ```sh
-go install github.com/ankitpokhrel/jira-cli/cmd/jira
+go install github.com/ankitpokhrel/jira-cli/cmd/jira@latest
 ```
 
 See [releases page](https://github.com/ankitpokhrel/jira-cli/releases) for more info. Other installation options will be available later.

--- a/internal/version/default.go
+++ b/internal/version/default.go
@@ -1,0 +1,17 @@
+//go:build go1.12
+// +build go1.12
+
+package version
+
+import "runtime/debug"
+
+func init() {
+	if info, ok := debug.ReadBuildInfo(); ok {
+		// info.Main.Version describes the version of the module containing
+		// package main, not the version of “the main module”.
+		// See https://golang.org/issue/33975.
+		if Version == "v0.0.0-dev" && info.Main.Version != "(devel)" {
+			Version = info.Main.Version
+		}
+	}
+}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -9,7 +9,7 @@ import (
 
 // Build information is populated at build-time.
 var (
-	Version         = "dev"
+	Version         = "v0.0.0-dev"
 	GitCommit       = ""
 	SourceDateEpoch = "-1"
 	GoVersion       = runtime.Version()


### PR DESCRIPTION
This PR adds a file that is compiled only for go1.12 or later. The main purpose is to initialize `version` from runtime information when user runs `go install github.com/ankitpokhrel/jira-cli/cmd/jira@latest`. Version is populated based on the latest build version.

```sh
(Version="v0.2.1-0.20220106190958-d362a5d3dedc", GitCommit="", CommitDate="", GoVersion="go1.16.6", Compiler="gc", Platform="linux/amd64")
```