### PR TITLE
feat: Allow insecure TLS

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -28,8 +28,13 @@ func Client(config jira.Config) *jira.Client {
 	if config.APIToken == "" {
 		config.APIToken = viper.GetString("api_token")
 	}
+	config.Insecure = viper.GetBool("insecure")
 
-	jiraClient = jira.NewClient(config, jira.WithTimeout(clientTimeout))
+	jiraClient = jira.NewClient(
+		config,
+		jira.WithTimeout(clientTimeout),
+		jira.WithInsecureTLS(config.Insecure),
+	)
 
 	return jiraClient
 }

--- a/internal/cmdutil/utils.go
+++ b/internal/cmdutil/utils.go
@@ -71,6 +71,11 @@ func Success(msg string, args ...interface{}) {
 	fmt.Fprintf(os.Stdout, fmt.Sprintf("\n\u001B[0;32m✓\u001B[0m %s\n", msg), args...)
 }
 
+// Warn prints warning message in stderr.
+func Warn(msg string, args ...interface{}) {
+	fmt.Fprintf(os.Stderr, fmt.Sprintf("\u001B[0;33m%s\u001B[0m\n", msg), args...)
+}
+
 // Fail prints failure message in stderr.
 func Fail(msg string, args ...interface{}) {
 	fmt.Fprintf(os.Stderr, fmt.Sprintf("\u001B[0;31m✗\u001B[0m %s\n", msg), args...)

--- a/pkg/jira/client.go
+++ b/pkg/jira/client.go
@@ -3,6 +3,7 @@ package jira
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"net"
@@ -95,12 +96,14 @@ type Config struct {
 	Server   string
 	Login    string
 	APIToken string
+	Insecure bool
 	Debug    bool
 }
 
 // Client is a jira client.
 type Client struct {
 	transport http.RoundTripper
+	insecure  bool
 	server    string
 	login     string
 	token     string
@@ -125,7 +128,8 @@ func NewClient(c Config, opts ...ClientFunc) *Client {
 	}
 
 	client.transport = &http.Transport{
-		Proxy: http.ProxyFromEnvironment,
+		Proxy:           http.ProxyFromEnvironment,
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: client.insecure},
 		DialContext: (&net.Dialer{
 			Timeout: client.timeout,
 		}).DialContext,
@@ -138,6 +142,13 @@ func NewClient(c Config, opts ...ClientFunc) *Client {
 func WithTimeout(to time.Duration) ClientFunc {
 	return func(c *Client) {
 		c.timeout = to
+	}
+}
+
+// WithInsecureTLS is a functional opt that allow you to skip TLS certificate verfication.
+func WithInsecureTLS(ins bool) ClientFunc {
+	return func(c *Client) {
+		c.insecure = ins
 	}
 }
 


### PR DESCRIPTION
This PR adds an `--insecure` option in `init` cmd to skip TLS verification. This can be useful if the Jira server is using self-signed certificates.

Relates to: https://github.com/ankitpokhrel/jira-cli/discussions/271#discussioncomment-2091603
