### PR TITLE
feat: Make date time input in worklog flexible

### DIFF
--- a/internal/cmdutil/datetime.go
+++ b/internal/cmdutil/datetime.go
@@ -1,0 +1,65 @@
+package cmdutil
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/ankitpokhrel/jira-cli/pkg/jira"
+)
+
+// Supported datetime layouts.
+const (
+	DateLayout          = "2006-01-02"
+	DateTimeLayout      = "2006-01-02 15:04:05"
+	ShortDateLayout     = "20060102"
+	ShortDateTimeLayout = "20060102150405"
+)
+
+var (
+	// ErrInvlalidTimezone is returned if timezone is not in a valid IANA timezone format.
+	ErrInvlalidTimezone = fmt.Errorf("timezone should be a valid IANA timezone, eg: Asia/Kathmandu or Europe/Berlin")
+	// ErrorInvalidDateTime is returned when datetime string is invalid.
+	ErrorInvalidDateTime = fmt.Errorf("datetime string should be in a valid format, eg: 2022-01-02 10:10:05 or 2022-01-02")
+)
+
+// DateStringToJiraFormatInLocation parses a standard string to jira compatible RFC3339 datetime format.
+//nolint:gomnd
+func DateStringToJiraFormatInLocation(value string, timezone string) (string, error) {
+	if _, err := time.Parse(jira.RFC3339MilliLayout, value); err == nil {
+		return value, nil
+	}
+	if value == "" || value == "0" || value == "0000-00-00 00:00:00" || value == "0000-00-00" || value == "00:00:00" {
+		return "", nil
+	}
+	layout := DateTimeLayout
+	if _, err := strconv.ParseInt(value, 10, 64); err == nil {
+		switch {
+		case len(value) == 8:
+			layout = ShortDateLayout
+		case len(value) == 14:
+			layout = ShortDateTimeLayout
+		}
+	} else if len(value) == 10 && strings.Count(value, "-") == 2 {
+		layout = DateLayout
+	}
+	t, err := parseByLayout(layout, value, timezone)
+	if err != nil {
+		return "", err
+	}
+	return t.Format(jira.RFC3339MilliLayout), nil
+}
+
+// parseByLayout parses a string as a time by layout in given timezone.
+func parseByLayout(layout, value string, timezone string) (*time.Time, error) {
+	loc, err := time.LoadLocation(timezone)
+	if err != nil {
+		return nil, ErrInvlalidTimezone
+	}
+	t, err := time.ParseInLocation(layout, value, loc)
+	if err != nil {
+		return nil, ErrorInvalidDateTime
+	}
+	return &t, nil
+}

--- a/internal/cmdutil/datetime.go
+++ b/internal/cmdutil/datetime.go
@@ -19,7 +19,7 @@ const (
 
 var (
 	// ErrInvlalidTimezone is returned if timezone is not in a valid IANA timezone format.
-	ErrInvlalidTimezone = fmt.Errorf("timezone should be a valid IANA timezone, eg: Asia/Kathmandu or Europe/Berlin")
+	ErrInvlalidTimezone = fmt.Errorf("timezone should be a valid IANA timezone, eg: Asia/Kathmandu, Europe/Berlin etc")
 	// ErrorInvalidDateTime is returned when datetime string is invalid.
 	ErrorInvalidDateTime = fmt.Errorf("datetime string should be in a valid format, eg: 2022-01-02 10:10:05 or 2022-01-02")
 )
@@ -27,12 +27,14 @@ var (
 // DateStringToJiraFormatInLocation parses a standard string to jira compatible RFC3339 datetime format.
 //nolint:gomnd
 func DateStringToJiraFormatInLocation(value string, timezone string) (string, error) {
-	if _, err := time.Parse(jira.RFC3339MilliLayout, value); err == nil {
-		return value, nil
-	}
 	if value == "" || value == "0" || value == "0000-00-00 00:00:00" || value == "0000-00-00" || value == "00:00:00" {
 		return "", nil
 	}
+
+	if _, err := time.Parse(jira.RFC3339MilliLayout, value); err == nil {
+		return value, nil
+	}
+
 	layout := DateTimeLayout
 	if _, err := strconv.ParseInt(value, 10, 64); err == nil {
 		switch {
@@ -44,6 +46,7 @@ func DateStringToJiraFormatInLocation(value string, timezone string) (string, er
 	} else if len(value) == 10 && strings.Count(value, "-") == 2 {
 		layout = DateLayout
 	}
+
 	t, err := parseByLayout(layout, value, timezone)
 	if err != nil {
 		return "", err

--- a/internal/cmdutil/datetime_test.go
+++ b/internal/cmdutil/datetime_test.go
@@ -80,7 +80,7 @@ func TestDateStringToJiraFormatInLocation(t *testing.T) {
 			input:    "2022-01-02 10:10:05",
 			timezone: "invalid",
 			expected: "",
-			err:      "timezone should be a valid IANA timezone, eg: Asia/Kathmandu or Europe/Berlin",
+			err:      "timezone should be a valid IANA timezone, eg: Asia/Kathmandu, Europe/Berlin etc",
 		},
 	}
 

--- a/internal/cmdutil/datetime_test.go
+++ b/internal/cmdutil/datetime_test.go
@@ -1,0 +1,103 @@
+package cmdutil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDateStringToJiraFormatInLocation(t *testing.T) {
+	cases := []struct {
+		name     string
+		input    string
+		timezone string
+		expected string
+		err      string
+	}{
+		{
+			name:     "it returns empty for zero value",
+			input:    "0000-00-00 00:00:00",
+			expected: "",
+		},
+		{
+			name:     "it returns the input for valid jira datetime format",
+			input:    "2022-01-01T09:30:00.000+0200",
+			expected: "2022-01-01T09:30:00.000+0200",
+		},
+		{
+			name:     "it returns valid jira datetime format for date string",
+			input:    "2022-01-02",
+			expected: "2022-01-02T00:00:00.000+0000",
+		},
+		{
+			name:     "it returns valid jira datetime format for datetime string",
+			input:    "2022-01-02 10:10:05",
+			expected: "2022-01-02T10:10:05.000+0000",
+		},
+		{
+			name:     "it can handle timezone",
+			input:    "2022-01-02 15:04:05",
+			timezone: "Asia/Kathmandu",
+			expected: "2022-01-02T15:04:05.000+0545",
+		},
+		{
+			name:     "it can detect central european time",
+			input:    "2022-01-02 10:10:05",
+			timezone: "Europe/Berlin",
+			expected: "2022-01-02T10:10:05.000+0100",
+		},
+		{
+			name:     "it can detect central european summer time",
+			input:    "2022-09-01 10:10:05",
+			timezone: "Europe/Berlin",
+			expected: "2022-09-01T10:10:05.000+0200",
+		},
+		{
+			name:     "it can handle short date format",
+			input:    "20220102",
+			expected: "2022-01-02T00:00:00.000+0000",
+		},
+		{
+			name:     "it can handle short datetime format",
+			input:    "20220102101005",
+			timezone: "Asia/Bangkok",
+			expected: "2022-01-02T10:10:05.000+0700",
+		},
+		{
+			name:     "it returns error for input in invalid format",
+			input:    "2022-01-02T15:04:05",
+			expected: "",
+			err:      "datetime string should be in a valid format, eg: 2022-01-02 10:10:05 or 2022-01-02",
+		},
+		{
+			name:     "it returns error for completely invalid format",
+			input:    "invalid",
+			expected: "",
+			err:      "datetime string should be in a valid format, eg: 2022-01-02 10:10:05 or 2022-01-02",
+		},
+		{
+			name:     "it returns error for invalid timezone",
+			input:    "2022-01-02 10:10:05",
+			timezone: "invalid",
+			expected: "",
+			err:      "timezone should be a valid IANA timezone, eg: Asia/Kathmandu or Europe/Berlin",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			dt, err := DateStringToJiraFormatInLocation(tc.input, tc.timezone)
+			if tc.err != "" {
+				assert.NotNil(t, err)
+				assert.Equal(t, tc.err, err.Error())
+			} else {
+				assert.Nil(t, err)
+			}
+			assert.Equal(t, tc.expected, dt)
+		})
+	}
+}

--- a/pkg/jira/client.go
+++ b/pkg/jira/client.go
@@ -16,6 +16,8 @@ import (
 const (
 	// RFC3339 is jira datetime format.
 	RFC3339 = "2006-01-02T15:04:05-0700"
+	// RFC3339MilliLayout is jira datetime format with milliseconds.
+	RFC3339MilliLayout = "2006-01-02T15:04:05.000-0700"
 
 	// InstallationTypeCloud represents Jira cloud server.
 	InstallationTypeCloud = "Cloud"


### PR DESCRIPTION
Relates to #453

We can now use regular date/datetime string for `started` flag in worklog add.

```sh
# You can add a worklog with the specific start date (defaults to UTC timezone)
$ jira issue worklog add ISSUE-1 "2d 1h 30m" --started "2022-01-01 09:30:00"

# You can specify timezone to use along with the start date in IANA timezone format
$ jira issue worklog add ISSUE-1 3h --started "2022-01-01 09:30:00" --timezone "Europe/Berlin"

# Or, you can use start date in Jira datetime format and skip the timezone flag
$ jira issue worklog add ISSUE-1 "1h 30m" --started "2022-01-01T09:30:00.000+0200"
```

