### PR TITLE
feat: Add `mtls` authentication for client certificate auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Follow the [installation guide](https://github.com/ankitpokhrel/jira-cli/wiki/In
      more [here](https://github.com/ankitpokhrel/jira-cli/discussions/356).
 2. Run `jira init`, select installation type as `Local`, and provide the required details to generate a config file required
    for the tool.
+   - If you want to use `mtls` (client certificates), select auth type `mtls` and provide the CA Cert, client Key, and client cert.
 
    **Note:** If your on-premise Jira installation is using a language other than `English`, then the issue/epic creation
    may not work because the older version of Jira API doesn't return the untranslated name for `issuetypes`. In that case,
@@ -95,8 +96,11 @@ See [FAQs](https://github.com/ankitpokhrel/jira-cli/discussions/categories/faqs)
 
 #### Authentication types
 
-The tool supports `basic` and `bearer` (Personal Access Token) authentication types at the moment. Basic auth is used by
-default. If you want to use PAT, you need to set `JIRA_AUTH_TYPE` as `bearer`.
+The tool supports `basic`, `bearer` (Personal Access Token), and `mtls` (Client Certificates) authentication types. Basic auth is used by
+default.
+
+* If you want to use PAT, you need to set `JIRA_AUTH_TYPE` as `bearer`. 
+* If you want to use `mtls` run `jira init`. Select installation type `Local`, and then select authentication type as `mtls`.
 
 #### Shell completion
 Check `jira completion --help` for more info on setting up a bash/zsh shell completion.

--- a/api/client.go
+++ b/api/client.go
@@ -48,6 +48,18 @@ func Client(config jira.Config) *jira.Client {
 		config.Insecure = &insecure
 	}
 
+	// MTLS
+
+	if config.MTLSConfig.CaCert == "" {
+		config.MTLSConfig.CaCert = viper.GetString("mtls.ca_cert")
+	}
+	if config.MTLSConfig.ClientCert == "" {
+		config.MTLSConfig.ClientCert = viper.GetString("mtls.client_cert")
+	}
+	if config.MTLSConfig.ClientKey == "" {
+		config.MTLSConfig.ClientKey = viper.GetString("mtls.client_key")
+	}
+
 	jiraClient = jira.NewClient(
 		config,
 		jira.WithTimeout(clientTimeout),

--- a/internal/cmd/root/root.go
+++ b/internal/cmd/root/root.go
@@ -21,6 +21,7 @@ import (
 	"github.com/ankitpokhrel/jira-cli/internal/cmd/version"
 	"github.com/ankitpokhrel/jira-cli/internal/cmdutil"
 	jiraConfig "github.com/ankitpokhrel/jira-cli/internal/config"
+	"github.com/ankitpokhrel/jira-cli/pkg/jira"
 	"github.com/ankitpokhrel/jira-cli/pkg/netrc"
 
 	"github.com/zalando/go-keyring"
@@ -76,7 +77,10 @@ func NewCmdRoot() *cobra.Command {
 				return
 			}
 
-			checkForJiraToken(viper.GetString("server"), viper.GetString("login"))
+			// mtls doesn't need Jira API Token
+			if viper.GetString("auth_type") != string(jira.AuthTypeMTLS) {
+				checkForJiraToken(viper.GetString("server"), viper.GetString("login"))
+			}
 
 			configFile := viper.ConfigFileUsed()
 			if !jiraConfig.Exists(configFile) {

--- a/pkg/jira/types.go
+++ b/pkg/jira/types.go
@@ -9,6 +9,8 @@ const (
 	AuthTypeBasic AuthType = "basic"
 	// AuthTypeBearer is a bearer auth.
 	AuthTypeBearer AuthType = "bearer"
+	// AuthTypeMTLS is a mTLS auth.
+	AuthTypeMTLS AuthType = "mtls"
 )
 
 // AuthType is a jira authentication type.


### PR DESCRIPTION
* Persist auth type in config file
* Update `jira init` to configure `mtls`
* Update README with instructions

Discussion: https://github.com/ankitpokhrel/jira-cli/discussions/603

```
$ jira init
? Installation type: Local
? Authentication type: mtls
? CA Certificate /home/mhatch/.certs/ca_list.pem
? MTLS Client Certificate /home/mhatch/.certs/mhatch.crt
? MTLS Client Key /home/mhatch/.certs/mhatch.key
? Link to Jira server: https://example.com/jira
? Login username: mhatch
? Default project: PROJECT
? Default board: PROJECT - Component work
```