### PR TITLE
Add support for updating the estimate

### DIFF
--- a/internal/cmd/issue/worklog/add/add.go
+++ b/internal/cmd/issue/worklog/add/add.go
@@ -32,7 +32,10 @@ $ jira issue worklog add ISSUE-1 "2d 1h 30m" --started "2022-01-01 09:30:00"
 $ jira issue worklog add ISSUE-1 3h --started "2022-01-01 09:30:00" --timezone "Europe/Berlin"
 
 # Or, you can use start date in Jira datetime format and skip the timezone flag
-$ jira issue worklog add ISSUE-1 "1h 30m" --started "2022-01-01T09:30:00.000+0200"`
+$ jira issue worklog add ISSUE-1 "1h 30m" --started "2022-01-01T09:30:00.000+0200"
+
+# Or, you can update a worklogs remaining estimate
+$ jira issue worklog add ISSUE-1 "1h 30m" --started "2022-01-01T09:30:00.000+0200" --new-estimate 0h`
 )
 
 // NewCmdWorklogAdd is a worklog add command.
@@ -54,6 +57,7 @@ func NewCmdWorklogAdd() *cobra.Command {
 	cmd.Flags().String("started", "", "The datetime on which the worklog effort was started, eg: 2022-01-01 09:30:00")
 	cmd.Flags().String("timezone", "UTC", "The timezone to use for the started date in IANA timezone format, eg: Europe/Berlin")
 	cmd.Flags().String("comment", "", "Comment about the worklog")
+	cmd.Flags().String("new-estimate", "", "the new estimate for the backlog to be completed by")
 	cmd.Flags().Bool("no-input", false, "Disable prompt for non-required fields")
 
 	return &cmd
@@ -97,7 +101,7 @@ func add(cmd *cobra.Command, args []string) {
 		s := cmdutil.Info("Adding a worklog")
 		defer s.Stop()
 
-		return client.AddIssueWorklog(ac.params.issueKey, ac.params.started, ac.params.timeSpent, ac.params.comment)
+		return client.AddIssueWorklog(ac.params.issueKey, ac.params.started, ac.params.timeSpent, ac.params.comment, ac.params.newEstimate)
 	}()
 	cmdutil.ExitIfError(err)
 
@@ -108,13 +112,14 @@ func add(cmd *cobra.Command, args []string) {
 }
 
 type addParams struct {
-	issueKey  string
-	started   string
-	timezone  string
-	timeSpent string
-	comment   string
-	noInput   bool
-	debug     bool
+	issueKey    string
+	started     string
+	timezone    string
+	timeSpent   string
+	comment     string
+	newEstimate string
+	noInput     bool
+	debug       bool
 }
 
 func parseArgsAndFlags(args []string, flags query.FlagParser) *addParams {
@@ -146,14 +151,18 @@ func parseArgsAndFlags(args []string, flags query.FlagParser) *addParams {
 	noInput, err := flags.GetBool("no-input")
 	cmdutil.ExitIfError(err)
 
+	newEstimate, err := flags.GetString("new-estimate")
+	cmdutil.ExitIfError(err)
+
 	return &addParams{
-		issueKey:  issueKey,
-		started:   startedWithTZ,
-		timezone:  timezone,
-		timeSpent: timeSpent,
-		comment:   comment,
-		noInput:   noInput,
-		debug:     debug,
+		issueKey:    issueKey,
+		started:     startedWithTZ,
+		timezone:    timezone,
+		timeSpent:   timeSpent,
+		comment:     comment,
+		newEstimate: newEstimate,
+		noInput:     noInput,
+		debug:       debug,
 	}
 }
 

--- a/pkg/jira/issue.go
+++ b/pkg/jira/issue.go
@@ -306,7 +306,7 @@ type issueWorklogRequest struct {
 
 // AddIssueWorklog adds worklog to an issue using POST /issue/{key}/worklog endpoint.
 // Leave param `started` empty to use the server's current datetime as start date.
-func (c *Client) AddIssueWorklog(key, started, timeSpent, comment string) error {
+func (c *Client) AddIssueWorklog(key, started, timeSpent, comment, newEstimate string) error {
 	worklogReq := issueWorklogRequest{
 		TimeSpent: timeSpent,
 		Comment:   md.ToJiraMD(comment),
@@ -320,6 +320,9 @@ func (c *Client) AddIssueWorklog(key, started, timeSpent, comment string) error 
 	}
 
 	path := fmt.Sprintf("/issue/%s/worklog", key)
+	if newEstimate != "" {
+		path = fmt.Sprintf("%s?adjustEstimate=new&newEstimate=%s", path, newEstimate)
+	}
 	res, err := c.PostV2(context.Background(), path, body, Header{
 		"Accept":       "application/json",
 		"Content-Type": "application/json",

--- a/pkg/jira/issue_test.go
+++ b/pkg/jira/issue_test.go
@@ -419,8 +419,8 @@ func TestAddIssueWorklog(t *testing.T) {
 		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
 
 		var (
-			expectedBody string
-			actualBody   = new(strings.Builder)
+			expectedBody, expectedQuery string
+			actualBody                  = new(strings.Builder)
 		)
 
 		_, _ = io.Copy(actualBody, r.Body)
@@ -433,6 +433,11 @@ func TestAddIssueWorklog(t *testing.T) {
 
 		assert.Equal(t, expectedBody, actualBody.String())
 
+		if r.URL.RawQuery != "" {
+			expectedQuery = `adjustEstimate=new&newEstimate=1d`
+		}
+		assert.Equal(t, expectedQuery, r.URL.RawQuery)
+
 		if unexpectedStatusCode {
 			w.WriteHeader(400)
 		} else {
@@ -443,15 +448,18 @@ func TestAddIssueWorklog(t *testing.T) {
 
 	client := NewClient(Config{Server: server.URL}, WithTimeout(3*time.Second))
 
-	err := client.AddIssueWorklog("TEST-1", "2022-01-01T01:02:02.000+0200", "1h", "comment")
+	err := client.AddIssueWorklog("TEST-1", "2022-01-01T01:02:02.000+0200", "1h", "comment", "")
 	assert.NoError(t, err)
 
-	err = client.AddIssueWorklog("TEST-1", "", "1h", "comment")
+	err = client.AddIssueWorklog("TEST-1", "", "1h", "comment", "")
+	assert.NoError(t, err)
+
+	err = client.AddIssueWorklog("TEST-1", "", "1h", "comment", "1d")
 	assert.NoError(t, err)
 
 	unexpectedStatusCode = true
 
-	err = client.AddIssueWorklog("TEST-1", "", "1h", "comment")
+	err = client.AddIssueWorklog("TEST-1", "", "1h", "comment", "")
 	assert.Error(t, &ErrUnexpectedResponse{}, err)
 }
 


### PR DESCRIPTION
Referencing these docs to update the estimate when adding a worklog: 

https://docs.atlassian.com/software/jira/docs/api/REST/9.11.0/#api/2/issue-addWorklog

I've added tests but would like to do an e2d test as well. 