### PR TITLE
Only add project filter in JQL if project is not '' (empty string)

### DIFF
--- a/pkg/jql/jql.go
+++ b/pkg/jql/jql.go
@@ -24,7 +24,7 @@ type JQL struct {
 
 // NewJQL initializes jql query builder.
 func NewJQL(project string) *JQL {
-	var filterslist = []string{fmt.Sprintf("project=\"%s\"", project)}
+	filterslist := []string{fmt.Sprintf("project=\"%s\"", project)}
 	if project == "" {
 		filterslist = []string{}
 	}

--- a/pkg/jql/jql.go
+++ b/pkg/jql/jql.go
@@ -24,10 +24,10 @@ type JQL struct {
 
 // NewJQL initializes jql query builder.
 func NewJQL(project string) *JQL {
-    var filterslist []string = []string{fmt.Sprintf("project=\"%s\"", project)}
-    if (project == "") {
-        filterslist = []string{}
-    }
+	var filterslist []string = []string{fmt.Sprintf("project=\"%s\"", project)}
+	if project == "" {
+		filterslist = []string{}
+	}
 	return &JQL{
 		project: project,
 		filters: filterslist,

--- a/pkg/jql/jql.go
+++ b/pkg/jql/jql.go
@@ -24,9 +24,13 @@ type JQL struct {
 
 // NewJQL initializes jql query builder.
 func NewJQL(project string) *JQL {
+    var filterslist []string = []string{fmt.Sprintf("project=\"%s\"", project)}
+    if (project == "") {
+        filterslist = []string{}
+    }
 	return &JQL{
 		project: project,
-		filters: []string{fmt.Sprintf("project=\"%s\"", project)},
+		filters: filterslist,
 	}
 }
 

--- a/pkg/jql/jql.go
+++ b/pkg/jql/jql.go
@@ -24,7 +24,7 @@ type JQL struct {
 
 // NewJQL initializes jql query builder.
 func NewJQL(project string) *JQL {
-	var filterslist []string = []string{fmt.Sprintf("project=\"%s\"", project)}
+	var filterslist = []string{fmt.Sprintf("project=\"%s\"", project)}
 	if project == "" {
 		filterslist = []string{}
 	}


### PR DESCRIPTION
This change enables you to use `jira issue ..` commands - particularly, arbitrary JQL commands - without a project filter applied. Just pass an empty string for the project. *Probably* also works if you edit the config file to use an empty project name, but I haven't tried it.

For example:
```
$ jira issue list -p '' -q 'assignee IN (currentUser())' --plain
TYPE	KEY		SUMMARY									STATUS
Task	PROJ-123	One project task here							Backlog
Task	FOO-456		Different project here							Backlog

```

Above works for me to show me my current tickets across projects.