### PR TITLE
chore(Dockerfile): bump go & alpine versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 #   $ docker build -t jira-cli:latest .
 #   $ docker run --rm -it -v ~/.netrc:/root/.netrc -v ~/.config/.jira:/root/.config/.jira jira-cli
 
-FROM golang:1.19-alpine3.17 as builder
+FROM golang:1.21-alpine3.19 as builder
 
 ENV CGO_ENABLED=0
 ENV GOOS=linux
@@ -17,7 +17,7 @@ RUN set -eux; \
     apk add -U --no-cache make git ; \
     make deps install
 
-FROM alpine:3.17
+FROM alpine:3.19
 
 RUN apk --no-cache add ca-certificates
 


### PR DESCRIPTION
Current versions of Go & Alpine introduce 5 high security vulnerabilities:

1. https://scout.docker.com/vulnerabilities/id/CVE-2023-39325
1. https://scout.docker.com/vulnerabilities/id/CVE-2023-5363
1. https://scout.docker.com/vulnerabilities/id/CVE-2023-29403
1. https://scout.docker.com/vulnerabilities/id/CVE-2023-39325
1. https://scout.docker.com/vulnerabilities/id/CVE-2023-45287

This PR bumps up Go & Alpine to their latest versions (Go 1.21 & Alpine 3.19)