### PR TITLE
feat(718): issue view: raw response option

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -95,6 +95,15 @@ func ProxyCreate(c *jira.Client, cr *jira.CreateRequest) (*jira.CreateResponse, 
 	return resp, err
 }
 
+// ProxyGetIssueRaw executes the same request as ProxyGetIssue but returns raw API response body string.
+func ProxyGetIssueRaw(c *jira.Client, key string) (string, error) {
+	it := viper.GetString("installation")
+	if it == jira.InstallationTypeLocal {
+		return c.GetIssueV2Raw(key)
+	}
+	return c.GetIssueRaw(key)
+}
+
 // ProxyGetIssue uses either a v2 or v3 version of the Jira GET /issue/{key}
 // endpoint to fetch the issue details based on configured installation type.
 // Defaults to v3 if installation type is not defined in the config.

--- a/internal/cmd/issue/view/view.go
+++ b/internal/cmd/issue/view/view.go
@@ -1,6 +1,8 @@
 package view
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
@@ -16,7 +18,20 @@ const (
 	examples = `$ jira issue view ISSUE-1
 
 # Show 5 recent comments when viewing the issue
-$ jira issue view ISSUE-1 --comments 5`
+$ jira issue view ISSUE-1 --comments 5
+
+# Get the raw JSON data
+$ jira issue view ISSUE-1 --raw`
+
+	flagRaw      = "raw"
+	flagDebug    = "debug"
+	flagComments = "comments"
+	flagPlain    = "plain"
+
+	configProject = "project.key"
+	configServer  = "server"
+
+	messageFetchingData = "Fetching issue details..."
 )
 
 // NewCmdView is a view command.
@@ -34,22 +49,52 @@ func NewCmdView() *cobra.Command {
 		Run:  view,
 	}
 
-	cmd.Flags().Uint("comments", 1, "Show N comments")
-	cmd.Flags().Bool("plain", false, "Display output in plain mode")
+	cmd.Flags().Uint(flagComments, 1, "Show N comments")
+	cmd.Flags().Bool(flagPlain, false, "Display output in plain mode")
+	cmd.Flags().Bool(flagRaw, false, "Print raw Jira API response. Set this flag if you want to process the issue contents using a program")
 
 	return &cmd
 }
 
 func view(cmd *cobra.Command, args []string) {
-	debug, err := cmd.Flags().GetBool("debug")
+	raw, err := cmd.Flags().GetBool(flagRaw)
 	cmdutil.ExitIfError(err)
 
-	comments, err := cmd.Flags().GetUint("comments")
+	if raw {
+		viewRaw(cmd, args)
+		return
+	}
+	viewPretty(cmd, args)
+}
+
+func viewRaw(cmd *cobra.Command, args []string) {
+	debug, err := cmd.Flags().GetBool(flagDebug)
 	cmdutil.ExitIfError(err)
 
-	key := cmdutil.GetJiraIssueKey(viper.GetString("project.key"), args[0])
+	key := cmdutil.GetJiraIssueKey(viper.GetString(configProject), args[0])
+
+	apiResp, err := func() (string, error) {
+		s := cmdutil.Info(messageFetchingData)
+		defer s.Stop()
+
+		client := api.DefaultClient(debug)
+		return api.ProxyGetIssueRaw(client, key)
+	}()
+	cmdutil.ExitIfError(err)
+
+	fmt.Println(apiResp)
+}
+
+func viewPretty(cmd *cobra.Command, args []string) {
+	debug, err := cmd.Flags().GetBool(flagDebug)
+	cmdutil.ExitIfError(err)
+
+	comments, err := cmd.Flags().GetUint(flagComments)
+	cmdutil.ExitIfError(err)
+
+	key := cmdutil.GetJiraIssueKey(viper.GetString(configProject), args[0])
 	iss, err := func() (*jira.Issue, error) {
-		s := cmdutil.Info("Fetching issue details...")
+		s := cmdutil.Info(messageFetchingData)
 		defer s.Stop()
 
 		client := api.DefaultClient(debug)
@@ -57,11 +102,11 @@ func view(cmd *cobra.Command, args []string) {
 	}()
 	cmdutil.ExitIfError(err)
 
-	plain, err := cmd.Flags().GetBool("plain")
+	plain, err := cmd.Flags().GetBool(flagPlain)
 	cmdutil.ExitIfError(err)
 
 	v := tuiView.Issue{
-		Server:  viper.GetString("server"),
+		Server:  viper.GetString(configServer),
 		Data:    iss,
 		Display: tuiView.DisplayFormat{Plain: plain},
 		Options: tuiView.IssueOption{NumComments: comments},

--- a/pkg/jira/issue_test.go
+++ b/pkg/jira/issue_test.go
@@ -14,6 +14,11 @@ import (
 	"github.com/ankitpokhrel/jira-cli/pkg/adf"
 )
 
+const (
+	_testdataPathIssue   = "./testdata/issue.json"
+	_testdataPathIssueV2 = "./testdata/issue-2.json"
+)
+
 func TestGetIssue(t *testing.T) {
 	var unexpectedStatusCode bool
 
@@ -23,7 +28,7 @@ func TestGetIssue(t *testing.T) {
 		if unexpectedStatusCode {
 			w.WriteHeader(400)
 		} else {
-			resp, err := os.ReadFile("./testdata/issue.json")
+			resp, err := os.ReadFile(_testdataPathIssue)
 			assert.NoError(t, err)
 
 			w.Header().Set("Content-Type", "application/json")
@@ -155,7 +160,7 @@ func TestGetIssueV2(t *testing.T) {
 		if unexpectedStatusCode {
 			w.WriteHeader(400)
 		} else {
-			resp, err := os.ReadFile("./testdata/issue-2.json")
+			resp, err := os.ReadFile(_testdataPathIssueV2)
 			assert.NoError(t, err)
 
 			w.Header().Set("Content-Type", "application/json")
@@ -200,6 +205,146 @@ func TestGetIssueV2(t *testing.T) {
 
 	_, err = client.GetIssueV2("TEST-1")
 	assert.Error(t, &ErrUnexpectedResponse{}, err)
+}
+
+func TestGetIssueRaw(t *testing.T) {
+	cases := []struct {
+		title              string
+		givePayloadFile    string
+		giveClientCallFunc func(c *Client) (string, error)
+		wantReqURL         string
+		wantOut            string
+	}{
+		{
+			title:           "v3",
+			givePayloadFile: _testdataPathIssue,
+			giveClientCallFunc: func(c *Client) (string, error) {
+				return c.GetIssueRaw("KAN-1")
+			},
+			wantReqURL: "/rest/api/3/issue/KAN-1",
+			wantOut: `{
+  "key": "TEST-1",
+  "fields": {
+    "issuetype": {
+      "name": "Bug"
+    },
+    "resolution": null,
+    "created": "2020-12-03T14:05:20.974+0100",
+    "priority": {
+      "name": "Medium"
+    },
+    "labels": [],
+    "assignee": null,
+    "updated": "2020-12-03T14:05:20.974+0100",
+    "status": {
+      "name": "To Do"
+    },
+    "summary": "Bug summary",
+    "description": {
+      "version": 1,
+      "type": "doc",
+      "content": [
+        {
+          "type": "paragraph",
+          "content": [
+            {
+              "type": "text",
+              "text": "Test description"
+            }
+          ]
+        }
+      ]
+    },
+    "issuelinks": [
+      {
+        "id": "10001",
+        "outwardIssue": {
+          "key": "TEST-2"
+        }
+      },
+      {
+        "id": "10002",
+        "outwardIssue": {}
+      }
+    ],
+    "reporter": {
+      "displayName": "Person A"
+    },
+    "watches": {
+      "watchCount": 1,
+      "isWatching": true
+    }
+  }
+}
+`,
+		},
+		{
+			title:           "v2",
+			givePayloadFile: _testdataPathIssueV2,
+			giveClientCallFunc: func(c *Client) (string, error) {
+				return c.GetIssueV2Raw("KAN-1")
+			},
+			wantReqURL: "/rest/api/2/issue/KAN-1",
+			wantOut: `{
+  "key": "TEST-1",
+  "fields": {
+    "issuetype": {
+      "name": "Bug"
+    },
+    "resolution": null,
+    "created": "2020-12-03T14:05:20.974+0100",
+    "priority": {
+      "name": "Medium"
+    },
+    "labels": [],
+    "assignee": null,
+    "updated": "2020-12-03T14:05:20.974+0100",
+    "status": {
+      "name": "To Do"
+    },
+    "summary": "Bug summary",
+    "description": "Test description",
+    "reporter": {
+      "displayName": "Person A"
+    },
+    "watches": {
+      "watchCount": 1,
+      "isWatching": true
+    }
+  }
+}
+`,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.title, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, c.wantReqURL, r.URL.Path)
+
+				respContent, err := os.ReadFile(c.givePayloadFile)
+				if !assert.NoError(t, err) {
+					return
+				}
+
+				w.Header().Set("Content-Type", "application/json")
+				_, err = w.Write(respContent)
+				if !assert.NoError(t, err) {
+					return
+				}
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer server.Close()
+
+			client := NewClient(Config{Server: server.URL}, WithTimeout(3*time.Second))
+			out, err := c.giveClientCallFunc(client)
+			if !assert.NoError(t, err) {
+				return
+			}
+
+			assert.Equal(t, c.wantOut, out)
+		})
+	}
 }
 
 func TestAssignIssue(t *testing.T) {
@@ -352,7 +497,7 @@ func TestGetLinkID(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "/rest/api/2/issue/TEST-1", r.URL.Path)
 
-		resp, err := os.ReadFile("./testdata/issue.json")
+		resp, err := os.ReadFile(_testdataPathIssue)
 		assert.NoError(t, err)
 
 		w.Header().Set("Content-Type", "application/json")


### PR DESCRIPTION
https://github.com/ankitpokhrel/jira-cli/issues/718

Adding `--json` flag to the `jira issue view <KEY>` command so that the tool prints the issue contents as plain JSON if the flag is set. This feature allows users to process the issue information with their programs to support various automation scenarios.

I've added an intermediate struct `printableIssue` to ensure correct null/empty values in the produced JSON, to avoid zero-values like 
```
{
...
  "assignee": {
    "displayName": ""
  }
...
}
```

![Screenshot 2024-03-14 at 16 29 36](https://github.com/ankitpokhrel/jira-cli/assets/93705561/e52f2a22-34cf-40a0-8801-3a47d52a1beb)
