### PR TITLE
Bugfix: Properly close created files

### DIFF
--- a/internal/config/generator.go
+++ b/internal/config/generator.go
@@ -858,7 +858,8 @@ func create(file string) error {
 			return err
 		}
 	}
-	_, err := os.Create(file)
+	f, err := os.Create(file)
+	defer func() { _ = f.Close() }()
 
 	return err
 }


### PR DESCRIPTION
I noticed the tests failing on my windows machine.

So I searched for the issue and found that created files are never closed. The fix is small and simple :)