### PR TITLE
feat: Support custom fields on issue create

### DIFF
--- a/internal/cmd/issue/create/create.go
+++ b/internal/cmd/issue/create/create.go
@@ -137,6 +137,7 @@ func create(cmd *cobra.Command, _ []string) {
 			Labels:         params.labels,
 			Components:     params.components,
 			FixVersions:    params.fixVersions,
+			CustomFields:   params.customFields,
 			EpicField:      viper.GetString("epic.link"),
 		}
 		cr.ForProjectType(projectType)
@@ -356,6 +357,7 @@ type createParams struct {
 	labels         []string
 	components     []string
 	fixVersions    []string
+	customFields   map[string]string
 	template       string
 	noInput        bool
 	debug          bool
@@ -389,6 +391,9 @@ func parseFlags(flags query.FlagParser) *createParams {
 	fixVersions, err := flags.GetStringArray("fix-version")
 	cmdutil.ExitIfError(err)
 
+	custom, err := flags.GetStringToString("custom")
+	cmdutil.ExitIfError(err)
+
 	template, err := flags.GetString("template")
 	cmdutil.ExitIfError(err)
 
@@ -408,6 +413,7 @@ func parseFlags(flags query.FlagParser) *createParams {
 		labels:         labels,
 		components:     components,
 		fixVersions:    fixVersions,
+		customFields:   custom,
 		template:       template,
 		noInput:        noInput,
 		debug:          debug,

--- a/internal/cmdcommon/create.go
+++ b/internal/cmdcommon/create.go
@@ -16,6 +16,8 @@ const (
 
 // SetCreateFlags sets flags supported by create command.
 func SetCreateFlags(cmd *cobra.Command, prefix string) {
+	custom := make(map[string]string)
+
 	cmd.Flags().SortFlags = false
 
 	if prefix == "Epic" {
@@ -32,6 +34,7 @@ And, this field is mandatory when creating a sub-task.`)
 	cmd.Flags().StringArrayP("label", "l", []string{}, prefix+" labels")
 	cmd.Flags().StringArrayP("component", "C", []string{}, prefix+" components")
 	cmd.Flags().StringArray("fix-version", []string{}, "Release info (fixVersions)")
+	cmd.Flags().StringToString("custom", custom, "Set custom fields")
 	cmd.Flags().StringP("template", "T", "", "Path to a file to read body/description from")
 	cmd.Flags().Bool("web", false, "Open in web browser after successful creation")
 	cmd.Flags().Bool("no-input", false, "Disable prompt for non-required fields")

--- a/internal/query/issue_test.go
+++ b/internal/query/issue_test.go
@@ -109,8 +109,9 @@ func (tfp *issueFlagParser) GetStringArray(name string) ([]string, error) {
 	return tfp.labels, nil
 }
 
-func (*issueFlagParser) GetUint(string) (uint, error) { return 100, nil }
-func (*issueFlagParser) Set(string, string) error     { return nil }
+func (*issueFlagParser) GetStringToString(string) (map[string]string, error) { return nil, nil }
+func (*issueFlagParser) GetUint(string) (uint, error)                        { return 100, nil }
+func (*issueFlagParser) Set(string, string) error                            { return nil }
 
 func TestIssueGet(t *testing.T) {
 	cases := []struct {

--- a/internal/query/query.go
+++ b/internal/query/query.go
@@ -5,6 +5,7 @@ type FlagParser interface {
 	GetBool(string) (bool, error)
 	GetString(string) (string, error)
 	GetStringArray(string) ([]string, error)
+	GetStringToString(string) (map[string]string, error)
 	GetUint(name string) (uint, error)
 	Set(name, value string) error
 }

--- a/internal/query/sprint_test.go
+++ b/internal/query/sprint_test.go
@@ -43,9 +43,10 @@ func (sfp sprintFlagParser) GetString(name string) (string, error) {
 	return sfp.state, nil
 }
 
-func (sprintFlagParser) GetStringArray(string) ([]string, error) { return []string{}, nil }
-func (sprintFlagParser) GetUint(string) (uint, error)            { return 100, nil }
-func (sprintFlagParser) Set(string, string) error                { return nil }
+func (sprintFlagParser) GetStringArray(string) ([]string, error)             { return []string{}, nil }
+func (sprintFlagParser) GetStringToString(string) (map[string]string, error) { return nil, nil }
+func (sprintFlagParser) GetUint(string) (uint, error)                        { return 100, nil }
+func (sprintFlagParser) Set(string, string) error                            { return nil }
 
 func TestSprintGet(t *testing.T) {
 	cases := []struct {

--- a/pkg/jira/create.go
+++ b/pkg/jira/create.go
@@ -198,7 +198,7 @@ func constructCustomFields(fields map[string]string, data *createRequest) {
 	for key, val := range fields {
 		for _, configured := range configuredFields {
 			identifier := strings.ReplaceAll(strings.ToLower(strings.TrimSpace(configured.Name)), " ", "-")
-			if identifier != key {
+			if identifier != strings.ToLower(key) {
 				continue
 			}
 

--- a/pkg/jira/createmeta.go
+++ b/pkg/jira/createmeta.go
@@ -26,7 +26,7 @@ type CreateMetaResponse struct {
 // CreateMetaIssueType struct holds issue types from GET /issue/createmeta endpoint.
 type CreateMetaIssueType struct {
 	IssueType
-	Fields map[string]interface{} `json:"fields"`
+	Fields map[string]IssueTypeField `json:"fields"`
 }
 
 // GetCreateMeta gets create metadata using GET /issue/createmeta endpoint.

--- a/pkg/jira/createmeta_test.go
+++ b/pkg/jira/createmeta_test.go
@@ -62,18 +62,18 @@ func TestGetCreateMeta(t *testing.T) {
 						Name:    "Epic",
 						Subtask: false,
 					},
-					Fields: map[string]interface{}{
-						"customfield_10011": map[string]interface{}{
-							"name": "Epic Name",
-							"key":  "customfield_10011",
+					Fields: map[string]IssueTypeField{
+						"customfield_10011": {
+							Name: "Epic Name",
+							Key:  "customfield_10011",
 						},
-						"priority": map[string]interface{}{
-							"name": "Priority",
-							"key":  "priority",
+						"priority": {
+							Name: "Priority",
+							Key:  "priority",
 						},
-						"customfield_10014": map[string]interface{}{
-							"name": "Epic Link",
-							"key":  "customfield_10014",
+						"customfield_10014": {
+							Name: "Epic Link",
+							Key:  "customfield_10014",
 						},
 					},
 				},

--- a/pkg/jira/customfield.go
+++ b/pkg/jira/customfield.go
@@ -1,0 +1,15 @@
+package jira
+
+const (
+	customFieldFormatOption = "option"
+	customFieldFormatArray  = "array"
+	customFieldFormatNumber = "number"
+)
+
+type customField map[string]interface{}
+
+type customFieldTypeNumber float64
+
+type customFieldTypeOption struct {
+	Value string `json:"value"`
+}

--- a/pkg/jira/types.go
+++ b/pkg/jira/types.go
@@ -103,6 +103,17 @@ type IssueFields struct {
 	Updated string `json:"updated"`
 }
 
+// IssueTypeField holds issue field info.
+type IssueTypeField struct {
+	Name   string `json:"name"`
+	Key    string `json:"key"`
+	Schema struct {
+		DataType string `json:"type"`
+		Items    string `json:"items,omitempty"`
+	} `json:"schema"`
+	FieldID string `json:"fieldId,omitempty"`
+}
+
 // IssueType holds issue type info.
 type IssueType struct {
 	ID      string `json:"id"`


### PR DESCRIPTION
This PR adds initial support for custom fields on the issue creation. Relates to https://github.com/ankitpokhrel/jira-cli/discussions/222. Fixes #340.

Jira supports a wide variety of datatypes when creating a custom field. Out of all [formats mentioned in the Jira doc](https://developer.atlassian.com/cloud/jira/service-desk/rest/intro/#fieldformats), the implementation right now doesn't support `Cascading select custom field`, `Single-user picker custom field` and  `Multi-user picker custom field`. Support for these missing types will be added based on the request and the usecase.

### Implementation Details

Since we are already using the [createmeta endpoint](https://developer.atlassian.com/cloud/jira/platform/rest/v2/api-group-issues/#api-rest-api-2-issue-createmeta-get) to save metadata during `jira init` process, this step is modified to save custom field details. The initialization process will now add a new section `issue.fields.custom` to save required details about configured custom fields.

![Screen Shot 2022-03-05 at 12 34 27 PM](https://user-images.githubusercontent.com/2364546/156881255-58e3a8bf-dfb4-4e08-ad9a-713bc83a270f.png)

Next, a new flag `--custom` is added on `create` command that accepts a key-value pair.  The key is derived from the `name` you see in the configuration. This is the same name that you see in the UI making it easy to guess. Dash/hyphen (`-`) separated lowercase `name` is used as a key.  The value depends on the datatype of the field. For some datatypes like `string`, `datetime`, `date`, `option`, the value is a plain string (eg: `--custom note="An example note"`). For array types, its a comma separated value (eg: `--custom platform=iOS,Android`).

### Example
Given some custom fields as below:
| Custom Field         | Field Type     | Comment |
|--------------|-----------|------------|
| Due Date | Datetime      | ISO 8601 ('YYYY-MM-DDThh:mm:ss.sTZD') format         |
| Note      |   Paragraph | A single or multiline text input      |
| Platform | Checkbox      | Array of strings        |
| Quarter | Radio button      | Single value string data       |
| Tags | Labels      | Array of strings        |

You can use `--custom` flag to pass data for custom fields
```
$ jira issue create -tStory --custom story-points=3 --custom due-date="2022-03-10T14:39:00.000+1100" \
 --custom note="A custom note" --custom platform=Windows,Linux --custom quarter=Q3 --custom tags=p1,q3,y2022

# Or, alternatively

$ jira issue create -tStory --custom=story-points=3 --custom=due-date="2022-03-10T14:39:00.000+1100" \
 --custom=note="A custom note" --custom=platform=Windows,Linux --custom=quarter=Q3 --custom=tags=p1,q3,y2022
```

The example command above creates a `story` with defined custom fields of different types as seen in the screenshot below.

![Screen Shot 2022-03-05 at 11 30 42 AM](https://user-images.githubusercontent.com/2364546/156879456-7825b561-f3db-43b3-b301-6c6654f7d842.png)

### Caveats

The Jira API returns invalid types for some locked custom fields. For instance, for the `sprint` field the returned datatype is an array of strings or JSON depending on the Jira version used. However, that is not true since the create API expects a single numeric value for a sprint field.

In such cases, the config needs to be modified manually to make the field work.

```sh
# Details returned by the Jira API for sprint field
- name: Sprint
  key: customfield_10020
  schema:
     datatype: array
     items: json

# Manual change needed to make it work
- name: Sprint
  key: customfield_10020
  schema:
     datatype: number
```

### Testing

To try out this change, you can either [build the app locally](https://github.com/ankitpokhrel/jira-cli#development) or install it using the following command.

```sh
go install github.com/ankitpokhrel/jira-cli/cmd/jira@request-222
```

Note that you will have to regenerate the config with `jira init`.