### PR TITLE
feat: Resolution, assignee & comment on issue move

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,6 +426,17 @@ $ jira issue move ISSUE-1 "In Progress"
 
 ![Move an issue](.github/assets/move.gif)
 
+If your workflow allows to add comment, resolution or assignee while moving an issue, you can do so as shown below.
+See [this documentation](https://confluence.atlassian.com/jirakb/how-to-add-a-comment-during-a-transition-779160682.html) on how to setup your workflow to allow these fields.
+
+```sh
+# Move an issue and add comment
+$ jira issue move ISSUE-1 "In Progress" --comment "Started working on it"
+
+# Set resolution to fixed and assign to self while moving the issue
+$ jira issue move ISSUE-1 Done -rFixed -a$(jira me)
+```
+
 #### View
 The `view` command lets you see issue details in a terminal. Atlassian document is roughly converted to a markdown
 and is nicely displayed in the terminal.

--- a/README.md
+++ b/README.md
@@ -434,7 +434,7 @@ See [this documentation](https://confluence.atlassian.com/jirakb/how-to-add-a-co
 $ jira issue move ISSUE-1 "In Progress" --comment "Started working on it"
 
 # Set resolution to fixed and assign to self while moving the issue
-$ jira issue move ISSUE-1 Done -rFixed -a$(jira me)
+$ jira issue move ISSUE-1 Done -RFixed -a$(jira me)
 ```
 
 #### View

--- a/pkg/jira/transition.go
+++ b/pkg/jira/transition.go
@@ -7,14 +7,14 @@ import (
 	"net/http"
 )
 
-// TransitionRequest struct holds request data for transition request.
+// TransitionRequest struct holds request data for issue transition request.
 type TransitionRequest struct {
 	Update     *TransitionRequestUpdate `json:"update,omitempty"`
 	Fields     *TransitionRequestFields `json:"fields,omitempty"`
 	Transition *TransitionRequestData   `json:"transition"`
 }
 
-// TransitionRequestUpdate struct holds update request data for transition request.
+// TransitionRequestUpdate struct holds a list of operations to perform on the issue screen field.
 type TransitionRequestUpdate struct {
 	Comment []struct {
 		Add struct {
@@ -23,7 +23,7 @@ type TransitionRequestUpdate struct {
 	} `json:"comment,omitempty"`
 }
 
-// TransitionRequestFields struct holds transition fields to update for transition request.
+// TransitionRequestFields struct holds a list of issue screen fields to update along with sub-fields.
 type TransitionRequestFields struct {
 	Assignee *struct {
 		Name string `json:"name"`

--- a/pkg/jira/transition.go
+++ b/pkg/jira/transition.go
@@ -9,7 +9,28 @@ import (
 
 // TransitionRequest struct holds request data for transition request.
 type TransitionRequest struct {
-	Transition *TransitionRequestData `json:"transition"`
+	Update     *TransitionRequestUpdate `json:"update,omitempty"`
+	Fields     *TransitionRequestFields `json:"fields,omitempty"`
+	Transition *TransitionRequestData   `json:"transition"`
+}
+
+// TransitionRequestUpdate struct holds update request data for transition request.
+type TransitionRequestUpdate struct {
+	Comment []struct {
+		Add struct {
+			Body string `json:"body"`
+		} `json:"add"`
+	} `json:"comment,omitempty"`
+}
+
+// TransitionRequestFields struct holds transition fields to update for transition request.
+type TransitionRequestFields struct {
+	Assignee *struct {
+		Name string `json:"name"`
+	} `json:"assignee,omitempty"`
+	Resolution *struct {
+		Name string `json:"name"`
+	} `json:"resolution,omitempty"`
 }
 
 // TransitionRequestData is a transition request data.


### PR DESCRIPTION
This PR adds an option to set Resolution, Assignee and Comment when moving the issue. Note that these fields needs to be available in the Workflow to work, else it will be ignored.

See: https://confluence.atlassian.com/jirakb/how-to-add-a-comment-during-a-transition-779160682.html

```sh
$ jira issue move ISS-1 Done --comment "Example comment"
$ jira issue move ISS-1 Done -R Fixed
```