### PR TITLE
fix: Shell completion for Fish and PowerShell

### DIFF
--- a/internal/cmd/completion/completion.go
+++ b/internal/cmd/completion/completion.go
@@ -56,13 +56,17 @@ func NewCmdCompletion() *cobra.Command {
 		Long:                  helpText,
 		DisableFlagsInUseLine: true,
 		ValidArgs:             []string{"bash", "zsh", "fish", "powershell"},
-		Args:                  cobra.ExactValidArgs(1),
+		Args:                  cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
 		Run: func(cmd *cobra.Command, args []string) {
 			switch args[0] {
 			case "bash":
 				_ = cmd.Root().GenBashCompletion(os.Stdout)
 			case "zsh":
 				_ = cmd.Root().GenZshCompletion(os.Stdout)
+			case "fish":
+				_ = cmd.Root().GenFishCompletion(os.Stdout, true)
+			case "powershell":
+				_ = cmd.Root().GenPowerShellCompletion(os.Stdout)
 			}
 		},
 	}


### PR DESCRIPTION
Fixes #552
