### PR TITLE
Allow custom field values to be specified as JSON

### DIFF
--- a/internal/cmdcommon/create.go
+++ b/internal/cmdcommon/create.go
@@ -252,6 +252,9 @@ func ValidateCustomFields(fields map[string]string, configuredFields []jira.Issu
 
 	invalidCustomFields := make([]string, 0, len(fields))
 	for key := range fields {
+		if strings.HasPrefix(key, "json:") {
+			key = key[5:]
+		}
 		if _, ok := fieldsMap[key]; !ok {
 			invalidCustomFields = append(invalidCustomFields, key)
 		}

--- a/pkg/jira/create.go
+++ b/pkg/jira/create.go
@@ -228,9 +228,19 @@ func constructCustomFields(fields map[string]string, configuredFields []IssueTyp
 	data.Fields.M.customFields = make(customField)
 
 	for key, val := range fields {
+		rawJson := false
+		if strings.HasPrefix(key, "json:") {
+			key = key[5:]
+			rawJson = true
+		}
 		for _, configured := range configuredFields {
 			identifier := strings.ReplaceAll(strings.ToLower(strings.TrimSpace(configured.Name)), " ", "-")
 			if identifier != strings.ToLower(key) {
+				continue
+			}
+
+			if rawJson {
+				data.Fields.M.customFields[configured.Key] = customFieldTypeJson{Json: val}
 				continue
 			}
 

--- a/pkg/jira/customfield.go
+++ b/pkg/jira/customfield.go
@@ -39,3 +39,11 @@ type customFieldTypeProject struct {
 type customFieldTypeProjectSet struct {
 	Set customFieldTypeProject `json:"set"`
 }
+
+type customFieldTypeJson struct {
+	Json string
+}
+
+func (field customFieldTypeJson) MarshalJSON() ([]byte, error) {
+	return []byte(field.Json), nil
+}

--- a/pkg/jira/edit.go
+++ b/pkg/jira/edit.go
@@ -361,9 +361,19 @@ func constructCustomFieldsForEdit(fields map[string]string, configuredFields []I
 	data.Update.M.customFields = make(customField)
 
 	for key, val := range fields {
+		rawJson := false
+		if strings.HasPrefix(key, "json:") {
+			key = key[5:]
+			rawJson = true
+		}
 		for _, configured := range configuredFields {
 			identifier := strings.ReplaceAll(strings.ToLower(strings.TrimSpace(configured.Name)), " ", "-")
 			if identifier != strings.ToLower(key) {
+				continue
+			}
+
+			if rawJson {
+				data.Update.M.customFields[configured.Key] = []customFieldTypeJson{{Json: val}}
 				continue
 			}
 


### PR DESCRIPTION
This PR adds the ability to update custom fields whose type is not directly supported by `jira-cli`. This is achieved by specifying the JSON representation of the field value, e.g.:

```
jira issue create --custom 'json:found-in-version={"name":"Product 1.4"}'

jira issue edit ISSUE-123 --custom 'json:team={"set":"My Team"}' \
    --custom 'json:assigned-developer={"set":{"name":"MyUsername"}}'
```

If the field value starts with `json:`, the remaining string is interpreted as raw JSON. Note that when updating an issue, the `set` or `add` operation must also be provided, since this can be different for each custom field.

The implementation uses a new custom field struct type, `customFieldTypeJson`, and an implementation of `MarshallJSON` for that type which just returns the JSON stored in the struct.

After I implemented this I found #593 suggesting the same idea.