### PR TITLE
feat: Jira init non-interactive

### DIFF
--- a/internal/cmd/init/init.go
+++ b/internal/cmd/init/init.go
@@ -36,12 +36,12 @@ func NewCmdInit() *cobra.Command {
 
 	cmd.Flags().SortFlags = false
 
-	cmd.Flags().String("installation", "", "Is this is a 'cloud' or 'local' jira installation?")
+	cmd.Flags().String("installation", "", "Is this a 'cloud' or 'local' jira installation?")
 	cmd.Flags().String("server", "", "Link to your jira server")
 	cmd.Flags().String("login", "", "Jira login username or email based on your setup")
 	cmd.Flags().String("project", "", "Your default project key")
 	cmd.Flags().String("board", "", "Name of your default board in the project")
-	cmd.Flags().Bool("force", false, "Forcefully override existing config if it exist")
+	cmd.Flags().Bool("force", false, "Forcefully override existing config if it exists")
 	cmd.Flags().Bool("insecure", false, `If set, the tool will skip TLS certificate verification.
 This can be useful if your server is using self-signed certificates.`)
 

--- a/internal/config/generator.go
+++ b/internal/config/generator.go
@@ -370,7 +370,7 @@ func (c *JiraCLIConfigGenerator) configureProjectAndBoardDetails() error {
 	}
 	c.value.board = c.boardsMap[strings.ToLower(board)]
 
-	if c.value.board == nil && strings.EqualFold(board, optionNone) {
+	if c.value.board == nil && !strings.EqualFold(board, optionNone) {
 		return fmt.Errorf(
 			"board not found\n  Boards available for the project '%s' are '%s'",
 			c.value.project.Key,

--- a/internal/config/generator.go
+++ b/internal/config/generator.go
@@ -370,7 +370,7 @@ func (c *JiraCLIConfigGenerator) configureProjectAndBoardDetails() error {
 	}
 	c.value.board = c.boardsMap[strings.ToLower(board)]
 
-	if c.value.board == nil && strings.ToLower(board) != strings.ToLower(optionNone) {
+	if c.value.board == nil && strings.EqualFold(board, optionNone) {
 		return fmt.Errorf(
 			"board not found\n  Boards available for the project '%s' are '%s'",
 			c.value.project.Key,


### PR DESCRIPTION
Fixes #366

We can now use available flags to skip the prompt while generating the config.

```sh
$ jira init --installation cloud --server https://demo.atlassian.net --login user@example.com --project KEY --board "My Board Name"
```

Available flags

```sh
$ jira init -h
Init initializes jira configuration required for the tool to work properly.

USAGE
  jira init [flags]

FLAGS
      --installation string   Is this a 'cloud' or 'local' jira installation?
      --server string         Link to your jira server
      --login string          Jira login username or email based on your setup
      --board string          Name of your default board in the project
      --force                 Forcefully override existing config if it exists
      --insecure              If set, the tool will skip TLS certificate verification.
                              This can be useful if your server is using self-signed certificates.
  -h, --help                  help for init

INHERITED FLAGS
  -c, --config string    Config file (default is ~/.config/.jira/.config.yml)
      --debug            Turn on debug output
  -p, --project string   Jira project to look into (defaults to ~/.config/.jira/.config.yml)
```

