### PR TITLE
feat: Make selection highlight customizable

### DIFF
--- a/internal/cmd/epic/list/list.go
+++ b/internal/cmd/epic/list/list.go
@@ -160,6 +160,7 @@ func singleEpicView(flags query.FlagParser, key, project, projectType, server st
 				}
 				return []string{}
 			}(),
+			TableStyle: cmdutil.GetTUIStyleConfig(),
 		},
 	}
 
@@ -208,6 +209,9 @@ func epicExplorerView(flags query.FlagParser, project, projectType, server strin
 				return []*jira.Issue{}
 			}
 			return resp.Issues
+		},
+		Display: view.DisplayFormat{
+			TableStyle: cmdutil.GetTUIStyleConfig(),
 		},
 	}
 

--- a/internal/cmd/issue/list/list.go
+++ b/internal/cmd/issue/list/list.go
@@ -137,6 +137,7 @@ func loadList(cmd *cobra.Command) {
 				}
 				return []string{}
 			}(),
+			TableStyle: cmdutil.GetTUIStyleConfig(),
 		},
 	}
 

--- a/internal/cmd/sprint/list/list.go
+++ b/internal/cmd/sprint/list/list.go
@@ -165,6 +165,7 @@ func singleSprintView(flags query.FlagParser, boardID, sprintID int, project, se
 				}
 				return []string{}
 			}(),
+			TableStyle: cmdutil.GetTUIStyleConfig(),
 		},
 	}
 
@@ -226,6 +227,7 @@ func sprintExplorerView(flags query.FlagParser, boardID int, project, server str
 				}
 				return []string{}
 			}(),
+			TableStyle: cmdutil.GetTUIStyleConfig(),
 		},
 	}
 

--- a/internal/cmdutil/utils.go
+++ b/internal/cmdutil/utils.go
@@ -197,10 +197,18 @@ func GetSubtaskHandle(issueType string, issueTypes []*jira.IssueType) string {
 }
 
 // GetTUIStyleConfig returns the custom style configured by the user.
-func GetTUIStyleConfig() *tui.TableStyle {
-	return &tui.TableStyle{
+func GetTUIStyleConfig() tui.TableStyle {
+	var bold bool
+
+	if !viper.IsSet("tui.selection.bold") {
+		bold = true
+	} else {
+		bold = viper.GetBool("tui.selection.bold")
+	}
+
+	return tui.TableStyle{
 		SelectionBackground: viper.GetString("tui.selection.background"),
 		SelectionForeground: viper.GetString("tui.selection.foreground"),
-		SelectionTextIsBold: viper.GetBool("tui.selection.bold"),
+		SelectionTextIsBold: bold,
 	}
 }

--- a/internal/cmdutil/utils.go
+++ b/internal/cmdutil/utils.go
@@ -200,7 +200,7 @@ func GetSubtaskHandle(issueType string, issueTypes []*jira.IssueType) string {
 func GetTUIStyleConfig() *tui.TableStyle {
 	return &tui.TableStyle{
 		SelectionBackground: viper.GetString("tui.selection.background"),
-		SelectionForeground: viper.GetString("tui.selection.background"),
+		SelectionForeground: viper.GetString("tui.selection.foreground"),
 		SelectionTextIsBold: viper.GetBool("tui.selection.bold"),
 	}
 }

--- a/internal/cmdutil/utils.go
+++ b/internal/cmdutil/utils.go
@@ -11,9 +11,11 @@ import (
 	"github.com/briandowns/spinner"
 	"github.com/fatih/color"
 	"github.com/mitchellh/go-homedir"
+	"github.com/spf13/viper"
 
 	"github.com/ankitpokhrel/jira-cli/pkg/browser"
 	"github.com/ankitpokhrel/jira-cli/pkg/jira"
+	"github.com/ankitpokhrel/jira-cli/pkg/tui"
 )
 
 // ExitIfError exists with error message if err is not nil.
@@ -192,4 +194,13 @@ func GetSubtaskHandle(issueType string, issueTypes []*jira.IssueType) string {
 	}
 
 	return fallback
+}
+
+// GetTUIStyleConfig returns the custom style configured by the user.
+func GetTUIStyleConfig() *tui.TableStyle {
+	return &tui.TableStyle{
+		SelectionBackground: viper.GetString("tui.selection.background"),
+		SelectionForeground: viper.GetString("tui.selection.background"),
+		SelectionTextIsBold: viper.GetBool("tui.selection.bold"),
+	}
 }

--- a/internal/view/epic.go
+++ b/internal/view/epic.go
@@ -19,6 +19,7 @@ type EpicList struct {
 	Server  string
 	Data    []*jira.Issue
 	Issues  EpicIssueFunc
+	Display DisplayFormat
 }
 
 // Render renders the epic explorer view.
@@ -35,6 +36,7 @@ func (el EpicList) Render() error {
 		tui.WithInitialText(helpText),
 		tui.WithSidebarSelectedFunc(navigate(el.Server)),
 		tui.WithContentTableOpts(
+			tui.WithTableStyle(el.Display.TableStyle),
 			tui.WithSelectedFunc(navigate(el.Server)),
 			tui.WithViewModeFunc(func(r, c int, d interface{}) (func() interface{}, func(interface{}) (string, error)) {
 				dataFn := func() interface{} {

--- a/internal/view/issues.go
+++ b/internal/view/issues.go
@@ -24,7 +24,7 @@ type DisplayFormat struct {
 	NoHeaders  bool
 	NoTruncate bool
 	Columns    []string
-	TableStyle *tui.TableStyle
+	TableStyle tui.TableStyle
 }
 
 // IssueList is a list view for issues.

--- a/internal/view/issues.go
+++ b/internal/view/issues.go
@@ -24,6 +24,7 @@ type DisplayFormat struct {
 	NoHeaders  bool
 	NoTruncate bool
 	Columns    []string
+	TableStyle *tui.TableStyle
 }
 
 // IssueList is a list view for issues.
@@ -57,6 +58,7 @@ func (l *IssueList) Render() error {
 	view := tui.NewTable(
 		tui.WithColPadding(colPadding),
 		tui.WithMaxColWidth(maxColWidth),
+		tui.WithTableStyle(l.Display.TableStyle),
 		tui.WithTableFooterText(l.FooterText),
 		tui.WithSelectedFunc(navigate(l.Server)),
 		tui.WithViewModeFunc(func(r, c int, _ interface{}) (func() interface{}, func(interface{}) (string, error)) {

--- a/internal/view/sprint.go
+++ b/internal/view/sprint.go
@@ -46,6 +46,7 @@ func (sl SprintList) Render() error {
 		),
 		tui.WithInitialText(helpText),
 		tui.WithContentTableOpts(
+			tui.WithTableStyle(sl.Display.TableStyle),
 			tui.WithSelectedFunc(navigate(sl.Server)),
 			tui.WithViewModeFunc(func(r, c int, d interface{}) (func() interface{}, func(interface{}) (string, error)) {
 				dataFn := func() interface{} {
@@ -83,6 +84,7 @@ func (sl SprintList) RenderInTable() error {
 	view := tui.NewTable(
 		tui.WithColPadding(colPadding),
 		tui.WithMaxColWidth(maxColWidth),
+		tui.WithTableStyle(sl.Display.TableStyle),
 		tui.WithTableFooterText(
 			fmt.Sprintf(
 				"Showing %d results from board \"%s\" of project \"%s\"",

--- a/pkg/tui/helper.go
+++ b/pkg/tui/helper.go
@@ -85,3 +85,21 @@ func cmdExists(cmd string) bool {
 	_, err := exec.LookPath(cmd)
 	return err == nil
 }
+
+func customTUIStyle(style *TableStyle) tcell.Style {
+	if style == nil {
+		return tcell.StyleDefault.Bold(true).Dim(true)
+	}
+	bg, ok := tcell.ColorNames[style.SelectionBackground]
+	if !ok {
+		bg = tcell.ColorDefault
+	}
+	fg, ok := tcell.ColorNames[style.SelectionForeground]
+	if !ok {
+		fg = tcell.ColorDefault
+	}
+	return tcell.StyleDefault.
+		Background(bg).
+		Foreground(fg).
+		Bold(style.SelectionTextIsBold)
+}

--- a/pkg/tui/helper.go
+++ b/pkg/tui/helper.go
@@ -86,17 +86,14 @@ func cmdExists(cmd string) bool {
 	return err == nil
 }
 
-func customTUIStyle(style *TableStyle) tcell.Style {
-	if style == nil {
-		return tcell.StyleDefault.Bold(true).Dim(true)
-	}
+func customTUIStyle(style TableStyle) tcell.Style {
 	bg, ok := tcell.ColorNames[style.SelectionBackground]
 	if !ok {
 		bg = tcell.ColorDefault
 	}
 	fg, ok := tcell.ColorNames[style.SelectionForeground]
 	if !ok {
-		fg = tcell.ColorDefault
+		fg = tcell.ColorDarkOliveGreen
 	}
 	return tcell.StyleDefault.
 		Background(bg).

--- a/pkg/tui/preview.go
+++ b/pkg/tui/preview.go
@@ -275,7 +275,7 @@ func (pv *Preview) initFooter() {
 }
 
 func (pv *Preview) initLayout(view *tview.Table) {
-	view.SetSelectedStyle(tcell.StyleDefault.Bold(true).Dim(true)).
+	view.SetSelectedStyle(customTUIStyle(pv.contents.style)).
 		SetDoneFunc(func(key tcell.Key) {
 			if key == tcell.KeyEsc {
 				pv.screen.Stop()

--- a/pkg/tui/table.go
+++ b/pkg/tui/table.go
@@ -46,7 +46,7 @@ type Table struct {
 	painter      *tview.Pages
 	view         *tview.Table
 	footer       *tview.TextView
-	style        *TableStyle
+	style        TableStyle
 	data         TableData
 	colPad       uint
 	maxColWidth  uint
@@ -107,7 +107,7 @@ func WithMaxColWidth(width uint) TableOption {
 }
 
 // WithTableStyle sets the style of the table.
-func WithTableStyle(style *TableStyle) TableOption {
+func WithTableStyle(style TableStyle) TableOption {
 	return func(t *Table) {
 		t.style = style
 	}

--- a/pkg/tui/table.go
+++ b/pkg/tui/table.go
@@ -33,12 +33,20 @@ type CopyKeyFunc func(row, column int, data interface{})
 // TableData is the data to be displayed in a table.
 type TableData [][]string
 
+// TableStyle sets the style of the table.
+type TableStyle struct {
+	SelectionBackground string
+	SelectionForeground string
+	SelectionTextIsBold bool
+}
+
 // Table is a table layout.
 type Table struct {
 	screen       *Screen
 	painter      *tview.Pages
 	view         *tview.Table
 	footer       *tview.TextView
+	style        *TableStyle
 	data         TableData
 	colPad       uint
 	maxColWidth  uint
@@ -95,6 +103,13 @@ func WithColPadding(pad uint) TableOption {
 func WithMaxColWidth(width uint) TableOption {
 	return func(t *Table) {
 		t.maxColWidth = width
+	}
+}
+
+// WithTableStyle sets the style of the table.
+func WithTableStyle(style *TableStyle) TableOption {
+	return func(t *Table) {
+		t.style = style
 	}
 }
 
@@ -169,7 +184,7 @@ func (t *Table) initFooter() {
 
 func (t *Table) initTable() {
 	t.view.SetSelectable(true, false).
-		SetSelectedStyle(tcell.StyleDefault.Bold(true).Dim(true)).
+		SetSelectedStyle(customTUIStyle(t.style)).
 		SetDoneFunc(func(key tcell.Key) {
 			if key == tcell.KeyEsc {
 				t.screen.Stop()


### PR DESCRIPTION
We can now customize the UI of the selected row. List of valid colors can be found [here](https://github.com/gdamore/tcell/blob/e15e96cbcae1cd93791c337294f2cb37838b8788/color.go#L846-L991). The config needs to be added manually for now and will be overwritten if you run `jira init` again.


```yaml
tui:
  selection:
    foreground: red
    background: navy
    bold: true
```

Fixes #415 #379 