### PR TITLE
fix: regression introduced by new OriginalEstimate attribute

### DIFF
--- a/pkg/jira/create.go
+++ b/pkg/jira/create.go
@@ -133,9 +133,6 @@ func (*Client) getRequestData(req *CreateRequest) *createRequest {
 		Summary:   req.Summary,
 		Labels:    req.Labels,
 		epicField: req.EpicField,
-		TimeTracking: struct {
-			OriginalEstimate string `json:"originalEstimate,omitempty"`
-		}{OriginalEstimate: req.OriginalEstimate},
 	}
 
 	switch v := req.Body.(type) {
@@ -219,6 +216,12 @@ func (*Client) getRequestData(req *CreateRequest) *createRequest {
 		}
 		data.Fields.M.AffectsVersions = versions
 	}
+	if req.OriginalEstimate != "" {
+		data.Fields.M.TimeTracking = &struct {
+			OriginalEstimate string `json:"originalEstimate,omitempty"`
+		}{OriginalEstimate: req.OriginalEstimate}
+	}
+
 	constructCustomFields(req.CustomFields, req.configuredCustomFields, &data)
 
 	return &data
@@ -307,7 +310,7 @@ type createFields struct {
 	AffectsVersions []struct {
 		Name string `json:"name,omitempty"`
 	} `json:"versions,omitempty"`
-	TimeTracking struct {
+	TimeTracking *struct {
 		OriginalEstimate string `json:"originalEstimate,omitempty"`
 	} `json:"timetracking,omitempty"`
 	epicField    string

--- a/pkg/jira/create_test.go
+++ b/pkg/jira/create_test.go
@@ -84,7 +84,7 @@ func TestCreate(t *testing.T) {
 
 func TestCreateSubtask(t *testing.T) {
 	expectedBody := `{"update":{},"fields":{"project":{"key":"TEST"},"issuetype":{"name":"Sub-task"},` +
-		`"parent":{"key":"TEST-123"},"summary":"Test sub-task","description":"Test description","timetracking":{}}}`
+		`"parent":{"key":"TEST-123"},"summary":"Test sub-task","description":"Test description"}}`
 	testServer := createTestServer{code: 201}
 	server := testServer.serve(t, expectedBody)
 	defer server.Close()
@@ -116,7 +116,7 @@ func TestCreateSubtask(t *testing.T) {
 
 func TestCreateEpic(t *testing.T) {
 	expectedBody := `{"update":{},"fields":{"customfield_10001":"CLI","description":"Test description","issuetype":{"name":` +
-		`"Bug"},"priority":{"name":"Normal"},"project":{"key":"TEST"},"summary":"Test bug", "timetracking":{}}}`
+		`"Bug"},"priority":{"name":"Normal"},"project":{"key":"TEST"},"summary":"Test bug"}}`
 	testServer := createTestServer{code: 201}
 	server := testServer.serve(t, expectedBody)
 	defer server.Close()
@@ -148,7 +148,7 @@ func TestCreateEpic(t *testing.T) {
 
 func TestCreateEpicNextGen(t *testing.T) {
 	expectedBody := `{"update":{},"fields":{"description":"Test description","issuetype":{"name":"Bug"},` +
-		`"parent":{"key":"TEST-123"},"project":{"key":"TEST"},"summary":"Test bug","timetracking":{}}}`
+		`"parent":{"key":"TEST-123"},"project":{"key":"TEST"},"summary":"Test bug"}}`
 	testServer := createTestServer{code: 201}
 	server := testServer.serve(t, expectedBody)
 	defer server.Close()


### PR DESCRIPTION
The recent changes in PR #748 caused issues with jira-cli when used with Jira Enterprise On-Prem (now referred to as DataCenter). All requests started failing with the following error message:

```
Error:
  - timetracking: Field 'timetracking' cannot be set. It is not on the appropriate screen, or unknown.
```

The issue arises because, even if the `--original-estimate` option is not specified, the timetracking field is included in the JSON query. This PR addresses the issue by ensuring that the timetracking field is only included in the JSON query if the `--original-estimate` option is set. I have tested the fix, and all tests are passing.

Please review the changes and let me know if there are any concerns.