### PR TITLE
feat: Allow removing labels on edit

### DIFF
--- a/pkg/jira/edit.go
+++ b/pkg/jira/edit.go
@@ -141,7 +141,7 @@ func getRequestDataForEdit(req *EditRequest) *editRequest {
 	}}
 
 	if len(req.Labels) > 0 {
-		add, sub := addOrSub(req.Labels)
+		add, sub := splitAddAndRemove(req.Labels)
 
 		labels := make([]struct {
 			Add    string `json:"add,omitempty"`
@@ -224,18 +224,18 @@ func getRequestDataForEdit(req *EditRequest) *editRequest {
 	return &data
 }
 
-func addOrSub(input []string) ([]string, []string) {
+func splitAddAndRemove(input []string) ([]string, []string) {
 	add := make([]string, 0, len(input))
 	sub := make([]string, 0, len(input))
 
-	for _, l := range input {
-		if strings.HasPrefix(l, separatorMinus) {
-			sub = append(sub, strings.TrimPrefix(l, separatorMinus))
+	for _, inp := range input {
+		if strings.HasPrefix(inp, separatorMinus) {
+			sub = append(sub, strings.TrimPrefix(inp, separatorMinus))
 		}
 	}
-	for _, l := range input {
-		if !strings.HasPrefix(l, separatorMinus) && !inArray(sub, l) {
-			add = append(add, l)
+	for _, inp := range input {
+		if !strings.HasPrefix(inp, separatorMinus) && !inArray(sub, inp) {
+			add = append(add, inp)
 		}
 	}
 


### PR DESCRIPTION
We can use minus `-` to remove labels when editing the issue.

![Screen Shot 2022-05-23 at 9 15 15 PM](https://user-images.githubusercontent.com/2364546/169890411-293ab188-8fcb-4951-b2c9-6b77a6b3c967.png)

```sh
$ jira issue edit 35 --label "-cmd" --label "-next" --label "prio"
```