### PR TITLE
feat: Allow to set start datetime on worklog add

### DIFF
--- a/internal/cmd/issue/worklog/add/add.go
+++ b/internal/cmd/issue/worklog/add/add.go
@@ -40,6 +40,10 @@ func NewCmdWorklogAdd() *cobra.Command {
 		Run: add,
 	}
 
+	cmd.Flags().SortFlags = false
+
+	cmd.Flags().String("started", "", "The datetime on which the worklog effort was started\n"+
+		"format: yyyy-MM-ddTHH:mm:ss.SSSZ, eg: 2022-01-01T09:30:00.000+0200")
 	cmd.Flags().String("comment", "", "Comment about the worklog")
 	cmd.Flags().Bool("no-input", false, "Disable prompt for non-required fields")
 
@@ -82,7 +86,7 @@ func add(cmd *cobra.Command, args []string) {
 		s := cmdutil.Info("Adding a worklog")
 		defer s.Stop()
 
-		return client.AddIssueWorklog(ac.params.issueKey, ac.params.timeSpent, ac.params.comment)
+		return client.AddIssueWorklog(ac.params.issueKey, ac.params.started, ac.params.timeSpent, ac.params.comment)
 	}()
 	cmdutil.ExitIfError(err)
 
@@ -94,6 +98,7 @@ func add(cmd *cobra.Command, args []string) {
 
 type addParams struct {
 	issueKey  string
+	started   string
 	timeSpent string
 	comment   string
 	noInput   bool
@@ -114,6 +119,9 @@ func parseArgsAndFlags(args []string, flags query.FlagParser) *addParams {
 	debug, err := flags.GetBool("debug")
 	cmdutil.ExitIfError(err)
 
+	started, err := flags.GetString("started")
+	cmdutil.ExitIfError(err)
+
 	comment, err := flags.GetString("comment")
 	cmdutil.ExitIfError(err)
 
@@ -122,6 +130,7 @@ func parseArgsAndFlags(args []string, flags query.FlagParser) *addParams {
 
 	return &addParams{
 		issueKey:  issueKey,
+		started:   started,
 		timeSpent: timeSpent,
 		comment:   comment,
 		noInput:   noInput,

--- a/pkg/jira/issue.go
+++ b/pkg/jira/issue.go
@@ -305,6 +305,7 @@ type issueWorklogRequest struct {
 }
 
 // AddIssueWorklog adds worklog to an issue using POST /issue/{key}/worklog endpoint.
+// Leave param `started` empty to use the server's current datetime as start date.
 func (c *Client) AddIssueWorklog(key, started, timeSpent, comment string) error {
 	worklogReq := issueWorklogRequest{
 		TimeSpent: timeSpent,

--- a/pkg/jira/issue.go
+++ b/pkg/jira/issue.go
@@ -299,16 +299,21 @@ func (c *Client) AddIssueComment(key, comment string) error {
 }
 
 type issueWorklogRequest struct {
+	Started   string `json:"started,omitempty"`
 	TimeSpent string `json:"timeSpent"`
 	Comment   string `json:"comment"`
 }
 
 // AddIssueWorklog adds worklog to an issue using POST /issue/{key}/worklog endpoint.
-func (c *Client) AddIssueWorklog(key, timeSpent, comment string) error {
-	body, err := json.Marshal(&issueWorklogRequest{
+func (c *Client) AddIssueWorklog(key, started, timeSpent, comment string) error {
+	worklogReq := issueWorklogRequest{
 		TimeSpent: timeSpent,
 		Comment:   md.ToJiraMD(comment),
-	})
+	}
+	if started != "" {
+		worklogReq.Started = started
+	}
+	body, err := json.Marshal(&worklogReq)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The datetime follows the format `yyyy-MM-ddTHH:mm:ss.SSSZ` expected by the Jira API (eg: `2022-01-01T09:30:00.000+0200`). This will be simplified in the subsequent PR.

```sh
jira issue worklog add ISS-1 6h --started="2022-01-01T01:02:02.000+0200"
```
