### PR TITLE
Allow API endpoint to be separate from web client endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ bin/
 coverage/
 vendor/
 /.gocache
+
+.vscode/

--- a/internal/cmd/epic/add/add.go
+++ b/internal/cmd/epic/add/add.go
@@ -96,7 +96,7 @@ func add(cmd *cobra.Command, args []string) {
 		return nil
 	}()
 
-	msg := fmt.Sprintf("Issues added to the epic %s\n%s/browse/%s", params.epicKey, server, params.epicKey)
+	msg := fmt.Sprintf("Issues added to the epic %s\n%s", params.epicKey, cmdutil.GenerateServerURL(server, params.epicKey))
 
 	if projectType != jira.ProjectTypeNextGen {
 		cmdutil.ExitIfError(err)

--- a/internal/cmd/epic/create/create.go
+++ b/internal/cmd/epic/create/create.go
@@ -128,7 +128,7 @@ func create(cmd *cobra.Command, _ []string) {
 	}()
 
 	cmdutil.ExitIfError(err)
-	cmdutil.Success("Epic created\n%s/browse/%s", server, key)
+	cmdutil.Success("Epic created\n%s", cmdutil.GenerateServerURL(server, key))
 
 	if web, _ := cmd.Flags().GetBool("web"); web {
 		err := cmdutil.Navigate(server, key)

--- a/internal/cmd/issue/assign/assign.go
+++ b/internal/cmd/issue/assign/assign.go
@@ -115,7 +115,7 @@ func assign(cmd *cobra.Command, args []string) {
 	} else {
 		cmdutil.Success("User %q assigned to issue %q", uname, ac.params.key)
 	}
-	fmt.Printf("%s/browse/%s\n", viper.GetString("server"), ac.params.key)
+	fmt.Printf("%s\n", cmdutil.GenerateServerURL(viper.GetString("server"), ac.params.key))
 }
 
 type assignParams struct {

--- a/internal/cmd/issue/clone/clone.go
+++ b/internal/cmd/issue/clone/clone.go
@@ -96,7 +96,7 @@ func clone(cmd *cobra.Command, args []string) {
 	}()
 	cmdutil.ExitIfError(err)
 
-	cmdutil.Success("Issue cloned\n%s/browse/%s", server, clonedIssueKey)
+	cmdutil.Success("Issue cloned\n%s", cmdutil.GenerateServerURL(server, clonedIssueKey))
 
 	var wg sync.WaitGroup
 	wg.Add(1)

--- a/internal/cmd/issue/comment/add/add.go
+++ b/internal/cmd/issue/comment/add/add.go
@@ -109,7 +109,7 @@ func add(cmd *cobra.Command, args []string) {
 	server := viper.GetString("server")
 
 	cmdutil.Success("Comment added to issue %q", ac.params.issueKey)
-	fmt.Printf("%s/browse/%s\n", server, ac.params.issueKey)
+	fmt.Printf("%s\n", cmdutil.GenerateServerURL(server, ac.params.issueKey))
 
 	if web, _ := cmd.Flags().GetBool("web"); web {
 		err := cmdutil.Navigate(server, ac.params.issueKey)

--- a/internal/cmd/issue/create/create.go
+++ b/internal/cmd/issue/create/create.go
@@ -131,7 +131,7 @@ func create(cmd *cobra.Command, _ []string) {
 	}()
 
 	cmdutil.ExitIfError(err)
-	cmdutil.Success("Issue created\n%s/browse/%s", server, key)
+	cmdutil.Success("Issue created\n%s", cmdutil.GenerateServerURL(server, key))
 
 	if web, _ := cmd.Flags().GetBool("web"); web {
 		err := cmdutil.Navigate(server, key)

--- a/internal/cmd/issue/edit/edit.go
+++ b/internal/cmd/issue/edit/edit.go
@@ -149,7 +149,7 @@ func edit(cmd *cobra.Command, args []string) {
 	}()
 	cmdutil.ExitIfError(err)
 
-	cmdutil.Success("Issue updated\n%s/browse/%s", server, params.issueKey)
+	cmdutil.Success("Issue updated\n%s", cmdutil.GenerateServerURL(server, params.issueKey))
 
 	handleUserAssign(project, params.issueKey, params.assignee, client)
 

--- a/internal/cmd/issue/link/link.go
+++ b/internal/cmd/issue/link/link.go
@@ -82,7 +82,7 @@ func link(cmd *cobra.Command, args []string) {
 	server := viper.GetString("server")
 
 	cmdutil.Success("Issues linked as %q", lc.params.linkType)
-	fmt.Printf("%s/browse/%s\n", server, lc.params.inwardIssueKey)
+	fmt.Printf("%s\n", cmdutil.GenerateServerURL(server, lc.params.inwardIssueKey))
 
 	if web, _ := cmd.Flags().GetBool("web"); web {
 		err := cmdutil.Navigate(server, lc.params.inwardIssueKey)

--- a/internal/cmd/issue/link/remote/remote.go
+++ b/internal/cmd/issue/link/remote/remote.go
@@ -61,7 +61,7 @@ func remotelink(cmd *cobra.Command, args []string) {
 	server := viper.GetString("server")
 
 	cmdutil.Success("Remote web link created for Issue %s", lc.params.issueKey)
-	fmt.Printf("%s/browse/%s\n", server, lc.params.issueKey)
+	fmt.Printf("%s\n", cmdutil.GenerateServerURL(server, lc.params.issueKey))
 
 	if web, _ := cmd.Flags().GetBool("web"); web {
 		err := cmdutil.Navigate(server, lc.params.issueKey)

--- a/internal/cmd/issue/move/move.go
+++ b/internal/cmd/issue/move/move.go
@@ -119,7 +119,7 @@ func move(cmd *cobra.Command, args []string) {
 	server := viper.GetString("server")
 
 	cmdutil.Success("Issue transitioned to state %q", tr.Name)
-	fmt.Printf("%s/browse/%s\n", server, mc.params.key)
+	fmt.Printf("%s\n", cmdutil.GenerateServerURL(server, mc.params.key))
 
 	if web, _ := cmd.Flags().GetBool("web"); web {
 		err := cmdutil.Navigate(server, mc.params.key)

--- a/internal/cmd/issue/unlink/unlink.go
+++ b/internal/cmd/issue/unlink/unlink.go
@@ -66,7 +66,7 @@ func unlink(cmd *cobra.Command, args []string) {
 	server := viper.GetString("server")
 
 	cmdutil.Success("Issues unlinked")
-	fmt.Printf("%s/browse/%s\n", server, uc.params.inwardIssueKey)
+	fmt.Printf("%s\n", cmdutil.GenerateServerURL(server, uc.params.inwardIssueKey))
 
 	if web, _ := cmd.Flags().GetBool("web"); web {
 		err := cmdutil.Navigate(server, uc.params.inwardIssueKey)

--- a/internal/cmd/issue/watch/watch.go
+++ b/internal/cmd/issue/watch/watch.go
@@ -81,7 +81,7 @@ func watch(cmd *cobra.Command, args []string) {
 	cmdutil.ExitIfError(err)
 
 	cmdutil.Success("User %q added as watcher of issue %q", uname, ac.params.key)
-	fmt.Printf("%s/browse/%s\n", viper.GetString("server"), ac.params.key)
+	fmt.Printf("%s\n", cmdutil.GenerateServerURL(viper.GetString("server"), ac.params.key))
 }
 
 type watchParams struct {

--- a/internal/cmd/issue/worklog/add/add.go
+++ b/internal/cmd/issue/worklog/add/add.go
@@ -104,7 +104,7 @@ func add(cmd *cobra.Command, args []string) {
 	server := viper.GetString("server")
 
 	cmdutil.Success("Worklog added to issue %q", ac.params.issueKey)
-	fmt.Printf("%s/browse/%s\n", server, ac.params.issueKey)
+	fmt.Printf("%s\n", cmdutil.GenerateServerURL(server, ac.params.issueKey))
 }
 
 type addParams struct {

--- a/internal/cmd/open/open.go
+++ b/internal/cmd/open/open.go
@@ -43,9 +43,9 @@ func open(cmd *cobra.Command, args []string) {
 	var url string
 
 	if len(args) == 0 {
-		url = fmt.Sprintf("%s/browse/%s", server, project)
+		url = fmt.Sprintf("%s", cmdutil.GenerateServerURL(server, project))
 	} else {
-		url = fmt.Sprintf("%s/browse/%s", server, cmdutil.GetJiraIssueKey(project, args[0]))
+		url = fmt.Sprintf("%s", cmdutil.GenerateServerURL(server, cmdutil.GetJiraIssueKey(project, args[0])))
 	}
 
 	fmt.Println(url)

--- a/internal/cmd/sprint/add/add.go
+++ b/internal/cmd/sprint/add/add.go
@@ -70,7 +70,7 @@ func add(cmd *cobra.Command, args []string) {
 	}()
 	cmdutil.ExitIfError(err)
 
-	cmdutil.Success(fmt.Sprintf("Issues added to the sprint %s\n%s/browse/%s", params.sprintID, server, project))
+	cmdutil.Success(fmt.Sprintf("Issues added to the sprint %s\n%s", params.sprintID, cmdutil.GenerateServerURL(server, project)))
 }
 
 func parseFlags(flags query.FlagParser, args []string, project string) *addParams {

--- a/internal/cmdutil/utils.go
+++ b/internal/cmdutil/utils.go
@@ -91,8 +91,18 @@ func Failed(msg string, args ...interface{}) {
 
 // Navigate navigates to jira issue.
 func Navigate(server, path string) error {
-	url := fmt.Sprintf("%s/browse/%s", server, path)
+	url := GenerateServerURL(server, path)
 	return browser.Browse(url)
+}
+
+// GenerateServerURL will return the `browse` URL for a given key
+// The server section can be overridden via `view_server` in config
+// This is useful if your API endpoint is separate from the web client endpoint
+func GenerateServerURL(server, key string) string {
+	if viper.GetString("view_server") != "" {
+		server = viper.GetString("view_server")
+	}
+	return fmt.Sprintf("%s/browse/%s", server, key)
 }
 
 // FormatDateTimeHuman formats date time in human readable format.

--- a/internal/view/helper.go
+++ b/internal/view/helper.go
@@ -13,6 +13,7 @@ import (
 	"github.com/fatih/color"
 	"github.com/mgutz/ansi"
 
+	"github.com/ankitpokhrel/jira-cli/internal/cmdutil"
 	"github.com/ankitpokhrel/jira-cli/pkg/browser"
 	"github.com/ankitpokhrel/jira-cli/pkg/tui"
 )
@@ -129,7 +130,7 @@ func issueKeyFromTuiData(r int, d interface{}) string {
 }
 
 func jiraURLFromTuiData(server string, r int, d interface{}) string {
-	return fmt.Sprintf("%s/browse/%s", server, issueKeyFromTuiData(r, d))
+	return fmt.Sprintf("%s", cmdutil.GenerateServerURL(server, issueKeyFromTuiData(r, d)))
 }
 
 func navigate(server string) tui.SelectedFunc {

--- a/internal/view/issue.go
+++ b/internal/view/issue.go
@@ -430,7 +430,7 @@ func (i Issue) footer() string {
 	if i.Display.Plain {
 		out.WriteString("\n")
 	}
-	out.WriteString(gray(fmt.Sprintf("View this issue on Jira: %s/browse/%s", i.Server, i.Data.Key)))
+	out.WriteString(gray(fmt.Sprintf("View this issue on Jira: %s", cmdutil.GenerateServerURL(i.Server, i.Data.Key))))
 
 	return out.String()
 }


### PR DESCRIPTION
At my company, the on-prem installation has a different API endpoint from the web client endpoint.
This change allows "view" or "browse" URLs to point to a different base URL.

https://github.com/ankitpokhrel/jira-cli/discussions/604

* Consolidate all `browse` URLs to use common GenerateServerURL function
* Add viper config option `view_server` to be able to modify the generated `browse` URLs
* This is useful if the API endpoint is different from the web client