### PR TITLE
feature: Remote link command

### DIFF
--- a/internal/cmd/issue/issue.go
+++ b/internal/cmd/issue/issue.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ankitpokhrel/jira-cli/internal/cmd/issue/link"
 	"github.com/ankitpokhrel/jira-cli/internal/cmd/issue/list"
 	"github.com/ankitpokhrel/jira-cli/internal/cmd/issue/move"
+	"github.com/ankitpokhrel/jira-cli/internal/cmd/issue/remotelink"
 	"github.com/ankitpokhrel/jira-cli/internal/cmd/issue/view"
 )
 
@@ -32,7 +33,7 @@ func NewCmdIssue() *cobra.Command {
 
 	cmd.AddCommand(
 		lc, cc, edit.NewCmdEdit(), move.NewCmdMove(), view.NewCmdView(), assign.NewCmdAssign(),
-		link.NewCmdLink(), comment.NewCmdComment(), clone.NewCmdClone(),
+		link.NewCmdLink(), comment.NewCmdComment(), clone.NewCmdClone(), remotelink.NewCmdRemoteLink(),
 	)
 
 	list.SetFlags(lc)

--- a/internal/cmd/issue/remotelink/remotelink.go
+++ b/internal/cmd/issue/remotelink/remotelink.go
@@ -50,20 +50,20 @@ func remoteLink(cmd *cobra.Command, args []string) {
 	}
 
 	cmdutil.ExitIfError(lc.setIssueKey(project))
-	cmdutil.ExitIfError(lc.setRemoteLinkUrl(project))
+	cmdutil.ExitIfError(lc.setRemoteLinkURL(project))
 	cmdutil.ExitIfError(lc.setRemoteLinkTitle())
 
 	err := func() error {
 		s := cmdutil.Info("Linking url")
 		defer s.Stop()
 
-		return client.AddIssueRemoteLink(lc.params.issueKey, lc.params.remoteLinkUrl, lc.params.remoteLinkTitle)
+		return client.AddIssueRemoteLink(lc.params.issueKey, lc.params.remoteLinkURL, lc.params.remoteLinkTitle)
 	}()
 	cmdutil.ExitIfError(err)
 
 	server := viper.GetString("server")
 
-	cmdutil.Success("Remote link \"%s\"(%s) added", lc.params.remoteLinkTitle, lc.params.remoteLinkUrl)
+	cmdutil.Success("Remote link \"%s\"(%s) added", lc.params.remoteLinkTitle, lc.params.remoteLinkURL)
 	fmt.Printf("%s/browse/%s\n", server, lc.params.issueKey)
 
 	if web, _ := cmd.Flags().GetBool("web"); web {
@@ -74,20 +74,20 @@ func remoteLink(cmd *cobra.Command, args []string) {
 
 type remoteLinkParams struct {
 	issueKey        string
-	remoteLinkUrl   string
+	remoteLinkURL   string
 	remoteLinkTitle string
 	debug           bool
 }
 
 func parseArgsAndFlags(flags query.FlagParser, args []string, project string) *remoteLinkParams {
-	var issueKey, remoteLinkUrl, remoteLinkTitle string
+	var issueKey, remoteLinkURL, remoteLinkTitle string
 
 	nargs := len(args)
 	if nargs >= 1 {
 		issueKey = cmdutil.GetJiraIssueKey(project, args[0])
 	}
 	if nargs >= 2 {
-		remoteLinkUrl = args[1]
+		remoteLinkURL = args[1]
 	}
 	if nargs >= 3 {
 		remoteLinkTitle = args[2]
@@ -98,7 +98,7 @@ func parseArgsAndFlags(flags query.FlagParser, args []string, project string) *r
 
 	return &remoteLinkParams{
 		issueKey:        issueKey,
-		remoteLinkUrl:   remoteLinkUrl,
+		remoteLinkURL:   remoteLinkURL,
 		remoteLinkTitle: remoteLinkTitle,
 		debug:           debug,
 	}
@@ -129,8 +129,8 @@ func (lc *remoteLinkCmd) setIssueKey(project string) error {
 	return nil
 }
 
-func (lc *remoteLinkCmd) setRemoteLinkUrl(project string) error {
-	if lc.params.remoteLinkUrl != "" {
+func (lc *remoteLinkCmd) setRemoteLinkURL(project string) error {
+	if lc.params.remoteLinkURL != "" {
 		return nil
 	}
 
@@ -144,7 +144,7 @@ func (lc *remoteLinkCmd) setRemoteLinkUrl(project string) error {
 	if err := survey.Ask([]*survey.Question{qs}, &ans); err != nil {
 		return err
 	}
-	lc.params.remoteLinkUrl = ans
+	lc.params.remoteLinkURL = ans
 
 	return nil
 }

--- a/internal/cmd/issue/remotelink/remotelink.go
+++ b/internal/cmd/issue/remotelink/remotelink.go
@@ -1,0 +1,172 @@
+package remotelink
+
+import (
+	"fmt"
+
+	"github.com/AlecAivazis/survey/v2"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/ankitpokhrel/jira-cli/api"
+	"github.com/ankitpokhrel/jira-cli/internal/cmdutil"
+	"github.com/ankitpokhrel/jira-cli/internal/query"
+	"github.com/ankitpokhrel/jira-cli/pkg/jira"
+)
+
+const (
+	helpText = `Remote link creates or update a remote issue link for an issue.`
+	examples = `$ jira issue remotelink ISSUE-1 https://example.com "Example page"`
+)
+
+// NewCmdRemoteLink is a remotelink command.
+func NewCmdRemoteLink() *cobra.Command {
+	cmd := cobra.Command{
+		Use:     "remotelink ISSUE_KEY REMOTE_LINK_URL REMOTE_LINK_TITLE",
+		Short:   "Remotelink adds link to an issue",
+		Long:    helpText,
+		Example: examples,
+		Aliases: []string{"rln"},
+		Annotations: map[string]string{
+			"help:args": "ISSUE_KEY\tKey of the issue, eg: ISSUE-1\n" +
+				"REMOTE_LINK_URL\tLinked url, eg: https://example.com\n" +
+				"REMOTE_LINK_TITLE\tLinked url title, eg: Example page",
+		},
+		Args: cobra.MinimumNArgs(3),
+		Run:  remoteLink,
+	}
+
+	cmd.Flags().Bool("web", false, "Open issue in web browser after successful linking")
+
+	return &cmd
+}
+
+func remoteLink(cmd *cobra.Command, args []string) {
+	project := viper.GetString("project.key")
+	params := parseArgsAndFlags(cmd.Flags(), args, project)
+	client := api.Client(jira.Config{Debug: params.debug})
+	lc := remoteLinkCmd{
+		client: client,
+		params: params,
+	}
+
+	cmdutil.ExitIfError(lc.setIssueKey(project))
+	cmdutil.ExitIfError(lc.setRemoteLinkUrl(project))
+	cmdutil.ExitIfError(lc.setRemoteLinkTitle())
+
+	err := func() error {
+		s := cmdutil.Info("Linking url")
+		defer s.Stop()
+
+		return client.AddIssueRemoteLink(lc.params.issueKey, lc.params.remoteLinkUrl, lc.params.remoteLinkTitle)
+	}()
+	cmdutil.ExitIfError(err)
+
+	server := viper.GetString("server")
+
+	cmdutil.Success("Remote link \"%s\"(%s) added", lc.params.remoteLinkTitle, lc.params.remoteLinkUrl)
+	fmt.Printf("%s/browse/%s\n", server, lc.params.issueKey)
+
+	if web, _ := cmd.Flags().GetBool("web"); web {
+		err := cmdutil.Navigate(server, lc.params.issueKey)
+		cmdutil.ExitIfError(err)
+	}
+}
+
+type remoteLinkParams struct {
+	issueKey        string
+	remoteLinkUrl   string
+	remoteLinkTitle string
+	debug           bool
+}
+
+func parseArgsAndFlags(flags query.FlagParser, args []string, project string) *remoteLinkParams {
+	var issueKey, remoteLinkUrl, remoteLinkTitle string
+
+	nargs := len(args)
+	if nargs >= 1 {
+		issueKey = cmdutil.GetJiraIssueKey(project, args[0])
+	}
+	if nargs >= 2 {
+		remoteLinkUrl = args[1]
+	}
+	if nargs >= 3 {
+		remoteLinkTitle = args[2]
+	}
+
+	debug, err := flags.GetBool("debug")
+	cmdutil.ExitIfError(err)
+
+	return &remoteLinkParams{
+		issueKey:        issueKey,
+		remoteLinkUrl:   remoteLinkUrl,
+		remoteLinkTitle: remoteLinkTitle,
+		debug:           debug,
+	}
+}
+
+type remoteLinkCmd struct {
+	client *jira.Client
+	params *remoteLinkParams
+}
+
+func (lc *remoteLinkCmd) setIssueKey(project string) error {
+	if lc.params.issueKey != "" {
+		return nil
+	}
+
+	var ans string
+
+	qs := &survey.Question{
+		Name:     "issueKey",
+		Prompt:   &survey.Input{Message: "Issue key"},
+		Validate: survey.Required,
+	}
+	if err := survey.Ask([]*survey.Question{qs}, &ans); err != nil {
+		return err
+	}
+	lc.params.issueKey = cmdutil.GetJiraIssueKey(project, ans)
+
+	return nil
+}
+
+func (lc *remoteLinkCmd) setRemoteLinkUrl(project string) error {
+	if lc.params.remoteLinkUrl != "" {
+		return nil
+	}
+
+	var ans string
+
+	qs := &survey.Question{
+		Name:     "remoteLinkUrl",
+		Prompt:   &survey.Input{Message: "Remote link url"},
+		Validate: survey.Required,
+	}
+	if err := survey.Ask([]*survey.Question{qs}, &ans); err != nil {
+		return err
+	}
+	lc.params.remoteLinkUrl = ans
+
+	return nil
+}
+
+func (lc *remoteLinkCmd) setRemoteLinkTitle() error {
+	if lc.params.remoteLinkTitle != "" {
+		return nil
+	}
+
+	var ans string
+
+	qs := &survey.Question{
+		Name: "remoteLinkTitle",
+		Prompt: &survey.Input{
+			Message: "Remote link title:",
+		},
+		Validate: survey.Required,
+	}
+	if err := survey.Ask([]*survey.Question{qs}, &ans); err != nil {
+		return err
+	}
+	lc.params.remoteLinkTitle = ans
+
+	return nil
+}

--- a/internal/cmd/issue/remotelink/remotelink.go
+++ b/internal/cmd/issue/remotelink/remotelink.go
@@ -50,7 +50,7 @@ func remoteLink(cmd *cobra.Command, args []string) {
 	}
 
 	cmdutil.ExitIfError(lc.setIssueKey(project))
-	cmdutil.ExitIfError(lc.setRemoteLinkURL(project))
+	cmdutil.ExitIfError(lc.setRemoteLinkURL())
 	cmdutil.ExitIfError(lc.setRemoteLinkTitle())
 
 	err := func() error {
@@ -129,7 +129,7 @@ func (lc *remoteLinkCmd) setIssueKey(project string) error {
 	return nil
 }
 
-func (lc *remoteLinkCmd) setRemoteLinkURL(project string) error {
+func (lc *remoteLinkCmd) setRemoteLinkURL() error {
 	if lc.params.remoteLinkURL != "" {
 		return nil
 	}

--- a/pkg/jira/issue.go
+++ b/pkg/jira/issue.go
@@ -229,7 +229,7 @@ func (c *Client) LinkIssue(inwardIssue, outwardIssue, linkType string) error {
 }
 
 type remoteLinkObject struct {
-	Url   string `json:"url"`
+	URL   string `json:"url"`
 	Title string `json:"title"`
 }
 
@@ -241,7 +241,7 @@ type remoteLinkRequest struct {
 func (c *Client) AddIssueRemoteLink(key, url, title string) error {
 	body, err := json.Marshal(remoteLinkRequest{
 		Object: remoteLinkObject{
-			Url:   url,
+			URL:   url,
 			Title: title,
 		},
 	})

--- a/pkg/jira/issue.go
+++ b/pkg/jira/issue.go
@@ -228,6 +228,47 @@ func (c *Client) LinkIssue(inwardIssue, outwardIssue, linkType string) error {
 	return nil
 }
 
+type remoteLinkObject struct {
+	Url   string `json:"url"`
+	Title string `json:"title"`
+}
+
+type remoteLinkRequest struct {
+	Object remoteLinkObject `json:"object"`
+}
+
+// AddIssueRemoteLink creates or updates remote link object on a given issue using POST /issue/{key}/remotelink endpoint.
+func (c *Client) AddIssueRemoteLink(key, url, title string) error {
+	body, err := json.Marshal(remoteLinkRequest{
+		Object: remoteLinkObject{
+			Url:   url,
+			Title: title,
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	res, err := c.Post(context.Background(), fmt.Sprintf("/issue/%s/remotelink", key), body, Header{
+		"Accept":       "application/json",
+		"Content-Type": "application/json",
+	})
+	if err != nil {
+		return err
+	}
+	if res == nil {
+		return ErrEmptyResponse
+	}
+	defer func() { _ = res.Body.Close() }()
+
+	switch res.StatusCode {
+	case http.StatusOK, http.StatusCreated:
+		return nil
+	default:
+		return formatUnexpectedResponse(res)
+	}
+}
+
 type issueCommentRequest struct {
 	Body string `json:"body"`
 }

--- a/pkg/jira/issue_test.go
+++ b/pkg/jira/issue_test.go
@@ -301,6 +301,33 @@ func TestLinkIssue(t *testing.T) {
 	assert.Error(t, &ErrUnexpectedResponse{}, err)
 }
 
+func TestAddIssueRemoteLink(t *testing.T) {
+	var unexpectedStatusCode bool
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/rest/api/3/issue/TEST-1/remotelink", r.URL.Path)
+		assert.Equal(t, "application/json", r.Header.Get("Accept"))
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+
+		if unexpectedStatusCode {
+			w.WriteHeader(400)
+		} else {
+			w.WriteHeader(201)
+		}
+	}))
+	defer server.Close()
+
+	client := NewClient(Config{Server: server.URL}, WithTimeout(3*time.Second))
+
+	err := client.AddIssueRemoteLink("TEST-1", "https://example.com", "Example")
+	assert.NoError(t, err)
+
+	unexpectedStatusCode = true
+
+	err = client.AddIssueRemoteLink("TEST-1", "https://example.com", "")
+	assert.Error(t, &ErrUnexpectedResponse{}, err)
+}
+
 func TestAddIssueComment(t *testing.T) {
 	var unexpectedStatusCode bool
 


### PR DESCRIPTION
Seeing that this command is missing (and it's mainly what I wanted to automate in my Jira workflow) I went on and implemented it.

This MR implements a bare minimum for creating a remote link with url and a title being required by the [API](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-remote-links/#api-rest-api-3-issue-issueidorkey-remotelink-post).

I'm open for changing the way this works and adding more functionality if it's needed.
Thank you for this project.