### PR TITLE
feat(make) install binaries to ./bin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,7 @@ export LDFLAGS += -w
 
 export CGO_ENABLED ?= 0
 export GOCACHE ?= $(CURDIR)/.gocache
+export GOBIN ?= $(CURDIR)/bin
 
 all: build
 


### PR DESCRIPTION
I had no experience with go before. So for me it was not so obvious where can I get `jira` executable after I run `make deps install` 
