### PR TITLE
feat: affects version

### DIFF
--- a/internal/cmd/epic/create/create.go
+++ b/internal/cmd/epic/create/create.go
@@ -98,18 +98,19 @@ func create(cmd *cobra.Command, _ []string) {
 		defer s.Stop()
 
 		cr := jira.CreateRequest{
-			Project:      project,
-			IssueType:    jira.IssueTypeEpic,
-			Summary:      params.Summary,
-			Body:         params.Body,
-			Reporter:     params.Reporter,
-			Assignee:     params.Assignee,
-			Priority:     params.Priority,
-			Labels:       params.Labels,
-			Components:   params.Components,
-			FixVersions:  params.FixVersions,
-			CustomFields: params.CustomFields,
-			EpicField:    viper.GetString("epic.name"),
+			Project:         project,
+			IssueType:       jira.IssueTypeEpic,
+			Summary:         params.Summary,
+			Body:            params.Body,
+			Reporter:        params.Reporter,
+			Assignee:        params.Assignee,
+			Priority:        params.Priority,
+			Labels:          params.Labels,
+			Components:      params.Components,
+			FixVersions:     params.FixVersions,
+			AffectsVersions: params.AffectsVersions,
+			CustomFields:    params.CustomFields,
+			EpicField:       viper.GetString("epic.name"),
 		}
 		if projectType != jira.ProjectTypeNextGen {
 			cr.Name = params.Name
@@ -229,6 +230,9 @@ func parseFlags(flags query.FlagParser) *cmdcommon.CreateParams {
 	fixVersions, err := flags.GetStringArray("fix-version")
 	cmdutil.ExitIfError(err)
 
+	affectsVersions, err := flags.GetStringArray("affects-version")
+	cmdutil.ExitIfError(err)
+
 	custom, err := flags.GetStringToString("custom")
 	cmdutil.ExitIfError(err)
 
@@ -242,18 +246,19 @@ func parseFlags(flags query.FlagParser) *cmdcommon.CreateParams {
 	cmdutil.ExitIfError(err)
 
 	return &cmdcommon.CreateParams{
-		Name:         name,
-		Summary:      summary,
-		Body:         body,
-		Priority:     priority,
-		Reporter:     reporter,
-		Assignee:     assignee,
-		Labels:       labels,
-		Components:   components,
-		FixVersions:  fixVersions,
-		CustomFields: custom,
-		Template:     template,
-		NoInput:      noInput,
-		Debug:        debug,
+		Name:            name,
+		Summary:         summary,
+		Body:            body,
+		Priority:        priority,
+		Reporter:        reporter,
+		Assignee:        assignee,
+		Labels:          labels,
+		Components:      components,
+		FixVersions:     fixVersions,
+		AffectsVersions: affectsVersions,
+		CustomFields:    custom,
+		Template:        template,
+		NoInput:         noInput,
+		Debug:           debug,
 	}
 }

--- a/internal/cmd/issue/create/create.go
+++ b/internal/cmd/issue/create/create.go
@@ -99,19 +99,20 @@ func create(cmd *cobra.Command, _ []string) {
 		defer s.Stop()
 
 		cr := jira.CreateRequest{
-			Project:        project,
-			IssueType:      params.IssueType,
-			ParentIssueKey: params.ParentIssueKey,
-			Summary:        params.Summary,
-			Body:           params.Body,
-			Reporter:       params.Reporter,
-			Assignee:       params.Assignee,
-			Priority:       params.Priority,
-			Labels:         params.Labels,
-			Components:     params.Components,
-			FixVersions:    params.FixVersions,
-			CustomFields:   params.CustomFields,
-			EpicField:      viper.GetString("epic.link"),
+			Project:         project,
+			IssueType:       params.IssueType,
+			ParentIssueKey:  params.ParentIssueKey,
+			Summary:         params.Summary,
+			Body:            params.Body,
+			Reporter:        params.Reporter,
+			Assignee:        params.Assignee,
+			Priority:        params.Priority,
+			Labels:          params.Labels,
+			Components:      params.Components,
+			FixVersions:     params.FixVersions,
+			AffectsVersions: params.AffectsVersions,
+			CustomFields:    params.CustomFields,
+			EpicField:       viper.GetString("epic.link"),
 		}
 		cr.ForProjectType(projectType)
 		cr.ForInstallationType(installation)
@@ -343,6 +344,9 @@ func parseFlags(flags query.FlagParser) *cmdcommon.CreateParams {
 	fixVersions, err := flags.GetStringArray("fix-version")
 	cmdutil.ExitIfError(err)
 
+	affectsVersions, err := flags.GetStringArray("affects-version")
+	cmdutil.ExitIfError(err)
+
 	custom, err := flags.GetStringToString("custom")
 	cmdutil.ExitIfError(err)
 
@@ -356,19 +360,20 @@ func parseFlags(flags query.FlagParser) *cmdcommon.CreateParams {
 	cmdutil.ExitIfError(err)
 
 	return &cmdcommon.CreateParams{
-		IssueType:      issueType,
-		ParentIssueKey: parentIssueKey,
-		Summary:        summary,
-		Body:           body,
-		Priority:       priority,
-		Assignee:       assignee,
-		Labels:         labels,
-		Reporter:       reporter,
-		Components:     components,
-		FixVersions:    fixVersions,
-		CustomFields:   custom,
-		Template:       template,
-		NoInput:        noInput,
-		Debug:          debug,
+		IssueType:       issueType,
+		ParentIssueKey:  parentIssueKey,
+		Summary:         summary,
+		Body:            body,
+		Priority:        priority,
+		Assignee:        assignee,
+		Labels:          labels,
+		Reporter:        reporter,
+		Components:      components,
+		FixVersions:     fixVersions,
+		AffectsVersions: affectsVersions,
+		CustomFields:    custom,
+		Template:        template,
+		NoInput:         noInput,
+		Debug:           debug,
 	}
 }

--- a/internal/cmdcommon/create.go
+++ b/internal/cmdcommon/create.go
@@ -23,21 +23,22 @@ const (
 
 // CreateParams holds parameters for create command.
 type CreateParams struct {
-	Name           string
-	IssueType      string
-	ParentIssueKey string
-	Summary        string
-	Body           string
-	Priority       string
-	Reporter       string
-	Assignee       string
-	Labels         []string
-	Components     []string
-	FixVersions    []string
-	CustomFields   map[string]string
-	Template       string
-	NoInput        bool
-	Debug          bool
+	Name            string
+	IssueType       string
+	ParentIssueKey  string
+	Summary         string
+	Body            string
+	Priority        string
+	Reporter        string
+	Assignee        string
+	Labels          []string
+	Components      []string
+	FixVersions     []string
+	AffectsVersions []string
+	CustomFields    map[string]string
+	Template        string
+	NoInput         bool
+	Debug           bool
 }
 
 // SetCreateFlags sets flags supported by create command.
@@ -61,6 +62,7 @@ And, this field is mandatory when creating a sub-task.`)
 	cmd.Flags().StringArrayP("label", "l", []string{}, prefix+" labels")
 	cmd.Flags().StringArrayP("component", "C", []string{}, prefix+" components")
 	cmd.Flags().StringArray("fix-version", []string{}, "Release info (fixVersions)")
+	cmd.Flags().StringArray("affects-version", []string{}, "Release info (affectsVersions)")
 	cmd.Flags().StringToString("custom", custom, "Set custom fields")
 	cmd.Flags().StringP("template", "T", "", "Path to a file to read body/description from")
 	cmd.Flags().Bool("web", false, "Open in web browser after successful creation")
@@ -90,7 +92,7 @@ func GetMetadata() []*survey.Question {
 			Name: "metadata",
 			Prompt: &survey.MultiSelect{
 				Message: "What would you like to add?",
-				Options: []string{"Priority", "Components", "Labels", "FixVersions"},
+				Options: []string{"Priority", "Components", "Labels", "FixVersions", "AffectsVersions"},
 			},
 		},
 	}
@@ -131,6 +133,14 @@ func GetMetadataQuestions(cat []string) []*survey.Question {
 					Help:    "Comma separated list of fixVersions. For eg: v1.0-beta,v2.0",
 				},
 			})
+		case "AffectsVersions":
+			qs = append(qs, &survey.Question{
+				Name: "affectsversions",
+				Prompt: &survey.Input{
+					Message: "Affects Versions",
+					Help:    "Comma separated list of affectsVersions. For eg: v1.0-beta,v2.0",
+				},
+			})
 		}
 	}
 
@@ -159,10 +169,11 @@ func HandleNoInput(params *CreateParams) error {
 			if len(ans.Metadata) > 0 {
 				qs := GetMetadataQuestions(ans.Metadata)
 				ans := struct {
-					Priority    string
-					Labels      string
-					Components  string
-					FixVersions string
+					Priority        string
+					Labels          string
+					Components      string
+					FixVersions     string
+					AffectsVersions string
 				}{}
 				err := survey.Ask(qs, &ans)
 				if err != nil {
@@ -180,6 +191,9 @@ func HandleNoInput(params *CreateParams) error {
 				}
 				if len(ans.FixVersions) > 0 {
 					params.FixVersions = strings.Split(ans.FixVersions, ",")
+				}
+				if len(ans.AffectsVersions) > 0 {
+					params.AffectsVersions = strings.Split(ans.AffectsVersions, ",")
 				}
 			}
 		}

--- a/pkg/jira/create.go
+++ b/pkg/jira/create.go
@@ -24,15 +24,16 @@ type CreateRequest struct {
 	IssueType string
 	// ParentIssueKey is required when creating a sub-task for classic project.
 	// This can also be used to attach epic for next-gen project.
-	ParentIssueKey string
-	Summary        string
-	Body           interface{} // string in v1/v2 and adf.ADF in v3
-	Reporter       string
-	Assignee       string
-	Priority       string
-	Labels         []string
-	Components     []string
-	FixVersions    []string
+	ParentIssueKey  string
+	Summary         string
+	Body            interface{} // string in v1/v2 and adf.ADF in v3
+	Reporter        string
+	Assignee        string
+	Priority        string
+	Labels          []string
+	Components      []string
+	FixVersions     []string
+	AffectsVersions []string
 	// EpicField is the dynamic epic field name
 	// that changes per jira installation.
 	EpicField string
@@ -202,6 +203,18 @@ func (*Client) getRequestData(req *CreateRequest) *createRequest {
 		}
 		data.Fields.M.FixVersions = versions
 	}
+	if len(req.AffectsVersions) > 0 {
+		versions := make([]struct {
+			Name string `json:"name,omitempty"`
+		}, 0, len(req.AffectsVersions))
+
+		for _, v := range req.AffectsVersions {
+			versions = append(versions, struct {
+				Name string `json:"name,omitempty"`
+			}{v})
+		}
+		data.Fields.M.AffectsVersions = versions
+	}
 	constructCustomFields(req.CustomFields, req.configuredCustomFields, &data)
 
 	return &data
@@ -287,7 +300,9 @@ type createFields struct {
 	FixVersions []struct {
 		Name string `json:"name,omitempty"`
 	} `json:"fixVersions,omitempty"`
-
+	AffectsVersions []struct {
+		Name string `json:"name,omitempty"`
+	} `json:"versions,omitempty"`
 	epicField    string
 	customFields customField
 }

--- a/pkg/jira/create_test.go
+++ b/pkg/jira/create_test.go
@@ -46,7 +46,7 @@ func (c *createTestServer) statusCode(code int) {
 func TestCreate(t *testing.T) {
 	expectedBody := `{"update":{},"fields":{"project":{"key":"TEST"},"issuetype":{"name":"Bug"},` +
 		`"summary":"Test bug","description":"Test description","priority":{"name":"Normal"},"labels":["test","dev"],` +
-		`"components":[{"name":"BE"},{"name":"FE"}],"fixVersions":[{"name":"v2.0"},{"name":"v2.1-hotfix"}]}}`
+		`"components":[{"name":"BE"},{"name":"FE"}],"fixVersions":[{"name":"v2.0"},{"name":"v2.1-hotfix"}],"versions":[{"name":"v3.0"},{"name":"v3.1-hotfix"}]}}`
 	testServer := createTestServer{code: 201}
 	server := testServer.serve(t, expectedBody)
 	defer server.Close()
@@ -54,14 +54,15 @@ func TestCreate(t *testing.T) {
 	client := NewClient(Config{Server: server.URL}, WithTimeout(3*time.Second))
 
 	requestData := CreateRequest{
-		Project:     "TEST",
-		IssueType:   "Bug",
-		Summary:     "Test bug",
-		Body:        "Test description",
-		Priority:    "Normal",
-		Labels:      []string{"test", "dev"},
-		Components:  []string{"BE", "FE"},
-		FixVersions: []string{"v2.0", "v2.1-hotfix"},
+		Project:         "TEST",
+		IssueType:       "Bug",
+		Summary:         "Test bug",
+		Body:            "Test description",
+		Priority:        "Normal",
+		Labels:          []string{"test", "dev"},
+		Components:      []string{"BE", "FE"},
+		FixVersions:     []string{"v2.0", "v2.1-hotfix"},
+		AffectsVersions: []string{"v3.0", "v3.1-hotfix"},
 	}
 	actual, err := client.CreateV2(&requestData)
 	assert.NoError(t, err)

--- a/pkg/jira/types.go
+++ b/pkg/jira/types.go
@@ -87,6 +87,9 @@ type IssueFields struct {
 	FixVersions []struct {
 		Name string `json:"name"`
 	} `json:"fixVersions"`
+	AffectsVersions []struct {
+		Name string `json:"name"`
+	} `json:"versions"`
 	Comment struct {
 		Comments []struct {
 			ID      string      `json:"id"`


### PR DESCRIPTION
@ankitpokhrel I cloned the code for fix-versions. As suggested in #587 the versions tag in the json payload could be used to set the affects version field.

I tested this for create issue only, against a cloud jira instance.

I'm not an expert in this API, (for example, in the fields.json testdata I'm unaware of this use, so not sure how/what to extend), so not in a position to say whether the PR is good or not, regardless, it should act as a starting point for this feature. 

Hope this helps,
Damian.