### PR TITLE
ehc: Make assignee operation atomic on create

### DIFF
--- a/internal/cmdcommon/create.go
+++ b/internal/cmdcommon/create.go
@@ -157,3 +157,12 @@ Invalid custom fields used in the command: %s`,
 		)
 	}
 }
+
+// GetUserKeyForConfiguredInstallation returns either the user name or account ID based on jira installation type.
+func GetUserKeyForConfiguredInstallation(user *jira.User) string {
+	it := viper.GetString("installation")
+	if it == jira.InstallationTypeLocal {
+		return user.Name
+	}
+	return user.AccountID
+}


### PR DESCRIPTION
Instead of setting assignee in a different API call after creating an issue/epic, we can do it in a single request.
