### PR TITLE
fix: Worklog comment don't work together with prompt

### DIFF
--- a/internal/cmd/issue/worklog/add/add.go
+++ b/internal/cmd/issue/worklog/add/add.go
@@ -78,7 +78,9 @@ func add(cmd *cobra.Command, args []string) {
 		if params.timeSpent == "" {
 			params.timeSpent = ans.TimeSpent
 		}
-		params.comment = ans.Comment
+		if ans.Comment != "" {
+			params.comment = ans.Comment
+		}
 	}
 
 	if !params.noInput {


### PR DESCRIPTION
Fixes #561
