### PR TITLE
feat: Support custom fields on issue edit

### DIFF
--- a/internal/cmd/issue/edit/edit.go
+++ b/internal/cmd/issue/edit/edit.go
@@ -143,6 +143,7 @@ func edit(cmd *cobra.Command, args []string) {
 			Labels:         labels,
 			Components:     components,
 			FixVersions:    fixVersions,
+			CustomFields:   params.customFields,
 		}
 
 		return client.Edit(params.issueKey, &edr)
@@ -278,16 +279,17 @@ func (ec *editCmd) askQuestions(issue *jira.Issue, originalBody string) error {
 }
 
 type editParams struct {
-	issueKey    string
-	summary     string
-	body        string
-	priority    string
-	assignee    string
-	labels      []string
-	components  []string
-	fixVersions []string
-	noInput     bool
-	debug       bool
+	issueKey     string
+	summary      string
+	body         string
+	priority     string
+	assignee     string
+	labels       []string
+	components   []string
+	fixVersions  []string
+	customFields map[string]string
+	noInput      bool
+	debug        bool
 }
 
 func (ep *editParams) isEmpty() bool {
@@ -317,6 +319,9 @@ func parseArgsAndFlags(flags query.FlagParser, args []string, project string) *e
 	fixVersions, err := flags.GetStringArray("fix-version")
 	cmdutil.ExitIfError(err)
 
+	custom, err := flags.GetStringToString("custom")
+	cmdutil.ExitIfError(err)
+
 	noInput, err := flags.GetBool("no-input")
 	cmdutil.ExitIfError(err)
 
@@ -324,16 +329,17 @@ func parseArgsAndFlags(flags query.FlagParser, args []string, project string) *e
 	cmdutil.ExitIfError(err)
 
 	return &editParams{
-		issueKey:    cmdutil.GetJiraIssueKey(project, args[0]),
-		summary:     summary,
-		body:        body,
-		priority:    priority,
-		assignee:    assignee,
-		labels:      labels,
-		components:  components,
-		fixVersions: fixVersions,
-		noInput:     noInput,
-		debug:       debug,
+		issueKey:     cmdutil.GetJiraIssueKey(project, args[0]),
+		summary:      summary,
+		body:         body,
+		priority:     priority,
+		assignee:     assignee,
+		labels:       labels,
+		components:   components,
+		fixVersions:  fixVersions,
+		customFields: custom,
+		noInput:      noInput,
+		debug:        debug,
 	}
 }
 
@@ -385,6 +391,8 @@ func getMetadataQuestions(meta []string, issue *jira.Issue) []*survey.Question {
 }
 
 func setFlags(cmd *cobra.Command) {
+	custom := make(map[string]string)
+
 	cmd.Flags().SortFlags = false
 
 	cmd.Flags().StringP("summary", "s", "", "Edit summary or title")
@@ -394,6 +402,7 @@ func setFlags(cmd *cobra.Command) {
 	cmd.Flags().StringArrayP("label", "l", []string{}, "Append labels")
 	cmd.Flags().StringArrayP("component", "C", []string{}, "Replace components")
 	cmd.Flags().StringArray("fix-version", []string{}, "Add/Append release info (fixVersions)")
+	cmd.Flags().StringToString("custom", custom, "Edit custom fields")
 	cmd.Flags().Bool("web", false, "Open in web browser after successful update")
 	cmd.Flags().Bool("no-input", false, "Disable prompt for non-required fields")
 }

--- a/pkg/jira/customfield.go
+++ b/pkg/jira/customfield.go
@@ -10,6 +10,23 @@ type customField map[string]interface{}
 
 type customFieldTypeNumber float64
 
+type customFieldTypeNumberSet struct {
+	Set customFieldTypeNumber `json:"set"`
+}
+
+type customFieldTypeStringSet struct {
+	Set string `json:"set"`
+}
+
 type customFieldTypeOption struct {
 	Value string `json:"value"`
+}
+
+type customFieldTypeOptionSet struct {
+	Set customFieldTypeOption `json:"set"`
+}
+
+type customFieldTypeOptionAddRemove struct {
+	Add    *customFieldTypeOption `json:"add,omitempty"`
+	Remove *customFieldTypeOption `json:"remove,omitempty"`
 }

--- a/pkg/jira/edit.go
+++ b/pkg/jira/edit.go
@@ -328,7 +328,11 @@ func constructCustomFieldsForEdit(fields map[string]string, data *editRequest) {
 				if configured.Schema.Items == customFieldFormatOption {
 					items := make([]customFieldTypeOptionAddRemove, 0)
 					for _, p := range pieces {
-						items = append(items, customFieldTypeOptionAddRemove{Add: &customFieldTypeOption{Value: p}})
+						if strings.HasPrefix(p, separatorMinus) {
+							items = append(items, customFieldTypeOptionAddRemove{Remove: &customFieldTypeOption{Value: strings.TrimPrefix(p, separatorMinus)}})
+						} else {
+							items = append(items, customFieldTypeOptionAddRemove{Add: &customFieldTypeOption{Value: p}})
+						}
 					}
 					data.Update.M.customFields[configured.Key] = items
 				} else {


### PR DESCRIPTION
Related: #319 #375

Similar to issue create, we can use `--custom` flag to edit custom fields on edit.

```sh
jira issue edit 35 --custom story-points=3 --custom due-date="2022-03-10T14:39:00.000+1100" \
 --custom note="A custom note" --custom platform=Windows,Linux --custom quarter=Q3 --custom tags=p1,q3,y2022
```

For multiple selection, we can use minus `-` to remove items

```sh
jira issue edit 35 --custom platform=-Windows,Linux --custom quarter=Q3 --custom tags=p1,-q3,y2022
```
