### PR TITLE
feat: Allow project filter in raw jql

### DIFF
--- a/internal/query/issue.go
+++ b/internal/query/issue.go
@@ -34,6 +34,14 @@ func NewIssue(project string, flags FlagParser) (*Issue, error) {
 
 // Get returns constructed jql query.
 func (i *Issue) Get() string {
+	var q *jql.JQL
+
+	defer func() {
+		if i.params.debug {
+			fmt.Printf("JQL: %s\n", q.String())
+		}
+	}()
+
 	q, obf := jql.NewJQL(i.Project), i.params.OrderBy
 	if obf == "created" &&
 		(i.params.Updated != "" || i.params.UpdatedBefore != "" || i.params.UpdatedAfter != "") &&
@@ -69,9 +77,6 @@ func (i *Issue) Get() string {
 		q.OrderBy(obf, jql.DirectionAscending)
 	} else {
 		q.OrderBy(obf, jql.DirectionDescending)
-	}
-	if i.params.debug {
-		fmt.Printf("JQL: %s\n", q.String())
 	}
 	if i.params.jql != "" {
 		q.And(func() { q.Raw(i.params.jql) })

--- a/pkg/jql/jql.go
+++ b/pkg/jql/jql.go
@@ -2,6 +2,7 @@ package jql
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 )
 
@@ -158,8 +159,12 @@ func (j *JQL) Or(fn GroupFunc) *JQL {
 
 // Raw sets the passed JQL query along with project context.
 func (j *JQL) Raw(q string) *JQL {
+	q = strings.TrimSpace(q)
 	if q == "" {
 		return j
+	}
+	if hasProjectFilter(q) {
+		j.filters = j.filters[1:]
 	}
 	j.filters = append(j.filters, q)
 	return j
@@ -196,5 +201,12 @@ func (j *JQL) compile() string {
 	if j.orderBy != "" {
 		q += " " + j.orderBy
 	}
+
 	return q
+}
+
+func hasProjectFilter(str string) bool {
+	regx := "(?i)((project)[\\s]*?={0,1}\\b)[^'.']"
+	m, _ := regexp.MatchString(regx, str)
+	return m
 }

--- a/pkg/jql/jql_test.go
+++ b/pkg/jql/jql_test.go
@@ -249,3 +249,73 @@ func TestJQL(t *testing.T) {
 		})
 	}
 }
+
+func TestHasProject(t *testing.T) {
+	cases := []struct {
+		input    string
+		expected bool
+	}{
+		{
+			input:    "project=",
+			expected: true,
+		},
+		{
+			input:    "project = TEST",
+			expected: true,
+		},
+		{
+			input:    "project     =    TEST",
+			expected: true,
+		},
+		{
+			input:    "  assigned = abc and PROJECT =   TEST  ",
+			expected: true,
+		},
+		{
+			input:    "assigned = abc and project =   TEST and project.property=abc",
+			expected: true,
+		},
+		{
+			input:    "PROJECT IS NOT EMPTY AND assignee IN (currentUser())",
+			expected: true,
+		},
+		{
+			input:    "PROJECT IN (TEST, TEST1) AND assignee IN (currentUser())",
+			expected: true,
+		},
+		{
+			input:    "PROJECT NOT IN (TEST,TEST1) AND assignee IN (currentUser())",
+			expected: true,
+		},
+		{
+			input:    "PROJECT != TEST AND projectType=\"classic\" AND assignee IS EMPTY",
+			expected: true,
+		},
+		{
+			input:    "project",
+			expected: false,
+		},
+		{
+			input:    "projectType",
+			expected: false,
+		},
+		{
+			input:    "project.property = ABC",
+			expected: false,
+		},
+		{
+			input:    "projectType=\"classic\" AND type=\"Story\" AND assignee IS EMPTY",
+			expected: false,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+
+		t.Run("", func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tc.expected, hasProjectFilter(tc.input))
+		})
+	}
+}


### PR DESCRIPTION
This change will allow us to use `project` filter when using a raw JQL.

```sh
# List issues from all projects
$ jira issue list -q "project IS NOT EMPTY"

# List issues from some projects
$ jira issue list -q "project IN (PRJ1,PRJ2)"

# List issues from all projects except PRJ1 and PRJ2 that are assigned to me
$ jira issue list -q "project NOT IN (PRJ1,PRJ2) AND assignee IN (currentUser())" 
```

Project filter with `-p` will still work for normal usecase

```sh
$ jira issue list -pPRJ2
```

