### PR TITLE
Feat/improve api tokens

### DIFF
--- a/internal/cmd/root/root.go
+++ b/internal/cmd/root/root.go
@@ -143,7 +143,7 @@ func cmdRequireToken(cmd string) bool {
 }
 
 func checkForJiraToken() {
-	token, _ := api.GetTokenConfig()
+	token, _, _ := api.GetTokenConfig()
 	if token != "" {
 		return
 	}

--- a/internal/cmd/root/root.go
+++ b/internal/cmd/root/root.go
@@ -7,6 +7,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
+	"github.com/ankitpokhrel/jira-cli/api"
 	"github.com/ankitpokhrel/jira-cli/internal/cmd/board"
 	"github.com/ankitpokhrel/jira-cli/internal/cmd/completion"
 	"github.com/ankitpokhrel/jira-cli/internal/cmd/epic"
@@ -142,11 +143,12 @@ func cmdRequireToken(cmd string) bool {
 }
 
 func checkForJiraToken() {
-	if os.Getenv("JIRA_API_TOKEN") != "" {
+	token, _ := api.GetTokenConfig()
+	if token != "" {
 		return
 	}
 
-	msg := fmt.Sprintf(`You need to define JIRA_API_TOKEN env for the tool to work. 
+	msg := fmt.Sprintf(`You need to define JIRA_API_TOKEN{|_CMD|_PAT|_PAT_CMD} env or set an appropriate value in the config file for the tool to work. 
 
 You can generate a token using this link: %s
 

--- a/pkg/jira/client.go
+++ b/pkg/jira/client.go
@@ -95,6 +95,7 @@ type Config struct {
 	Server   string
 	Login    string
 	APIToken string
+	IsPAT    bool
 	Debug    bool
 }
 
@@ -104,6 +105,7 @@ type Client struct {
 	server    string
 	login     string
 	token     string
+	bearer    bool
 	timeout   time.Duration
 	debug     bool
 }
@@ -117,6 +119,7 @@ func NewClient(c Config, opts ...ClientFunc) *Client {
 		server: strings.TrimSuffix(c.Server, "/"),
 		login:  c.Login,
 		token:  c.APIToken,
+		bearer: c.IsPAT,
 		debug:  c.Debug,
 	}
 	client.transport = &http.Transport{
@@ -222,7 +225,11 @@ func (c *Client) request(ctx context.Context, method, endpoint string, body []by
 		req.Header.Set(k, v)
 	}
 
-	req.SetBasicAuth(c.login, c.token)
+	if c.bearer {
+		req.Header.Set("Authorization", "Bearer "+c.token[4:])
+	} else {
+		req.SetBasicAuth(c.login, c.token)
+	}
 
 	res, err = c.transport.RoundTrip(req.WithContext(ctx))
 


### PR DESCRIPTION
This pull requests contains two improvements to API TOKEN handling:

1) The first improvement (commit 957284f) allows reading the api token from an external command
2) The second improvement allows using PAT tokens with an on-premise (local) jira server