### PR TITLE
fix: Epic description overridden in no-input mode

### DIFF
--- a/internal/cmd/epic/create/create.go
+++ b/internal/cmd/epic/create/create.go
@@ -167,7 +167,9 @@ func (cc *createCmd) getQuestions(projectType string) []*survey.Question {
 	}
 
 	if cc.params.NoInput {
-		cc.params.Body = defaultBody
+		if cc.params.Body == "" {
+			cc.params.Body = defaultBody
+		}
 		return qs
 	}
 


### PR DESCRIPTION
Fixes #667

