### PR TITLE
Try to detect if JIRA v8 server is not using the Createmeta REST endpoint

### DIFF
--- a/internal/config/generator.go
+++ b/internal/config/generator.go
@@ -475,10 +475,10 @@ func (c *JiraCLIConfigGenerator) configureMetadata() error {
 		err = c.configureIssueTypes()
 		if err != nil {
 			switch e := err.(type) {
-				case *url.Error:
-					if e.Err.Error() == "303 response missing Location header" && c.value.version.major == 8 && c.value.version.minor >= 4 {
-						err = c.configureIssueTypesForJiraServerV9()
-					}
+			case *url.Error:
+				if e.Err.Error() == "303 response missing Location header" && c.value.version.major == 8 && c.value.version.minor >= 4 {
+					err = c.configureIssueTypesForJiraServerV9()
+				}
 			}
 		}
 	}

--- a/internal/config/generator.go
+++ b/internal/config/generator.go
@@ -474,8 +474,7 @@ func (c *JiraCLIConfigGenerator) configureMetadata() error {
 	} else {
 		err = c.configureIssueTypes()
 		if err != nil {
-			switch e := err.(type) {
-			case *url.Error:
+			if e, ok := err.(*url.Error); ok {
 				if e.Err.Error() == "303 response missing Location header" && c.value.version.major == 8 && c.value.version.minor >= 4 {
 					err = c.configureIssueTypesForJiraServerV9()
 				}

--- a/internal/config/generator.go
+++ b/internal/config/generator.go
@@ -473,6 +473,14 @@ func (c *JiraCLIConfigGenerator) configureMetadata() error {
 		err = c.configureIssueTypesForJiraServerV9()
 	} else {
 		err = c.configureIssueTypes()
+		if err != nil {
+			switch e := err.(type) {
+				case *url.Error:
+					if e.Err.Error() == "303 response missing Location header" && c.value.version.major == 8 && c.value.version.minor >= 4 {
+						err = c.configureIssueTypesForJiraServerV9()
+					}
+			}
+		}
 	}
 	if err != nil {
 		return err

--- a/internal/config/generator.go
+++ b/internal/config/generator.go
@@ -469,17 +469,11 @@ func (c *JiraCLIConfigGenerator) searchAndAssignBoard(project, keyword string) e
 func (c *JiraCLIConfigGenerator) configureMetadata() error {
 	var err error
 
-	if c.value.installation == jira.InstallationTypeLocal && c.value.version.major >= 9 {
+	isV9Compatible := c.value.version.major >= 9 || (c.value.version.major == 8 && c.value.version.minor > 4)
+	if c.value.installation == jira.InstallationTypeLocal && isV9Compatible {
 		err = c.configureIssueTypesForJiraServerV9()
 	} else {
 		err = c.configureIssueTypes()
-		if err != nil {
-			if e, ok := err.(*url.Error); ok {
-				if e.Err.Error() == "303 response missing Location header" && c.value.version.major == 8 && c.value.version.minor >= 4 {
-					err = c.configureIssueTypesForJiraServerV9()
-				}
-			}
-		}
 	}
 	if err != nil {
 		return err


### PR DESCRIPTION
When I try to log into our JIRA instance, I get:
```
⠸ Verifying login details...

REQUEST DETAILS
------------------------------------------------------------

GET /rest/api/2/myself HTTP/1.1
Host: jira.instance
Authorization: Basic AAAAAAAAAAAAAAaaaaaaaaaaaaaaaaaa1111111

⠙ Fetching server details...

REQUEST DETAILS
------------------------------------------------------------

GET /rest/api/2/serverInfo HTTP/1.1
Host: jira.instance
Authorization: Basic AAAAAAAAAAAAAAaaaaaaaaaaaaaaaaaa1111111

⠹ Fetching projects...

REQUEST DETAILS
------------------------------------------------------------

GET /rest/api/2/project?expand=lead HTTP/1.1
Host: jira.instance
Authorization: Basic AAAAAAAAAAAAAAaaaaaaaaaaaaaaaaaa1111111

⠹ Fetching boards for project 'CD'...

REQUEST DETAILS
------------------------------------------------------------

GET /rest/agile/1.0/board?projectKeyOrId=CD HTTP/1.1
Host: jira.instance
Authorization: Basic AAAAAAAAAAAAAAaaaaaaaaaaaaaaaaaa1111111

⠹ Configuring metadata. Please wait...

REQUEST DETAILS
------------------------------------------------------------

GET /rest/api/2/issue/createmeta?projectKeys=CD&expand=projects.issuetypes.fields HTTP/1.1
Host: jira.instance
Authorization: Basic AAAAAAAAAAAAAAaaaaaaaaaaaaaaaaaa1111111


✗ Unable to generate configuration: Get "https://jira.instance/rest/api/2/issue/createmeta?projectKeys=CD&expand=projects.issuetypes.fields": 303 response missing Location header

```

This is with commit 6085aeedf5653ac370b2d4eb86a327049f763722, committed on February 13th.

When I attempted to try the last endpoint (`/rest/api/2/issue/createmeta?projectKeys=CD&expand=projects.issuetypes.fields`)  myself in a browser manually, I get:
```
This endpoint is disabled by the administrator. Please refer to https://confluence.atlassian.com/adminjira/createmeta-rest-endpoint-to-be-removed-975014604.html
```

The behavior of our v8 instance matches the default behavior of JIRA v9, which the CLI already accomodates. This tries to detect if the v9 behavior should be used for v8.
