### PR TITLE
Add PARENT field in list of columns that can be displayed in plain mode.

### DIFF
--- a/internal/view/fields.go
+++ b/internal/view/fields.go
@@ -18,4 +18,5 @@ const (
 	fieldEndDate      = "END"
 	fieldCompleteDate = "COMPLETE"
 	fieldLabels       = "LABELS"
+	fieldParent		  = "PARENT"
 )

--- a/internal/view/helper.go
+++ b/internal/view/helper.go
@@ -71,6 +71,7 @@ func ValidIssueColumns() []string {
 		fieldCreated,
 		fieldUpdated,
 		fieldLabels,
+		fieldParent,
 	}
 }
 

--- a/internal/view/issues.go
+++ b/internal/view/issues.go
@@ -202,6 +202,12 @@ func (l *IssueList) assignColumns(columns []string, issue *jira.Issue) []string 
 			bucket = append(bucket, prepareTitle(issue.Fields.Summary))
 		case fieldStatus:
 			bucket = append(bucket, issue.Fields.Status.Name)
+		case fieldParent:
+            if issue.Fields.Parent != nil {
+                bucket = append(bucket, issue.Fields.Parent.Key)
+            } else {
+                bucket = append(bucket, "No parent")
+            }
 		case fieldAssignee:
 			bucket = append(bucket, issue.Fields.Assignee.Name)
 		case fieldReporter:


### PR DESCRIPTION
Changes to make PARENT field selectable in list of columns that can be selected with --colums flag.

Please note that I'm not familiar with Go language so I didn't update any test, so please feel free to add any change you considere necessary or adequate to my fork