### PR TITLE
fix(build): Invalid commit hash in docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,2 @@
-.github
-.gocache
+vendor/
+.gocache/

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,4 +1,5 @@
 name: Publish a Docker image
+run-name: Docker image for ${{ github.ref_name }}
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
The commit hash is determined [using this command](https://github.com/ankitpokhrel/jira-cli/blob/7015c54fd31a23866a7f1e7bd44fc2f3c2893fb1/Makefile#L16-L17) during the build process. This is fine and works well. However, the docker image built in the CI has invalid git commit hash. 

```sh
$ jira version
(Version="1.2.0", GitCommit="9d8a0afd75b68aa519367f93c240429117cc4090", CommitDate="2022-12-16T10:53:08+00:00", GoVersion="go1.18.3", Compiler="gc", Platform="darwin/amd64")

$ docker run -it --rm ghcr.io/ankitpokhrel/jira-cli:latest
~ # jira version
(Version="v1.2.0", GitCommit="4ae631faa92d59052320464d09e0f34842c5f971", CommitDate="2022-12-17T10:21:57+00:00", GoVersion="go1.17.11", Compiler="gc", Platform="linux/amd64")

$ git show 4ae631faa92d59052320464d09e0f34842c5f971
fatal: bad object 4ae631faa92d59052320464d09e0f34842c5f971
```

This happens because we are ignoring `.github` directory in [.dockerignore](https://github.com/ankitpokhrel/jira-cli/blob/7015c54fd31a23866a7f1e7bd44fc2f3c2893fb1/.dockerignore#L1). This results in creation of stash ref with a different hash each time we create a build in a CI.

![Screen Shot 2022-12-21 at 4 43 48 PM](https://user-images.githubusercontent.com/2364546/208950576-06222d4c-4ccf-41ef-b3a1-a6d183a6642b.png)

This PR fixes the above mentioned issue.
