### PR TITLE
Allow user to set default priority, labels & components

### DIFF
--- a/internal/cmd/issue/create/create.go
+++ b/internal/cmd/issue/create/create.go
@@ -62,7 +62,7 @@ func create(cmd *cobra.Command, _ []string) {
 	projectType := viper.GetString("project.type")
 	defaultComponents := viper.GetStringSlice("project.default_components")
 	defaultLabels := viper.GetStringSlice("project.default_labels")
-	defaultPriority := viper.GetStringSlice("project.default_priority")
+	defaultPriority := viper.GetString("project.default_priority")
 
 	params := parseFlags(cmd.Flags())
 	client := api.Client(jira.Config{Debug: params.debug})

--- a/internal/cmd/issue/create/create.go
+++ b/internal/cmd/issue/create/create.go
@@ -60,6 +60,9 @@ func create(cmd *cobra.Command, _ []string) {
 	server := viper.GetString("server")
 	project := viper.GetString("project.key")
 	projectType := viper.GetString("project.type")
+	defaultComponents := viper.GetStringSlice("project.default_components")
+	defaultLabels := viper.GetStringSlice("project.default_labels")
+	defaultPriority := viper.GetStringSlice("project.default_priority")
 
 	params := parseFlags(cmd.Flags())
 	client := api.Client(jira.Config{Debug: params.debug})
@@ -108,12 +111,18 @@ func create(cmd *cobra.Command, _ []string) {
 
 					if ans.Priority != "" {
 						params.priority = ans.Priority
+					} else {
+						params.priority = defaultPriority
 					}
 					if len(ans.Labels) > 0 {
 						params.labels = strings.Split(ans.Labels, ",")
+					} else {
+						params.labels = defaultLabels
 					}
 					if len(ans.Components) > 0 {
 						params.components = strings.Split(ans.Components, ",")
+					} else {
+						params.components = defaultComponents
 					}
 					if len(ans.FixVersions) > 0 {
 						params.fixVersions = strings.Split(ans.FixVersions, ",")


### PR DESCRIPTION
Read `default_components`, `default_labels` and `default_priority` from the `project` key in config and use those as the default when creating an issue.