### PR TITLE
Add --summary flag to just print name of issue

### DIFF
--- a/internal/cmd/issue/view/view.go
+++ b/internal/cmd/issue/view/view.go
@@ -36,6 +36,7 @@ func NewCmdView() *cobra.Command {
 
 	cmd.Flags().Uint("comments", 1, "Show N comments")
 	cmd.Flags().Bool("plain", false, "Display output in plain mode")
+	cmd.Flags().Bool("summary", false, "Display only the summary")
 
 	return &cmd
 }
@@ -59,11 +60,13 @@ func view(cmd *cobra.Command, args []string) {
 
 	plain, err := cmd.Flags().GetBool("plain")
 	cmdutil.ExitIfError(err)
+	summary, err := cmd.Flags().GetBool("summary")
+	cmdutil.ExitIfError(err)
 
 	v := tuiView.Issue{
 		Server:  viper.GetString("server"),
 		Data:    iss,
-		Display: tuiView.DisplayFormat{Plain: plain},
+		Display: tuiView.DisplayFormat{Plain: plain, Summary: summary},
 		Options: tuiView.IssueOption{NumComments: comments},
 	}
 	cmdutil.ExitIfError(v.Render())

--- a/internal/view/issue.go
+++ b/internal/view/issue.go
@@ -55,6 +55,8 @@ type Issue struct {
 func (i Issue) Render() error {
 	if i.Display.Plain {
 		return i.renderPlain(os.Stdout)
+	} else if i.Display.Summary {
+		return i.renderSummary(os.Stdout)
 	}
 	r, err := MDRenderer()
 	if err != nil {
@@ -447,5 +449,11 @@ func (i Issue) renderPlain(w io.Writer) error {
 		return err
 	}
 	_, err = fmt.Fprint(w, out)
+	return err
+}
+
+func (i Issue) renderSummary(w io.Writer) error {
+	out := i.Data.Fields.Summary
+	_, err := fmt.Fprintln(w, out)
 	return err
 }

--- a/internal/view/issue.go
+++ b/internal/view/issue.go
@@ -52,7 +52,7 @@ type Issue struct {
 }
 
 // Render renders the view.
-func (i Issue) Render() error {
+func (i *Issue) Render() error {
 	if i.Display.Plain {
 		return i.renderPlain(os.Stdout)
 	} else if i.Display.Summary {
@@ -70,7 +70,7 @@ func (i Issue) Render() error {
 }
 
 // RenderedOut translates raw data to the format we want to display in.
-func (i Issue) RenderedOut(renderer *glamour.TermRenderer) (string, error) {
+func (i *Issue) RenderedOut(renderer *glamour.TermRenderer) (string, error) {
 	var res strings.Builder
 
 	for _, p := range i.fragments() {
@@ -88,7 +88,7 @@ func (i Issue) RenderedOut(renderer *glamour.TermRenderer) (string, error) {
 	return res.String(), nil
 }
 
-func (i Issue) String() string {
+func (i *Issue) String() string {
 	var s strings.Builder
 
 	s.WriteString(i.header())
@@ -122,7 +122,7 @@ func (i Issue) String() string {
 	return s.String()
 }
 
-func (i Issue) fragments() []fragment {
+func (i *Issue) fragments() []fragment {
 	scraps := []fragment{
 		{Body: i.header(), Parse: true},
 	}
@@ -180,7 +180,7 @@ func (i Issue) fragments() []fragment {
 	return append(scraps, newBlankFragment(1), fragment{Body: i.footer()}, newBlankFragment(2))
 }
 
-func (i Issue) separator(msg string) string {
+func (i *Issue) separator(msg string) string {
 	pad := func(m string) string {
 		if m != "" {
 			return fmt.Sprintf(" %s ", m)
@@ -199,7 +199,7 @@ func (i Issue) separator(msg string) string {
 	return gray(fmt.Sprintf("%s%s%s", sep, pad(msg), sep))
 }
 
-func (i Issue) header() string {
+func (i *Issue) header() string {
 	as := i.Data.Fields.Assignee.Name
 	if as == "" {
 		as = "Unassigned"
@@ -240,7 +240,7 @@ func (i Issue) header() string {
 	)
 }
 
-func (i Issue) description() string {
+func (i *Issue) description() string {
 	if i.Data.Fields.Description == nil {
 		return ""
 	}
@@ -257,7 +257,7 @@ func (i Issue) description() string {
 	return desc
 }
 
-func (i Issue) subtasks() string {
+func (i *Issue) subtasks() string {
 	if len(i.Data.Fields.Subtasks) == 0 {
 		return ""
 	}
@@ -303,7 +303,7 @@ func (i Issue) subtasks() string {
 	return subtasks.String()
 }
 
-func (i Issue) linkedIssues() string {
+func (i *Issue) linkedIssues() string {
 	if len(i.Data.Fields.IssueLinks) == 0 {
 		return ""
 	}
@@ -378,7 +378,7 @@ func (i Issue) linkedIssues() string {
 	return linked.String()
 }
 
-func (i Issue) comments() []issueComment {
+func (i *Issue) comments() []issueComment {
 	total := i.Data.Fields.Comment.Total
 	comments := make([]issueComment, 0, total)
 
@@ -417,7 +417,7 @@ func (i Issue) comments() []issueComment {
 	return comments
 }
 
-func (i Issue) footer() string {
+func (i *Issue) footer() string {
 	var out strings.Builder
 
 	nc := int(i.Options.NumComments)
@@ -436,7 +436,7 @@ func (i Issue) footer() string {
 }
 
 // renderPlain renders the issue in plain view.
-func (i Issue) renderPlain(w io.Writer) error {
+func (i *Issue) renderPlain(w io.Writer) error {
 	r, err := glamour.NewTermRenderer(
 		glamour.WithStandardStyle("notty"),
 		glamour.WithWordWrap(wordWrap),
@@ -452,7 +452,7 @@ func (i Issue) renderPlain(w io.Writer) error {
 	return err
 }
 
-func (i Issue) renderSummary(w io.Writer) error {
+func (i *Issue) renderSummary(w io.Writer) error {
 	out := i.Data.Fields.Summary
 	_, err := fmt.Fprintln(w, out)
 	return err

--- a/internal/view/issue_test.go
+++ b/internal/view/issue_test.go
@@ -11,69 +11,69 @@ import (
 	"github.com/ankitpokhrel/jira-cli/pkg/tui"
 )
 
+var TestData = jira.Issue{
+	Key: "TEST-1",
+	Fields: jira.IssueFields{
+		Summary: "This is a test",
+		Resolution: struct {
+			Name string `json:"name"`
+		}{Name: "Fixed"},
+		Description: &adf.ADF{
+			Version: 1,
+			DocType: "doc",
+			Content: []*adf.Node{
+				{
+					NodeType: "paragraph",
+					Content: []*adf.Node{
+						{NodeType: "text", NodeValue: adf.NodeValue{Text: "Test description"}},
+					},
+				},
+			},
+		},
+		IssueType: jira.IssueType{Name: "Bug"},
+		Assignee: struct {
+			Name string `json:"displayName"`
+		}{Name: "Person A"},
+		Priority: struct {
+			Name string `json:"name"`
+		}{Name: "High"},
+		Reporter: struct {
+			Name string `json:"displayName"`
+		}{Name: "Person Z"},
+		Status: struct {
+			Name string `json:"name"`
+		}{Name: "Done"},
+		Components: []struct {
+			Name string `json:"name"`
+		}{{Name: "BE"}, {Name: "FE"}},
+		Comment: struct {
+			Comments []struct {
+				ID      string      `json:"id"`
+				Author  jira.User   `json:"author"`
+				Body    interface{} `json:"body"`
+				Created string      `json:"created"`
+			} `json:"comments"`
+			Total int `json:"total"`
+		}{Total: 0},
+		Watches: struct {
+			IsWatching bool `json:"isWatching"`
+			WatchCount int  `json:"watchCount"`
+		}{IsWatching: true, WatchCount: 4},
+		Created: "2020-12-13T14:05:20.974+0100",
+		Updated: "2020-12-13T14:07:20.974+0100",
+	},
+}
+
+var TestIssue = Issue{
+	Server:  "https://test.local",
+	Data:    &TestData,
+	Display: DisplayFormat{Plain: true},
+}
+
 func TestIssueDetailsRenderInPlainView(t *testing.T) {
 	t.Parallel()
 
 	var b bytes.Buffer
-
-	data := &jira.Issue{
-		Key: "TEST-1",
-		Fields: jira.IssueFields{
-			Summary: "This is a test",
-			Resolution: struct {
-				Name string `json:"name"`
-			}{Name: "Fixed"},
-			Description: &adf.ADF{
-				Version: 1,
-				DocType: "doc",
-				Content: []*adf.Node{
-					{
-						NodeType: "paragraph",
-						Content: []*adf.Node{
-							{NodeType: "text", NodeValue: adf.NodeValue{Text: "Test description"}},
-						},
-					},
-				},
-			},
-			IssueType: jira.IssueType{Name: "Bug"},
-			Assignee: struct {
-				Name string `json:"displayName"`
-			}{Name: "Person A"},
-			Priority: struct {
-				Name string `json:"name"`
-			}{Name: "High"},
-			Reporter: struct {
-				Name string `json:"displayName"`
-			}{Name: "Person Z"},
-			Status: struct {
-				Name string `json:"name"`
-			}{Name: "Done"},
-			Components: []struct {
-				Name string `json:"name"`
-			}{{Name: "BE"}, {Name: "FE"}},
-			Comment: struct {
-				Comments []struct {
-					ID      string      `json:"id"`
-					Author  jira.User   `json:"author"`
-					Body    interface{} `json:"body"`
-					Created string      `json:"created"`
-				} `json:"comments"`
-				Total int `json:"total"`
-			}{Total: 0},
-			Watches: struct {
-				IsWatching bool `json:"isWatching"`
-				WatchCount int  `json:"watchCount"`
-			}{IsWatching: true, WatchCount: 4},
-			Created: "2020-12-13T14:05:20.974+0100",
-			Updated: "2020-12-13T14:07:20.974+0100",
-		},
-	}
-
-	issue := Issue{
-		Server:  "https://test.local",
-		Data:    data,
-		Display: DisplayFormat{Plain: true},
-	}
 
 	expected := "🐞 Bug  ✅ Done  ⌛ Sun, 13 Dec 20  👷 Person A  🔑️ TEST-1  💭 0 comments  \U0001F9F5 0 linked\n# This is a test\n⏱️  Sun, 13 Dec 20  🔎 Person Z  🚀 High  📦 BE, FE  🏷️  None  👀 You + 3 watchers\n\n------------------------ Description ------------------------\n\nTest description\n\n\n"
 	if xterm256() {
@@ -81,10 +81,22 @@ func TestIssueDetailsRenderInPlainView(t *testing.T) {
 	} else {
 		expected += "\x1b[0;90mView this issue on Jira: https://test.local/browse/TEST-1\x1b[0m"
 	}
-	actual := issue.String()
+	actual := TestIssue.String()
 
-	assert.NoError(t, issue.renderPlain(&b))
+	assert.NoError(t, TestIssue.renderPlain(&b))
 	assert.Equal(t, tui.TextData(expected), tui.TextData(actual))
+}
+
+func TestIssueDetailsRenderSummary(t *testing.T) {
+	t.Parallel()
+
+	var b bytes.Buffer
+
+	expected := "This is a test\n"
+
+	assert.NoError(t, TestIssue.renderSummary(&b))
+
+	assert.Equal(t, tui.TextData(expected), tui.TextData(b.String()))
 }
 
 func TestIssueDetailsWithV2Description(t *testing.T) {

--- a/internal/view/issues.go
+++ b/internal/view/issues.go
@@ -16,6 +16,7 @@ import (
 // DisplayFormat is a issue display type.
 type DisplayFormat struct {
 	Plain      bool
+	Summary    bool
 	NoHeaders  bool
 	NoTruncate bool
 	Columns    []string


### PR DESCRIPTION
Not sure if this is of interest, but I needed it and figured others might, too.

It adds a flag that causes the client to only print the summary of the issue.

eg: 
```$ jira issue view FOO-25 --summary
Do cool stuff```