### PR TITLE
Consider Windows Terminal as non-dumb terminal

### DIFF
--- a/pkg/tui/helper.go
+++ b/pkg/tui/helper.go
@@ -64,13 +64,14 @@ func getActionModal() *primitive.ActionModal {
 		SetTextColor(tcell.ColorDefault)
 }
 
-// IsDumbTerminal checks TERM environment variable and returns true if it is set to dumb.
+// IsDumbTerminal checks TERM/WT_SESSION environment variable and returns true if they indicate a dumb terminal.
 //
 // Dumb terminal indicates terminal with limited capability. It may not provide support
 // for special character sequences, e.g., no handling of ANSI escape sequences.
 func IsDumbTerminal() bool {
 	term := strings.ToLower(os.Getenv("TERM"))
-	return term == "" || term == "dumb"
+	_, wtSession := os.LookupEnv("WT_SESSION")
+	return !wtSession && (term == "" || term == "dumb")
 }
 
 // IsNotTTY returns true if the stdout file descriptor is not a TTY.

--- a/pkg/tui/helper_test.go
+++ b/pkg/tui/helper_test.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -43,6 +44,39 @@ func TestColumnPadding(t *testing.T) {
 
 			assert.Equal(t, tc.expected, pad(tc.input, tc.numPad))
 		})
+	}
+}
+
+func TestIsDumbTerminal(t *testing.T) {
+	// Store initial values & cleanup
+	t.Setenv("TERM", "")
+	t.Setenv("WT_SESSION", "")
+
+	empty := ""
+	foo := "foo"
+	setTermEnv(&empty, nil)
+	assert.True(t, IsDumbTerminal())
+
+	setTermEnv(nil, nil)
+	assert.True(t, IsDumbTerminal())
+
+	setTermEnv(&foo, nil)
+	assert.False(t, IsDumbTerminal())
+
+	setTermEnv(nil, &foo)
+	assert.False(t, IsDumbTerminal())
+}
+
+func setTermEnv(term *string, wtSession *string) {
+	if term != nil {
+		_ = os.Setenv("TERM", *term)
+	} else {
+		_ = os.Unsetenv("TERM")
+	}
+	if wtSession != nil {
+		_ = os.Setenv("WT_SESSION", *wtSession)
+	} else {
+		_ = os.Unsetenv("WT_SESSION")
 	}
 }
 


### PR DESCRIPTION
This is in accordance to [this comment](https://github.com/microsoft/terminal/issues/1040#issuecomment-496691842). As discussed further in the issue, in an ideal world, we wouldn't check "user agents" of terminals one-by-one, but instead would do proper feature probing like described [here](https://github.com/termstandard/colors).

But anyway: This is a good first step to enhance Windows support.
