### PR TITLE
fix: Option to show issues from all projects in sprint list

### DIFF
--- a/internal/query/issue.go
+++ b/internal/query/issue.go
@@ -49,8 +49,8 @@ func (i *Issue) Get() string {
 		obf = "updated"
 	}
 
-	if i.params.jql != "" {
-		q.Raw(i.params.jql)
+	if i.params.JQL != "" {
+		q.Raw(i.params.JQL)
 	}
 
 	q.And(func() {
@@ -162,8 +162,8 @@ type IssueParams struct {
 	Reverse       bool
 	From          uint
 	Limit         uint
+	JQL           string
 
-	jql   string
 	debug bool
 }
 
@@ -260,7 +260,7 @@ func (ip *IssueParams) setStringParams(paramsMap map[string]string) {
 		case "updated-before":
 			ip.UpdatedBefore = v
 		case "jql":
-			ip.jql = v
+			ip.JQL = v
 		case "order-by":
 			ip.OrderBy = v
 		}

--- a/internal/query/sprint.go
+++ b/internal/query/sprint.go
@@ -54,12 +54,13 @@ func (s *Sprint) Params() *SprintParams {
 
 // SprintParams is sprint command parameters.
 type SprintParams struct {
-	Status  string
-	Current bool
-	Prev    bool
-	Next    bool
-	From    uint
-	Limit   uint
+	Status        string
+	Current       bool
+	Prev          bool
+	Next          bool
+	From          uint
+	Limit         uint
+	ShowAllIssues bool
 
 	debug bool
 }
@@ -88,6 +89,12 @@ func (sp *SprintParams) init(flags FlagParser) error {
 		return err
 	}
 	sp.Next = next
+
+	showAll, err := flags.GetBool("show-all-issues")
+	if err != nil {
+		return err
+	}
+	sp.ShowAllIssues = showAll
 
 	paginate, err := flags.GetString("paginate")
 	if err != nil {

--- a/pkg/jira/sprint.go
+++ b/pkg/jira/sprint.go
@@ -93,8 +93,8 @@ func (c *Client) SprintsInBoards(boardIDs []int, qp string, limit int) []*Sprint
 }
 
 // SprintIssues fetches issues in the given sprint.
-func (c *Client) SprintIssues(boardID, sprintID int, jql string, from, limit uint) (*SearchResult, error) {
-	path := fmt.Sprintf("/board/%d/sprint/%d/issue?startAt=%d&maxResults=%d", boardID, sprintID, from, limit)
+func (c *Client) SprintIssues(sprintID int, jql string, from, limit uint) (*SearchResult, error) {
+	path := fmt.Sprintf("/sprint/%d/issue?startAt=%d&maxResults=%d", sprintID, from, limit)
 	if jql != "" {
 		path += fmt.Sprintf("&jql=%s", url.QueryEscape(jql))
 	}

--- a/pkg/jira/sprint_test.go
+++ b/pkg/jira/sprint_test.go
@@ -190,7 +190,7 @@ func TestSprintIssues(t *testing.T) {
 	var unexpectedStatusCode bool
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "/rest/agile/1.0/board/1/sprint/2/issue", r.URL.Path)
+		assert.Equal(t, "/rest/agile/1.0/sprint/2/issue", r.URL.Path)
 
 		qs := r.URL.Query()
 
@@ -215,7 +215,7 @@ func TestSprintIssues(t *testing.T) {
 
 	client := NewClient(Config{Server: server.URL}, WithTimeout(3*time.Second))
 
-	actual, err := client.SprintIssues(1, 2, "project=TEST AND status=Done ORDER BY created DESC", 0, 100)
+	actual, err := client.SprintIssues(2, "project=TEST AND status=Done ORDER BY created DESC", 0, 100)
 	assert.NoError(t, err)
 
 	expected := &SearchResult{
@@ -304,7 +304,7 @@ func TestSprintIssues(t *testing.T) {
 
 	unexpectedStatusCode = true
 
-	_, err = client.SprintIssues(1, 2, "project=TEST", 0, 100)
+	_, err = client.SprintIssues(2, "project=TEST", 0, 100)
 	assert.Error(t, &ErrUnexpectedResponse{}, err)
 }
 


### PR DESCRIPTION
Fixes #429

This PR updates `jira sprint list` to list issues from all projects if `--show-all-issues` flag is provided. By default, the command only shows issues for the given/configured project.

```sh
$ jira sprint list --show-all-issues

$ jira sprint list <sprint-id> --show-all-issues
```