### PR TITLE
Support creating issues with custom subtask type

### DIFF
--- a/internal/cmd/issue/create/create.go
+++ b/internal/cmd/issue/create/create.go
@@ -146,8 +146,8 @@ func create(cmd *cobra.Command, _ []string) {
 		}
 		cr.ForProjectType(projectType)
 
-		if strings.EqualFold(params.issueType, jira.IssueTypeSubTask) {
-			cr.SubtaskField = cmdutil.GetSubtaskHandle(cc.issueTypes)
+		if handle := cmdutil.GetSubtaskHandle(params.issueType, cc.issueTypes); handle != "" {
+			cr.SubtaskField = handle
 		}
 
 		resp, err := client.CreateV2(&cr)

--- a/internal/cmdutil/utils_test.go
+++ b/internal/cmdutil/utils_test.go
@@ -172,9 +172,10 @@ func TestGetSubtaskHandle(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
-		name     string
-		input    []*jira.IssueType
-		expected string
+		name      string
+		input     []*jira.IssueType
+		inputType string
+		expected  string
 	}{
 		{
 			name: "should get default issue type handle for sub-task",
@@ -186,7 +187,8 @@ func TestGetSubtaskHandle(t *testing.T) {
 					Subtask: false,
 				},
 			},
-			expected: "Sub-task",
+			inputType: "Sub-task",
+			expected:  "Sub-task",
 		},
 		{
 			name: "should get valid sub-task handle",
@@ -204,7 +206,8 @@ func TestGetSubtaskHandle(t *testing.T) {
 					Subtask: true,
 				},
 			},
-			expected: "Sub-Task",
+			inputType: "Sub-task",
+			expected:  "Sub-Task",
 		},
 		{
 			name: "should get sub-task name as handle",
@@ -221,7 +224,33 @@ func TestGetSubtaskHandle(t *testing.T) {
 					Subtask: true,
 				},
 			},
-			expected: "Subtask",
+			inputType: "Sub-task",
+			expected:  "Subtask",
+		},
+		{
+			name: "exact matches for a custom sub-task should take precedence",
+			input: []*jira.IssueType{
+				{
+					ID:      "123",
+					Name:    "Story",
+					Handle:  "story",
+					Subtask: false,
+				},
+				{
+					ID:      "234",
+					Name:    "Sub-Task",
+					Handle:  "Sub-Task",
+					Subtask: true,
+				},
+				{
+					ID:      "567",
+					Name:    "Custom Sub-Task",
+					Handle:  "Custom Sub-Task",
+					Subtask: true,
+				},
+			},
+			inputType: "Custom Sub-Task",
+			expected:  "Custom Sub-Task",
 		},
 	}
 
@@ -231,7 +260,7 @@ func TestGetSubtaskHandle(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			assert.Equal(t, tc.expected, GetSubtaskHandle(tc.input))
+			assert.Equal(t, tc.expected, GetSubtaskHandle(tc.inputType, tc.input))
 		})
 	}
 }


### PR DESCRIPTION
Before, the code was assuming only one sub-task type existed (the
default). This would cause any issues filed with a custom sub-task type
to fail with the following error:

```
Error:
  - Issue 'XXX-23668' must be of type 'Epic'.

jira: Received unexpected response '400 Bad Request'
```

because `jira.CreateRequest::SubtaskField` was not being set.

Fix by modifying `GetSubtaskHandle()` helper to look for exact matches
on sub-task types.