### PR TITLE
feat: allow setting of fixed columns in the list of issues, epics and sprints

### DIFF
--- a/internal/cmd/epic/list/list.go
+++ b/internal/cmd/epic/list/list.go
@@ -139,6 +139,9 @@ func singleEpicView(flags query.FlagParser, key, project, projectType, server st
 	noTruncate, err := flags.GetBool("no-truncate")
 	cmdutil.ExitIfError(err)
 
+	fixedColumns, err := flags.GetUint("fixed-columns")
+	cmdutil.ExitIfError(err)
+
 	columns, err := flags.GetString("columns")
 	cmdutil.ExitIfError(err)
 
@@ -151,9 +154,10 @@ func singleEpicView(flags query.FlagParser, key, project, projectType, server st
 			singleEpicView(flags, key, project, projectType, server, client)
 		},
 		Display: view.DisplayFormat{
-			Plain:      plain,
-			NoHeaders:  noHeaders,
-			NoTruncate: noTruncate,
+			Plain:        plain,
+			NoHeaders:    noHeaders,
+			NoTruncate:   noTruncate,
+			FixedColumns: fixedColumns,
 			Columns: func() []string {
 				if columns != "" {
 					return strings.Split(columns, ",")
@@ -189,6 +193,9 @@ func epicExplorerView(flags query.FlagParser, project, projectType, server strin
 		return
 	}
 
+	fixedColumns, err := flags.GetUint("fixed-columns")
+	cmdutil.ExitIfError(err)
+
 	v := view.EpicList{
 		Total:   total,
 		Project: project,
@@ -211,7 +218,8 @@ func epicExplorerView(flags query.FlagParser, project, projectType, server strin
 			return resp.Issues
 		},
 		Display: view.DisplayFormat{
-			TableStyle: cmdutil.GetTUIStyleConfig(),
+			FixedColumns: fixedColumns,
+			TableStyle:   cmdutil.GetTUIStyleConfig(),
 		},
 	}
 

--- a/internal/cmd/issue/list/list.go
+++ b/internal/cmd/issue/list/list.go
@@ -116,6 +116,9 @@ func loadList(cmd *cobra.Command) {
 	noTruncate, err := cmd.Flags().GetBool("no-truncate")
 	cmdutil.ExitIfError(err)
 
+	fixedColumns, err := cmd.Flags().GetUint("fixed-columns")
+	cmdutil.ExitIfError(err)
+
 	columns, err := cmd.Flags().GetString("columns")
 	cmdutil.ExitIfError(err)
 
@@ -128,9 +131,10 @@ func loadList(cmd *cobra.Command) {
 			loadList(cmd)
 		},
 		Display: view.DisplayFormat{
-			Plain:      plain,
-			NoHeaders:  noHeaders,
-			NoTruncate: noTruncate,
+			Plain:        plain,
+			NoHeaders:    noHeaders,
+			NoTruncate:   noTruncate,
+			FixedColumns: fixedColumns,
 			Columns: func() []string {
 				if columns != "" {
 					return strings.Split(columns, ",")
@@ -178,6 +182,7 @@ func SetFlags(cmd *cobra.Command) {
 	cmd.Flags().Bool("plain", false, "Display output in plain mode")
 	cmd.Flags().Bool("no-headers", false, "Don't display table headers in plain mode. Works only with --plain")
 	cmd.Flags().Bool("no-truncate", false, "Show all available columns in plain mode. Works only with --plain")
+	cmd.Flags().Uint("fixed-columns", 1, "Number of fixed columns in the interactive mode.")
 
 	if cmd.HasParent() && cmd.Parent().Name() != "sprint" {
 		cmd.Flags().String("columns", "", "Comma separated list of columns to display in the plain mode.\n"+

--- a/internal/cmd/sprint/list/list.go
+++ b/internal/cmd/sprint/list/list.go
@@ -126,6 +126,9 @@ func singleSprintView(sprintQuery *query.Sprint, flags query.FlagParser, boardID
 	noTruncate, err := flags.GetBool("no-truncate")
 	cmdutil.ExitIfError(err)
 
+	fixedColumns, err := flags.GetUint("fixed-columns")
+	cmdutil.ExitIfError(err)
+
 	columns, err := flags.GetString("columns")
 	cmdutil.ExitIfError(err)
 
@@ -161,9 +164,10 @@ func singleSprintView(sprintQuery *query.Sprint, flags query.FlagParser, boardID
 			singleSprintView(sprintQuery, flags, boardID, sprintID, project, server, client, nil)
 		},
 		Display: view.DisplayFormat{
-			Plain:      plain,
-			NoHeaders:  noHeaders,
-			NoTruncate: noTruncate,
+			Plain:        plain,
+			NoHeaders:    noHeaders,
+			NoTruncate:   noTruncate,
+			FixedColumns: fixedColumns,
 			Columns: func() []string {
 				if columns != "" {
 					return strings.Split(columns, ",")
@@ -205,6 +209,9 @@ func sprintExplorerView(sprintQuery *query.Sprint, flags query.FlagParser, board
 	noHeaders, err := flags.GetBool("no-headers")
 	cmdutil.ExitIfError(err)
 
+	fixedColumns, err := flags.GetUint("fixed-columns")
+	cmdutil.ExitIfError(err)
+
 	columns, err := flags.GetString("columns")
 	cmdutil.ExitIfError(err)
 
@@ -225,8 +232,9 @@ func sprintExplorerView(sprintQuery *query.Sprint, flags query.FlagParser, board
 			return resp.Issues
 		},
 		Display: view.DisplayFormat{
-			Plain:     plain,
-			NoHeaders: noHeaders,
+			Plain:        plain,
+			NoHeaders:    noHeaders,
+			FixedColumns: fixedColumns,
 			Columns: func() []string {
 				if columns != "" {
 					return strings.Split(columns, ",")

--- a/internal/view/epic.go
+++ b/internal/view/epic.go
@@ -37,6 +37,7 @@ func (el *EpicList) Render() error {
 		tui.WithSidebarSelectedFunc(navigate(el.Server)),
 		tui.WithContentTableOpts(
 			tui.WithTableStyle(el.Display.TableStyle),
+			tui.WithFixedColumns(el.Display.FixedColumns),
 			tui.WithSelectedFunc(navigate(el.Server)),
 			tui.WithViewModeFunc(func(r, c int, d interface{}) (func() interface{}, func(interface{}) (string, error)) {
 				dataFn := func() interface{} {

--- a/internal/view/issues.go
+++ b/internal/view/issues.go
@@ -15,11 +15,12 @@ import (
 
 // DisplayFormat is a issue display type.
 type DisplayFormat struct {
-	Plain      bool
-	NoHeaders  bool
-	NoTruncate bool
-	Columns    []string
-	TableStyle tui.TableStyle
+	Plain        bool
+	NoHeaders    bool
+	NoTruncate   bool
+	Columns      []string
+	FixedColumns uint
+	TableStyle   tui.TableStyle
 }
 
 // IssueList is a list view for issues.
@@ -73,6 +74,7 @@ func (l *IssueList) Render() error {
 		tui.WithCopyFunc(copyURL(l.Server)),
 		tui.WithCopyKeyFunc(copyKey()),
 		tui.WithRefreshFunc(l.Refresh),
+		tui.WithFixedColumns(l.Display.FixedColumns),
 	)
 
 	return view.Paint(data)

--- a/internal/view/sprint.go
+++ b/internal/view/sprint.go
@@ -46,6 +46,7 @@ func (sl *SprintList) Render() error {
 		),
 		tui.WithInitialText(helpText),
 		tui.WithContentTableOpts(
+			tui.WithFixedColumns(sl.Display.FixedColumns),
 			tui.WithTableStyle(sl.Display.TableStyle),
 			tui.WithSelectedFunc(navigate(sl.Server)),
 			tui.WithViewModeFunc(func(r, c int, d interface{}) (func() interface{}, func(interface{}) (string, error)) {
@@ -82,6 +83,7 @@ func (sl *SprintList) RenderInTable() error {
 
 	data := sl.tableData()
 	view := tui.NewTable(
+		tui.WithFixedColumns(sl.Display.FixedColumns),
 		tui.WithTableStyle(sl.Display.TableStyle),
 		tui.WithTableFooterText(
 			fmt.Sprintf(

--- a/pkg/tui/preview.go
+++ b/pkg/tui/preview.go
@@ -282,7 +282,7 @@ func (pv *Preview) initLayout(view *tview.Table) {
 			}
 		})
 
-	view.SetFixed(1, 1)
+	view.SetFixed(1, int(pv.contents.colFixed))
 }
 
 func (pv *Preview) printText(s string) {

--- a/pkg/tui/table.go
+++ b/pkg/tui/table.go
@@ -49,6 +49,7 @@ type Table struct {
 	style        TableStyle
 	data         TableData
 	colPad       uint
+	colFixed     uint
 	maxColWidth  uint
 	footerText   string
 	selectedFunc SelectedFunc
@@ -141,6 +142,13 @@ func WithCopyKeyFunc(fn CopyKeyFunc) TableOption {
 	}
 }
 
+// WithFixedColumns sets the number of columns that are locked (do not scroll right).
+func WithFixedColumns(cols uint) TableOption {
+	return func(t *Table) {
+		t.colFixed = cols
+	}
+}
+
 // Paint paints the table layout. First row is treated as a table header.
 func (t *Table) Paint(data TableData) error {
 	if len(data) == 0 {
@@ -229,7 +237,7 @@ func (t *Table) initTable() {
 			return ev
 		})
 
-	t.view.SetFixed(1, 1)
+	t.view.SetFixed(1, int(t.colFixed))
 }
 
 func renderTableHeader(t *Table, data []string) {


### PR DESCRIPTION
Allow setting the number of locked (not scrolling) columns in the issue list, epic list and sprint list.

You can do e.g.:
```
jira issues list -s~Closed --fixed-columns 2
```

And the "Type" and "KEY" columns will not disappear as you press the right arrow.
