### PR TITLE
fix: timetracking field always marshalled

### DIFF
--- a/pkg/jira/create.go
+++ b/pkg/jira/create.go
@@ -133,9 +133,6 @@ func (*Client) getRequestData(req *CreateRequest) *createRequest {
 		Summary:   req.Summary,
 		Labels:    req.Labels,
 		epicField: req.EpicField,
-		TimeTracking: struct {
-			OriginalEstimate string `json:"originalEstimate,omitempty"`
-		}{OriginalEstimate: req.OriginalEstimate},
 	}
 
 	switch v := req.Body.(type) {
@@ -218,6 +215,12 @@ func (*Client) getRequestData(req *CreateRequest) *createRequest {
 			}{v})
 		}
 		data.Fields.M.AffectsVersions = versions
+	}
+
+	if req.OriginalEstimate != "" {
+		data.Fields.M.TimeTracking = &struct {
+			OriginalEstimate string `json:"originalEstimate,omitempty"`
+		}{OriginalEstimate: req.OriginalEstimate}
 	}
 	constructCustomFields(req.CustomFields, req.configuredCustomFields, &data)
 
@@ -307,7 +310,8 @@ type createFields struct {
 	AffectsVersions []struct {
 		Name string `json:"name,omitempty"`
 	} `json:"versions,omitempty"`
-	TimeTracking struct {
+	// Use pointer to avoid marshalling `timetracking` field even when estimate is an empty string
+	TimeTracking *struct {
 		OriginalEstimate string `json:"originalEstimate,omitempty"`
 	} `json:"timetracking,omitempty"`
 	epicField    string


### PR DESCRIPTION
Currently, the new field from https://github.com/ankitpokhrel/jira-cli/pull/748 for timetracking is always marshalled to JSON even if the "OriginalEstimate" field is an empty string.

This is because of the way the field is initialized as a struct that will never be nil and therefore never caught by the 'omitempty' tag.

This changes the TimeTracking field to be a pointer, which is nil by default, so that if OriginalEstimate isn't set, the timetracking field won't be in the JSON sent to Jira.

This is a problem if the issue type being created is one that doesn't support a timetracking field.