### PR TITLE
ehc: Remove viper dependency from pkg

### DIFF
--- a/internal/cmd/issue/create/create.go
+++ b/internal/cmd/issue/create/create.go
@@ -145,6 +145,9 @@ func create(cmd *cobra.Command, _ []string) {
 			EpicField:      viper.GetString("epic.link"),
 		}
 		cr.ForProjectType(projectType)
+		if configuredCustomFields, err := cmdcommon.GetConfiguredCustomFields(); err == nil {
+			cr.WithCustomFields(configuredCustomFields)
+		}
 
 		if handle := cmdutil.GetSubtaskHandle(params.issueType, cc.issueTypes); handle != "" {
 			cr.SubtaskField = handle

--- a/internal/cmd/issue/edit/edit.go
+++ b/internal/cmd/issue/edit/edit.go
@@ -140,6 +140,9 @@ func edit(cmd *cobra.Command, args []string) {
 			FixVersions:    fixVersions,
 			CustomFields:   params.customFields,
 		}
+		if configuredCustomFields, err := cmdcommon.GetConfiguredCustomFields(); err == nil {
+			edr.WithCustomFields(configuredCustomFields)
+		}
 
 		return client.Edit(params.issueKey, &edr)
 	}()

--- a/internal/cmdcommon/create.go
+++ b/internal/cmdcommon/create.go
@@ -3,6 +3,9 @@ package cmdcommon
 import (
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/ankitpokhrel/jira-cli/pkg/jira"
 )
 
 const (
@@ -108,4 +111,16 @@ func GetMetadataQuestions(cat []string) []*survey.Question {
 	}
 
 	return qs
+}
+
+// GetConfiguredCustomFields returns the custom fields configured by the user.
+func GetConfiguredCustomFields() ([]jira.IssueTypeField, error) {
+	var configuredFields []jira.IssueTypeField
+
+	err := viper.UnmarshalKey("issue.fields.custom", &configuredFields)
+	if err != nil {
+		return nil, err
+	}
+
+	return configuredFields, nil
 }

--- a/pkg/jira/create.go
+++ b/pkg/jira/create.go
@@ -180,12 +180,12 @@ func (*Client) getRequestData(req *CreateRequest) *createRequest {
 		}
 		data.Fields.M.FixVersions = versions
 	}
-	constructCustomFields(req.CustomFields, &data, req.configuredCustomFields)
+	constructCustomFields(req.CustomFields, req.configuredCustomFields, &data)
 
 	return &data
 }
 
-func constructCustomFields(fields map[string]string, data *createRequest, configuredFields []IssueTypeField) {
+func constructCustomFields(fields map[string]string, configuredFields []IssueTypeField, data *createRequest) {
 	if len(fields) == 0 || len(configuredFields) == 0 {
 		return
 	}

--- a/pkg/jira/edit.go
+++ b/pkg/jira/edit.go
@@ -6,8 +6,6 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
-
-	"github.com/spf13/viper"
 )
 
 const separatorMinus = "-"
@@ -32,6 +30,13 @@ type EditRequest struct {
 	// CustomFields holds all custom fields passed
 	// while editing the issue.
 	CustomFields map[string]string
+
+	configuredCustomFields []IssueTypeField
+}
+
+// WithCustomFields sets valid custom fields for the issue.
+func (er *EditRequest) WithCustomFields(cf []IssueTypeField) {
+	er.configuredCustomFields = cf
 }
 
 // Edit updates an issue using POST /issue endpoint.
@@ -294,20 +299,13 @@ func getRequestDataForEdit(req *EditRequest) *editRequest {
 		Update: update,
 		Fields: fields,
 	}
-	constructCustomFieldsForEdit(req.CustomFields, &data)
+	constructCustomFieldsForEdit(req.CustomFields, &data, req.configuredCustomFields)
 
 	return &data
 }
 
-func constructCustomFieldsForEdit(fields map[string]string, data *editRequest) {
-	if len(fields) == 0 {
-		return
-	}
-
-	var configuredFields []IssueTypeField
-
-	err := viper.UnmarshalKey("issue.fields.custom", &configuredFields)
-	if err != nil || len(configuredFields) == 0 {
+func constructCustomFieldsForEdit(fields map[string]string, data *editRequest, configuredFields []IssueTypeField) {
+	if len(fields) == 0 || len(configuredFields) == 0 {
 		return
 	}
 

--- a/pkg/jira/edit.go
+++ b/pkg/jira/edit.go
@@ -299,12 +299,12 @@ func getRequestDataForEdit(req *EditRequest) *editRequest {
 		Update: update,
 		Fields: fields,
 	}
-	constructCustomFieldsForEdit(req.CustomFields, &data, req.configuredCustomFields)
+	constructCustomFieldsForEdit(req.CustomFields, req.configuredCustomFields, &data)
 
 	return &data
 }
 
-func constructCustomFieldsForEdit(fields map[string]string, data *editRequest, configuredFields []IssueTypeField) {
+func constructCustomFieldsForEdit(fields map[string]string, configuredFields []IssueTypeField, data *editRequest) {
 	if len(fields) == 0 || len(configuredFields) == 0 {
 		return
 	}


### PR DESCRIPTION
This PR removes `viper` dependency from pkg. The configuration is passed from the higher layer to keep the package more usable.
