### PR TITLE
Allow search for issues of all projects

### DIFF
--- a/pkg/jql/jql.go
+++ b/pkg/jql/jql.go
@@ -25,9 +25,13 @@ type JQL struct {
 
 // NewJQL initializes jql query builder.
 func NewJQL(project string) *JQL {
+	var filters []string
+	if project != "" {
+		filters = []string{fmt.Sprintf("project=%q", project)}
+	}
 	return &JQL{
 		project: project,
-		filters: []string{fmt.Sprintf("project=%q", project)},
+		filters: filters,
 	}
 }
 


### PR DESCRIPTION
This is a very quick & rough implementation that allows us to
search for issues in all projects by passing an empty string as
project.

It effectively allows us to run `jira issue list -p ""` and get issues of all projects:

```
KEY     SUMMARY
BB-1    My fist story
AA-9    As a developer, I'd like to update story status during the sprint
```