### PR TITLE
feat(718): view issue: assignee and reporter email

### DIFF
--- a/internal/view/epic_test.go
+++ b/internal/view/epic_test.go
@@ -19,13 +19,15 @@ func TestEpicData(t *testing.T) {
 			}{Name: "Fixed"},
 			IssueType: jira.IssueType{Name: "Epic"},
 			Assignee: struct {
-				Name string `json:"displayName"`
+				Name  string `json:"displayName"`
+				Email string `json:"emailAddress"`
 			}{Name: "Person A"},
 			Priority: struct {
 				Name string `json:"name"`
 			}{Name: "High"},
 			Reporter: struct {
-				Name string `json:"displayName"`
+				Name  string `json:"displayName"`
+				Email string `json:"emailAddress"`
 			}{Name: "Person Z"},
 			Status: struct {
 				Name string `json:"name"`
@@ -43,7 +45,8 @@ func TestEpicData(t *testing.T) {
 				Name string `json:"name"`
 			}{Name: "Normal"},
 			Reporter: struct {
-				Name string `json:"displayName"`
+				Name  string `json:"displayName"`
+				Email string `json:"emailAddress"`
 			}{Name: "Person A"},
 			Status: struct {
 				Name string `json:"name"`
@@ -62,13 +65,15 @@ func TestEpicData(t *testing.T) {
 			}{Name: "Fixed"},
 			IssueType: jira.IssueType{Name: "Bug"},
 			Assignee: struct {
-				Name string `json:"displayName"`
+				Name  string `json:"displayName"`
+				Email string `json:"emailAddress"`
 			}{Name: "Person A"},
 			Priority: struct {
 				Name string `json:"name"`
 			}{Name: "High"},
 			Reporter: struct {
-				Name string `json:"displayName"`
+				Name  string `json:"displayName"`
+				Email string `json:"emailAddress"`
 			}{Name: "Person Z"},
 			Status: struct {
 				Name string `json:"name"`
@@ -86,7 +91,8 @@ func TestEpicData(t *testing.T) {
 				Name string `json:"name"`
 			}{Name: "Normal"},
 			Reporter: struct {
-				Name string `json:"displayName"`
+				Name  string `json:"displayName"`
+				Email string `json:"emailAddress"`
 			}{Name: "Person A"},
 			Status: struct {
 				Name string `json:"name"`

--- a/internal/view/issue.go
+++ b/internal/view/issue.go
@@ -200,9 +200,11 @@ func (i Issue) separator(msg string) string {
 }
 
 func (i Issue) header() string {
-	as := i.Data.Fields.Assignee.Name
-	if as == "" {
-		as = "Unassigned"
+	as := "Unassigned"
+	if i.Data.Fields.Assignee.Name != "" && i.Data.Fields.Assignee.Email != "" {
+		as = fmt.Sprintf("%s (%s)", i.Data.Fields.Assignee.Name, i.Data.Fields.Assignee.Email)
+	} else if i.Data.Fields.Assignee.Name != "" {
+		as = i.Data.Fields.Assignee.Name
 	}
 	st, sti := i.Data.Fields.Status.Name, "🚧"
 	if st == "Done" {
@@ -215,6 +217,10 @@ func (i Issue) header() string {
 	components := make([]string, 0, len(i.Data.Fields.Components))
 	for _, c := range i.Data.Fields.Components {
 		components = append(components, c.Name)
+	}
+	rep := i.Data.Fields.Reporter.Name
+	if i.Data.Fields.Reporter.Email != "" {
+		rep = fmt.Sprintf("%s (%s)", rep, i.Data.Fields.Reporter.Email)
 	}
 	cmpt := "None"
 	if len(components) > 0 {
@@ -235,7 +241,7 @@ func (i Issue) header() string {
 		iti, it, sti, st, cmdutil.FormatDateTimeHuman(i.Data.Fields.Updated, jira.RFC3339), as, i.Data.Key,
 		i.Data.Fields.Comment.Total, len(i.Data.Fields.IssueLinks),
 		i.Data.Fields.Summary,
-		cmdutil.FormatDateTimeHuman(i.Data.Fields.Created, jira.RFC3339), i.Data.Fields.Reporter.Name,
+		cmdutil.FormatDateTimeHuman(i.Data.Fields.Created, jira.RFC3339), rep,
 		i.Data.Fields.Priority.Name, cmpt, lbl, wch,
 	)
 }

--- a/internal/view/issue_test.go
+++ b/internal/view/issue_test.go
@@ -37,14 +37,16 @@ func TestIssueDetailsRenderInPlainView(t *testing.T) {
 			},
 			IssueType: jira.IssueType{Name: "Bug"},
 			Assignee: struct {
-				Name string `json:"displayName"`
-			}{Name: "Person A"},
+				Name  string `json:"displayName"`
+				Email string `json:"emailAddress"`
+			}{Name: "Person A", Email: "person.a@test.com"},
 			Priority: struct {
 				Name string `json:"name"`
 			}{Name: "High"},
 			Reporter: struct {
-				Name string `json:"displayName"`
-			}{Name: "Person Z"},
+				Name  string `json:"displayName"`
+				Email string `json:"emailAddress"`
+			}{Name: "Person Z", Email: "person.z@test.com"},
 			Status: struct {
 				Name string `json:"name"`
 			}{Name: "Done"},
@@ -75,7 +77,7 @@ func TestIssueDetailsRenderInPlainView(t *testing.T) {
 		Display: DisplayFormat{Plain: true},
 	}
 
-	expected := "🐞 Bug  ✅ Done  ⌛ Sun, 13 Dec 20  👷 Person A  🔑️ TEST-1  💭 0 comments  \U0001F9F5 0 linked\n# This is a test\n⏱️  Sun, 13 Dec 20  🔎 Person Z  🚀 High  📦 BE, FE  🏷️  None  👀 You + 3 watchers\n\n------------------------ Description ------------------------\n\nTest description\n\n\n"
+	expected := "🐞 Bug  ✅ Done  ⌛ Sun, 13 Dec 20  👷 Person A (person.a@test.com)  🔑️ TEST-1  💭 0 comments  \U0001F9F5 0 linked\n# This is a test\n⏱️  Sun, 13 Dec 20  🔎 Person Z (person.z@test.com)  🚀 High  📦 BE, FE  🏷️  None  👀 You + 3 watchers\n\n------------------------ Description ------------------------\n\nTest description\n\n\n"
 	if xterm256() {
 		expected += "\x1b[38;5;242mView this issue on Jira: https://test.local/browse/TEST-1\x1b[m"
 	} else {
@@ -102,13 +104,15 @@ func TestIssueDetailsWithV2Description(t *testing.T) {
 			Description: "h1. Title\nh2. Subtitle\n\nThis is a *bold* and _italic_ text with [a link|https://ankit.pl] in between.",
 			IssueType:   jira.IssueType{Name: "Bug"},
 			Assignee: struct {
-				Name string `json:"displayName"`
+				Name  string `json:"displayName"`
+				Email string `json:"emailAddress"`
 			}{Name: "Person A"},
 			Priority: struct {
 				Name string `json:"name"`
 			}{Name: "High"},
 			Reporter: struct {
-				Name string `json:"displayName"`
+				Name  string `json:"displayName"`
+				Email string `json:"emailAddress"`
 			}{Name: "Person Z"},
 			Status: struct {
 				Name string `json:"name"`

--- a/internal/view/issues_test.go
+++ b/internal/view/issues_test.go
@@ -142,13 +142,15 @@ func getIssues() []*jira.Issue {
 				}{Name: "Fixed"},
 				IssueType: jira.IssueType{Name: "Bug"},
 				Assignee: struct {
-					Name string `json:"displayName"`
+					Name  string `json:"displayName"`
+					Email string `json:"emailAddress"`
 				}{Name: "Person A"},
 				Priority: struct {
 					Name string `json:"name"`
 				}{Name: "High"},
 				Reporter: struct {
-					Name string `json:"displayName"`
+					Name  string `json:"displayName"`
+					Email string `json:"emailAddress"`
 				}{Name: "Person Z"},
 				Status: struct {
 					Name string `json:"name"`
@@ -167,7 +169,8 @@ func getIssues() []*jira.Issue {
 					Name string `json:"name"`
 				}{Name: "Normal"},
 				Reporter: struct {
-					Name string `json:"displayName"`
+					Name  string `json:"displayName"`
+					Email string `json:"emailAddress"`
 				}{Name: "Person A"},
 				Status: struct {
 					Name string `json:"name"`

--- a/internal/view/sprint_test.go
+++ b/internal/view/sprint_test.go
@@ -37,13 +37,15 @@ func TestSprintPreviewLayoutData(t *testing.T) {
 			}{Name: "Fixed"},
 			IssueType: jira.IssueType{Name: "Bug"},
 			Assignee: struct {
-				Name string `json:"displayName"`
+				Name  string `json:"displayName"`
+				Email string `json:"emailAddress"`
 			}{Name: "Person A"},
 			Priority: struct {
 				Name string `json:"name"`
 			}{Name: "High"},
 			Reporter: struct {
-				Name string `json:"displayName"`
+				Name  string `json:"displayName"`
+				Email string `json:"emailAddress"`
 			}{Name: "Person Z"},
 			Status: struct {
 				Name string `json:"name"`
@@ -62,7 +64,8 @@ func TestSprintPreviewLayoutData(t *testing.T) {
 				Name string `json:"name"`
 			}{Name: "Normal"},
 			Reporter: struct {
-				Name string `json:"displayName"`
+				Name  string `json:"displayName"`
+				Email string `json:"emailAddress"`
 			}{Name: "Person A"},
 			Status: struct {
 				Name string `json:"name"`

--- a/pkg/jira/epic_test.go
+++ b/pkg/jira/epic_test.go
@@ -61,7 +61,8 @@ func TestEpicIssues(t *testing.T) {
 						Name string `json:"name"`
 					}{Name: "Medium"},
 					Reporter: struct {
-						Name string `json:"displayName"`
+						Name  string `json:"displayName"`
+						Email string `json:"emailAddress"`
 					}{Name: "Person A"},
 					Watches: struct {
 						IsWatching bool `json:"isWatching"`
@@ -84,7 +85,8 @@ func TestEpicIssues(t *testing.T) {
 						Name string `json:"name"`
 					}{Name: "High"},
 					Reporter: struct {
-						Name string `json:"displayName"`
+						Name  string `json:"displayName"`
+						Email string `json:"emailAddress"`
 					}{Name: "Person B"},
 					Watches: struct {
 						IsWatching bool `json:"isWatching"`
@@ -107,13 +109,15 @@ func TestEpicIssues(t *testing.T) {
 					}{Name: "Done"},
 					IssueType: IssueType{Name: "Task"},
 					Assignee: struct {
-						Name string `json:"displayName"`
+						Name  string `json:"displayName"`
+						Email string `json:"emailAddress"`
 					}{Name: "Person A"},
 					Priority: struct {
 						Name string `json:"name"`
 					}{Name: "Low"},
 					Reporter: struct {
-						Name string `json:"displayName"`
+						Name  string `json:"displayName"`
+						Email string `json:"emailAddress"`
 					}{Name: "Person C"},
 					Watches: struct {
 						IsWatching bool `json:"isWatching"`

--- a/pkg/jira/issue_test.go
+++ b/pkg/jira/issue_test.go
@@ -60,7 +60,8 @@ func TestGetIssue(t *testing.T) {
 				Name string `json:"name"`
 			}{Name: "Medium"},
 			Reporter: struct {
-				Name string `json:"displayName"`
+				Name  string `json:"displayName"`
+				Email string `json:"emailAddress"`
 			}{Name: "Person A"},
 			Watches: struct {
 				IsWatching bool `json:"isWatching"`
@@ -130,7 +131,8 @@ func TestGetIssueWithoutDescription(t *testing.T) {
 				Name string `json:"name"`
 			}{Name: "Medium"},
 			Reporter: struct {
-				Name string `json:"displayName"`
+				Name  string `json:"displayName"`
+				Email string `json:"emailAddress"`
 			}{Name: "Person A"},
 			Watches: struct {
 				IsWatching bool `json:"isWatching"`
@@ -181,7 +183,8 @@ func TestGetIssueV2(t *testing.T) {
 				Name string `json:"name"`
 			}{Name: "Medium"},
 			Reporter: struct {
-				Name string `json:"displayName"`
+				Name  string `json:"displayName"`
+				Email string `json:"emailAddress"`
 			}{Name: "Person A"},
 			Watches: struct {
 				IsWatching bool `json:"isWatching"`

--- a/pkg/jira/search_test.go
+++ b/pkg/jira/search_test.go
@@ -66,7 +66,8 @@ func TestSearch(t *testing.T) {
 						Name string `json:"name"`
 					}{Name: "Medium"},
 					Reporter: struct {
-						Name string `json:"displayName"`
+						Name  string `json:"displayName"`
+						Email string `json:"emailAddress"`
 					}{Name: "Person A"},
 					Watches: struct {
 						IsWatching bool `json:"isWatching"`
@@ -89,7 +90,8 @@ func TestSearch(t *testing.T) {
 						Name string `json:"name"`
 					}{Name: "High"},
 					Reporter: struct {
-						Name string `json:"displayName"`
+						Name  string `json:"displayName"`
+						Email string `json:"emailAddress"`
 					}{Name: "Person B"},
 					Watches: struct {
 						IsWatching bool `json:"isWatching"`
@@ -112,13 +114,15 @@ func TestSearch(t *testing.T) {
 					}{Name: "Done"},
 					IssueType: IssueType{Name: "Task"},
 					Assignee: struct {
-						Name string `json:"displayName"`
+						Name  string `json:"displayName"`
+						Email string `json:"emailAddress"`
 					}{Name: "Person A"},
 					Priority: struct {
 						Name string `json:"name"`
 					}{Name: "Low"},
 					Reporter: struct {
-						Name string `json:"displayName"`
+						Name  string `json:"displayName"`
+						Email string `json:"emailAddress"`
 					}{Name: "Person C"},
 					Watches: struct {
 						IsWatching bool `json:"isWatching"`

--- a/pkg/jira/sprint_test.go
+++ b/pkg/jira/sprint_test.go
@@ -233,7 +233,8 @@ func TestSprintIssues(t *testing.T) {
 						Name string `json:"name"`
 					}{Name: "Medium"},
 					Reporter: struct {
-						Name string `json:"displayName"`
+						Name  string `json:"displayName"`
+						Email string `json:"emailAddress"`
 					}{Name: "Person A"},
 					Watches: struct {
 						IsWatching bool `json:"isWatching"`
@@ -256,7 +257,8 @@ func TestSprintIssues(t *testing.T) {
 						Name string `json:"name"`
 					}{Name: "High"},
 					Reporter: struct {
-						Name string `json:"displayName"`
+						Name  string `json:"displayName"`
+						Email string `json:"emailAddress"`
 					}{Name: "Person B"},
 					Watches: struct {
 						IsWatching bool `json:"isWatching"`
@@ -279,13 +281,15 @@ func TestSprintIssues(t *testing.T) {
 					}{Name: "Done"},
 					IssueType: IssueType{Name: "Task"},
 					Assignee: struct {
-						Name string `json:"displayName"`
+						Name  string `json:"displayName"`
+						Email string `json:"emailAddress"`
 					}{Name: "Person A"},
 					Priority: struct {
 						Name string `json:"name"`
 					}{Name: "Low"},
 					Reporter: struct {
-						Name string `json:"displayName"`
+						Name  string `json:"displayName"`
+						Email string `json:"emailAddress"`
 					}{Name: "Person C"},
 					Watches: struct {
 						IsWatching bool `json:"isWatching"`

--- a/pkg/jira/types.go
+++ b/pkg/jira/types.go
@@ -68,13 +68,15 @@ type IssueFields struct {
 		Key string `json:"key"`
 	} `json:"parent,omitempty"`
 	Assignee struct {
-		Name string `json:"displayName"`
+		Name  string `json:"displayName"`
+		Email string `json:"emailAddress"`
 	} `json:"assignee"`
 	Priority struct {
 		Name string `json:"name"`
 	} `json:"priority"`
 	Reporter struct {
-		Name string `json:"displayName"`
+		Name  string `json:"displayName"`
+		Email string `json:"emailAddress"`
 	} `json:"reporter"`
 	Watches struct {
 		IsWatching bool `json:"isWatching"`


### PR DESCRIPTION
https://github.com/ankitpokhrel/jira-cli/issues/718

This change only applies to the `jira issue view <key>` command. Parsing and displaying email addresses of the assignee and the reporter of the viewed issue if the emails are present in the Jira API response.

<img width="945" alt="Screenshot 2024-03-12 at 16 14 32" src="https://github.com/ankitpokhrel/jira-cli/assets/93705561/506ced8c-6cdc-4d66-86fb-aa9c98fe91a3">
