### PR TITLE
Fix Makefile compatiblity with Make 3.81

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,3 @@
-.ONESHELL:
 .PHONY: all deps build install lint test ci jira.server clean distclean
 
 ##############

--- a/Makefile
+++ b/Makefile
@@ -43,9 +43,9 @@ install:
 	go install -ldflags='$(LDFLAGS)' ./...
 
 lint:
-	@if ! command -v golangci-lint > /dev/null 2>&1; then
+	@if ! command -v golangci-lint > /dev/null 2>&1; then \
 		curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | \
-		sh -s -- -b "$$(go env GOPATH)/bin" v1.43.0
+		sh -s -- -b "$$(go env GOPATH)/bin" v1.43.0 ; \
 	fi
 	golangci-lint run ./...
 


### PR DESCRIPTION
Turned out to be easy to fix #251 , it's just newline handling that has changed. It now works both with make 3.81 and 4.3:

```
$ rm ~/gocode/bin/golangci-lint
$ make lint
golangci/golangci-lint info checking GitHub for tag 'v1.43.0'
golangci/golangci-lint info found version: 1.43.0 for v1.43.0/darwin/amd64
golangci/golangci-lint info installed ~/gocode/bin/golangci-lint
golangci-lint run ./...

$ rm ~/gocode/bin/golangci-lint
$ gmake lint
golangci/golangci-lint info checking GitHub for tag 'v1.43.0'
golangci/golangci-lint info found version: 1.43.0 for v1.43.0/darwin/amd64
golangci/golangci-lint info installed ~/gocode/bin/golangci-lint
```

