### PR TITLE
refactor!: Move boards and project list to subcommand

### DIFF
--- a/internal/cmd/board/board.go
+++ b/internal/cmd/board/board.go
@@ -1,54 +1,29 @@
 package board
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 
-	"github.com/ankitpokhrel/jira-cli/api"
-	"github.com/ankitpokhrel/jira-cli/internal/cmdutil"
-	"github.com/ankitpokhrel/jira-cli/internal/view"
-	"github.com/ankitpokhrel/jira-cli/pkg/jira"
+	"github.com/ankitpokhrel/jira-cli/internal/cmd/board/list"
 )
+
+const helpText = `Board manages Jira boards in a project. See available commands below.`
 
 // NewCmdBoard is a board command.
 func NewCmdBoard() *cobra.Command {
-	return &cobra.Command{
+	cmd := cobra.Command{
 		Use:         "board",
-		Short:       "Board lists all boards in a project",
-		Long:        "Board lists all boards in a project.",
+		Short:       "Board manages Jira boards in a project",
+		Long:        helpText,
 		Aliases:     []string{"boards"},
 		Annotations: map[string]string{"cmd:main": "true"},
-		Run:         board,
+		RunE:        board,
 	}
+
+	cmd.AddCommand(list.NewCmdList())
+
+	return &cmd
 }
 
-func board(cmd *cobra.Command, _ []string) {
-	project := viper.GetString("project.key")
-
-	debug, err := cmd.Flags().GetBool("debug")
-	cmdutil.ExitIfError(err)
-
-	boards, total, err := func() ([]*jira.Board, int, error) {
-		s := cmdutil.Info(fmt.Sprintf("Fetching boards in project %s...", project))
-		defer s.Stop()
-
-		resp, err := api.Client(jira.Config{Debug: debug}).Boards(project, jira.BoardTypeAll)
-		if err != nil {
-			return nil, 0, err
-		}
-		return resp.Boards, resp.Total, nil
-	}()
-	cmdutil.ExitIfError(err)
-
-	if total == 0 {
-		fmt.Println()
-		cmdutil.Failed("No boards found in project \"%s\"", project)
-		return
-	}
-
-	v := view.NewBoard(boards)
-
-	cmdutil.ExitIfError(v.Render())
+func board(cmd *cobra.Command, _ []string) error {
+	return cmd.Help()
 }

--- a/internal/cmd/board/list/list.go
+++ b/internal/cmd/board/list/list.go
@@ -1,0 +1,54 @@
+package list
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/ankitpokhrel/jira-cli/api"
+	"github.com/ankitpokhrel/jira-cli/internal/cmdutil"
+	"github.com/ankitpokhrel/jira-cli/internal/view"
+	"github.com/ankitpokhrel/jira-cli/pkg/jira"
+)
+
+// NewCmdList is a list command.
+func NewCmdList() *cobra.Command {
+	return &cobra.Command{
+		Use:     "list",
+		Short:   "List lists boards in a project",
+		Long:    "List lists boards in a project.",
+		Aliases: []string{"lists", "ls"},
+		Run:     List,
+	}
+}
+
+// List displays a list view.
+func List(cmd *cobra.Command, _ []string) {
+	project := viper.GetString("project.key")
+
+	debug, err := cmd.Flags().GetBool("debug")
+	cmdutil.ExitIfError(err)
+
+	boards, total, err := func() ([]*jira.Board, int, error) {
+		s := cmdutil.Info(fmt.Sprintf("Fetching boards in project %s...", project))
+		defer s.Stop()
+
+		resp, err := api.Client(jira.Config{Debug: debug}).Boards(project, jira.BoardTypeAll)
+		if err != nil {
+			return nil, 0, err
+		}
+		return resp.Boards, resp.Total, nil
+	}()
+	cmdutil.ExitIfError(err)
+
+	if total == 0 {
+		fmt.Println()
+		cmdutil.Failed("No boards found in project \"%s\"", project)
+		return
+	}
+
+	v := view.NewBoard(boards)
+
+	cmdutil.ExitIfError(v.Render())
+}

--- a/internal/cmd/project/list/list.go
+++ b/internal/cmd/project/list/list.go
@@ -1,0 +1,48 @@
+package list
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/ankitpokhrel/jira-cli/api"
+	"github.com/ankitpokhrel/jira-cli/internal/cmdutil"
+	"github.com/ankitpokhrel/jira-cli/internal/view"
+	"github.com/ankitpokhrel/jira-cli/pkg/jira"
+)
+
+// NewCmdList is a list command.
+func NewCmdList() *cobra.Command {
+	return &cobra.Command{
+		Use:     "list",
+		Short:   "List lists Jira projects",
+		Long:    "List lists Jira projects that a user has access to.",
+		Aliases: []string{"lists", "ls"},
+		Run:     List,
+	}
+}
+
+// List displays a list view.
+func List(cmd *cobra.Command, _ []string) {
+	debug, err := cmd.Flags().GetBool("debug")
+	cmdutil.ExitIfError(err)
+
+	projects, total, err := func() ([]*jira.Project, int, error) {
+		s := cmdutil.Info("Fetching projects...")
+		defer s.Stop()
+
+		projects, err := api.Client(jira.Config{Debug: debug}).Project()
+		if err != nil {
+			return nil, 0, err
+		}
+		return projects, len(projects), nil
+	}()
+	cmdutil.ExitIfError(err)
+
+	if total == 0 {
+		cmdutil.Failed("No projects found.")
+		return
+	}
+
+	v := view.NewProject(projects)
+
+	cmdutil.ExitIfError(v.Render())
+}

--- a/internal/cmd/project/project.go
+++ b/internal/cmd/project/project.go
@@ -3,46 +3,27 @@ package project
 import (
 	"github.com/spf13/cobra"
 
-	"github.com/ankitpokhrel/jira-cli/api"
-	"github.com/ankitpokhrel/jira-cli/internal/cmdutil"
-	"github.com/ankitpokhrel/jira-cli/internal/view"
-	"github.com/ankitpokhrel/jira-cli/pkg/jira"
+	"github.com/ankitpokhrel/jira-cli/internal/cmd/project/list"
 )
+
+const helpText = `Project manages Jira projects. See available commands below.`
 
 // NewCmdProject is a project command.
 func NewCmdProject() *cobra.Command {
-	return &cobra.Command{
+	cmd := cobra.Command{
 		Use:         "project",
-		Short:       "All accessible jira projects",
-		Long:        "Project lists all jira projects that a user has access to.",
+		Short:       "Project manages Jira projects",
+		Long:        helpText,
 		Aliases:     []string{"projects"},
 		Annotations: map[string]string{"cmd:main": "true"},
-		Run:         projects,
+		RunE:        projects,
 	}
+
+	cmd.AddCommand(list.NewCmdList())
+
+	return &cmd
 }
 
-func projects(cmd *cobra.Command, _ []string) {
-	debug, err := cmd.Flags().GetBool("debug")
-	cmdutil.ExitIfError(err)
-
-	projects, total, err := func() ([]*jira.Project, int, error) {
-		s := cmdutil.Info("Fetching projects...")
-		defer s.Stop()
-
-		projects, err := api.Client(jira.Config{Debug: debug}).Project()
-		if err != nil {
-			return nil, 0, err
-		}
-		return projects, len(projects), nil
-	}()
-	cmdutil.ExitIfError(err)
-
-	if total == 0 {
-		cmdutil.Failed("No projects found.")
-		return
-	}
-
-	v := view.NewProject(projects)
-
-	cmdutil.ExitIfError(v.Render())
+func projects(cmd *cobra.Command, _ []string) error {
+	return cmd.Help()
 }


### PR DESCRIPTION
> BREAKING CHANGE

This PR moves boards and project listing to `list` subcommand. This will make them consistent with other commands and enable us to add additional features.

#### Old

```sh
$ jira boards
$ jira projects
```

#### New

```sh
$ jira board list
$ jira project list
```