### PR TITLE
Improve zsh autocomplete directions

### DIFF
--- a/internal/cmd/completion/completion.go
+++ b/internal/cmd/completion/completion.go
@@ -28,7 +28,7 @@ Zsh:
   $ echo "autoload -U compinit; compinit" >> ~/.zshrc
 
   # To load completions for each session, execute once:
-  $ jira completion zsh > /usr/local/share/zsh/site-functions/_jira
+  $ jira completion zsh > "${fpath[1]}/_jira"
 
   # You will need to start a new shell for this setup to take effect.
 


### PR DESCRIPTION
`/usr/local/share/zsh/site-functions` is not guaranteed to exist.  `${fpath[1]}` is a more reliable way of accessing the site-functions folder.  

# Terminal Test Video
https://asciinema.org/a/6I6OewMIgP1LNGKvB2virBBao