### PR TITLE
Draft: support for multiple output formats

### DIFF
--- a/internal/cmd/issue/list/list.go
+++ b/internal/cmd/issue/list/list.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/ankitpokhrel/jira-cli/api"
+	"github.com/ankitpokhrel/jira-cli/internal/cmdutil/output"
 	"github.com/ankitpokhrel/jira-cli/internal/cmdutil"
 	"github.com/ankitpokhrel/jira-cli/internal/query"
 	"github.com/ankitpokhrel/jira-cli/internal/view"
@@ -52,6 +53,7 @@ $ jira issue list -s~Open -ax
 # List issues from all projects
 $ jira issue list -q"project IS NOT EMPTY"`
 )
+var format output.Format = output.Fancy
 
 // NewCmdList is a list command.
 func NewCmdList() *cobra.Command {
@@ -132,6 +134,7 @@ func loadList(cmd *cobra.Command) {
 		},
 		Display: view.DisplayFormat{
 			Plain:        plain,
+			Format:       format,
 			NoHeaders:    noHeaders,
 			NoTruncate:   noTruncate,
 			FixedColumns: fixedColumns,
@@ -179,9 +182,10 @@ func SetFlags(cmd *cobra.Command) {
 	cmd.Flags().String("order-by", "created", "Field to order the list with")
 	cmd.Flags().Bool("reverse", false, "Reverse the display order (default \"DESC\")")
 	cmd.Flags().String("paginate", "0:100", "Paginate the result. Max 100 at a time, format: <from>:<limit> where <from> is optional")
-	cmd.Flags().Bool("plain", false, "Display output in plain mode")
+	cmd.Flags().Bool("plain", false, "Deprecated: use --output=plain")
 	cmd.Flags().Bool("no-headers", false, "Don't display table headers in plain mode. Works only with --plain")
 	cmd.Flags().Bool("no-truncate", false, "Show all available columns in plain mode. Works only with --plain")
+	cmd.Flags().Var(&format, "format", format.Help())
 
 	if cmd.HasParent() && cmd.Parent().Name() != "sprint" {
 		cmd.Flags().String("columns", "", "Comma separated list of columns to display in the plain mode.\n"+

--- a/internal/cmd/issue/view/view.go
+++ b/internal/cmd/issue/view/view.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/ankitpokhrel/jira-cli/api"
 	"github.com/ankitpokhrel/jira-cli/internal/cmdutil"
+	"github.com/ankitpokhrel/jira-cli/internal/cmdutil/output"
 	tuiView "github.com/ankitpokhrel/jira-cli/internal/view"
 	"github.com/ankitpokhrel/jira-cli/pkg/jira"
 	"github.com/ankitpokhrel/jira-cli/pkg/jira/filter/issue"
@@ -19,8 +20,11 @@ const (
 $ jira issue view ISSUE-1 --comments 5`
 )
 
+var format output.Format = output.Fancy
+
 // NewCmdView is a view command.
 func NewCmdView() *cobra.Command {
+
 	cmd := cobra.Command{
 		Use:     "view ISSUE-KEY",
 		Short:   "View displays contents of an issue",
@@ -35,10 +39,12 @@ func NewCmdView() *cobra.Command {
 	}
 
 	cmd.Flags().Uint("comments", 1, "Show N comments")
-	cmd.Flags().Bool("plain", false, "Display output in plain mode")
-
+	cmd.Flags().Bool("plain", false, "Deprecated: use --output=plain")
+	cmd.Flags().Var(&format, "format", format.Help())
 	return &cmd
 }
+
+
 
 func view(cmd *cobra.Command, args []string) {
 	debug, err := cmd.Flags().GetBool("debug")
@@ -63,7 +69,7 @@ func view(cmd *cobra.Command, args []string) {
 	v := tuiView.Issue{
 		Server:  viper.GetString("server"),
 		Data:    iss,
-		Display: tuiView.DisplayFormat{Plain: plain},
+		Display: tuiView.DisplayFormat{Plain: plain, Format: format},
 		Options: tuiView.IssueOption{NumComments: comments},
 	}
 	cmdutil.ExitIfError(v.Render())

--- a/internal/cmdutil/output/output.go
+++ b/internal/cmdutil/output/output.go
@@ -1,0 +1,34 @@
+package output
+
+import (
+	"fmt"
+)
+
+type Format string
+
+const (
+	JSON  Format = "json"
+	Plain Format = "plain"
+	Fancy Format = "fancy"
+)
+
+func (e *Format) String() string {
+	return string(*e)
+}
+func (e *Format) Help() string {
+	return "Sets output type. allowed: json|plain|fancy"
+}
+
+func (e *Format) Set(v string) error {
+	switch v {
+	case "json", "plain", "fancy":
+		*e = Format(v)
+	default:
+		return fmt.Errorf("invalid value %q", v)
+	}
+	return nil
+}
+
+func (e *Format) Type() string {
+	return "Format"
+}

--- a/internal/view/helper.go
+++ b/internal/view/helper.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"text/tabwriter"
 	"time"
+	"encoding/json"
 
 	"github.com/atotto/clipboard"
 	"github.com/charmbracelet/glamour"
@@ -167,6 +168,12 @@ func renderPlain(w io.Writer, data tui.TableData) error {
 		return w.(*tabwriter.Writer).Flush()
 	}
 	return nil
+}
+
+func renderJSON(w io.Writer, data any) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "")
+	return enc.Encode(data)
 }
 
 func coloredOut(msg string, clr color.Attribute, attrs ...color.Attribute) string {

--- a/internal/view/issue.go
+++ b/internal/view/issue.go
@@ -10,6 +10,7 @@ import (
 	"github.com/charmbracelet/glamour"
 	"github.com/fatih/color"
 
+	"github.com/ankitpokhrel/jira-cli/internal/cmdutil/output"
 	"github.com/ankitpokhrel/jira-cli/internal/cmdutil"
 	"github.com/ankitpokhrel/jira-cli/pkg/adf"
 	"github.com/ankitpokhrel/jira-cli/pkg/jira"
@@ -55,7 +56,11 @@ type Issue struct {
 
 // Render renders the view.
 func (i Issue) Render() error {
-	if i.Display.Plain || tui.IsDumbTerminal() || tui.IsNotTTY() {
+	switch i.Display.Format {
+	case output.JSON:
+		return i.renderJSON(os.Stdout)
+	}
+	if i.Display.Plain || i.Display.Format == output.Plain || tui.IsDumbTerminal() || tui.IsNotTTY() {
 		return i.renderPlain(os.Stdout)
 	}
 	r, err := MDRenderer()
@@ -439,6 +444,11 @@ func (i Issue) footer() string {
 	out.WriteString(gray(fmt.Sprintf("View this issue on Jira: %s", cmdutil.GenerateServerBrowseURL(i.Server, i.Data.Key))))
 
 	return out.String()
+}
+
+// renderJSON renders the issue in JSON format.
+func (i Issue) renderJSON(w io.Writer) error {
+	return renderJSON(w, i.Data)
 }
 
 // renderPlain renders the issue in plain view.

--- a/internal/view/issues.go
+++ b/internal/view/issues.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"text/tabwriter"
 
+	"github.com/ankitpokhrel/jira-cli/internal/cmdutil/output"
 	"github.com/ankitpokhrel/jira-cli/api"
 	"github.com/ankitpokhrel/jira-cli/pkg/jira"
 	"github.com/ankitpokhrel/jira-cli/pkg/jira/filter/issue"
@@ -16,6 +17,7 @@ import (
 // DisplayFormat is a issue display type.
 type DisplayFormat struct {
 	Plain        bool
+	Format       output.Format
 	NoHeaders    bool
 	NoTruncate   bool
 	Columns      []string
@@ -36,7 +38,12 @@ type IssueList struct {
 
 // Render renders the view.
 func (l *IssueList) Render() error {
-	if l.Display.Plain || tui.IsDumbTerminal() || tui.IsNotTTY() {
+	switch l.Display.Format {
+	case output.JSON:
+		return l.renderJSON(os.Stdout)
+	}
+
+	if l.Display.Plain || l.Display.Format == output.Plain || tui.IsDumbTerminal() || tui.IsNotTTY() {
 		w := tabwriter.NewWriter(os.Stdout, 0, tabWidth, 1, '\t', 0)
 		return l.renderPlain(w)
 	}
@@ -124,6 +131,11 @@ func (l *IssueList) Render() error {
 // renderPlain renders the issue in plain view.
 func (l *IssueList) renderPlain(w io.Writer) error {
 	return renderPlain(w, l.data())
+}
+
+// renderJSON renders the issue in JSON format.
+func (l *IssueList) renderJSON(w io.Writer) error {
+	return renderJSON(w, l.Data)
 }
 
 func (*IssueList) validColumnsMap() map[string]struct{} {


### PR DESCRIPTION
Added a `--format` flag to `issue list` and `issue view` with supported formats:
 - plain ( same as `--plain`)
 - fancy (original format)
 - JSON