### PR TITLE
Make issue create errors more verbose to ensure description is not lost

### DIFF
--- a/internal/cmd/issue/create/create.go
+++ b/internal/cmd/issue/create/create.go
@@ -128,7 +128,7 @@ func create(cmd *cobra.Command, _ []string) {
 
 		resp, err := client.CreateV2(&cr)
 		if err != nil {
-			fmt.Printf("\nCreation failed. Text dump follows.\nSummary:\n--------\n%s\n\nBody:\n-----\n%s\n\n", params.summary, params.body)
+			fmt.Printf("\nCreation failed. Text dump follows.\nSummary:\n--------\n%s\n\nBody:\n-----\n%s\n\n", params.Summary, params.Body)
 			return "", err
 		}
 		return resp.Key, nil

--- a/internal/cmd/issue/create/create.go
+++ b/internal/cmd/issue/create/create.go
@@ -128,7 +128,7 @@ func create(cmd *cobra.Command, _ []string) {
 
 		resp, err := client.CreateV2(&cr)
 		if err != nil {
-			fmt.Printf("\nCreation failed. Text dump follows.\nSummary:\n--------\n%s\n\nBody:\n-----\n%s\n\n", params.Summary, params.Body)
+			fmt.Printf("\nCreation failed. Text dump follows.\nSummary:\n--------\n%s\n\nBody:\n-----\n%s\n", params.Summary, params.Body)
 			return "", err
 		}
 		return resp.Key, nil


### PR DESCRIPTION
Most users spend a lot more time editing their description than anything else. This change ensures that if creating an issue fails for any reason, it is not lost to `/dev/null` forever.

```
15:16:13 ~/projects/jira-cli (main*)$ jira issue create
? Issue type Card
? Summary Testing JiraCLI
? Description <Received>
? What's next? Add metadata
? What would you like to add? Priority
? Priority 1
? What's next? Submit
⠹ Creating an issue...
Creation failed. Text dump follows.
Summary:
--------
Testing JiraCLI

Body:
-----
This is a test description which I can view from the output of a failed create command


Error:
  - priority: Specify the Priority (name) in the string format

jira: Received unexpected response '400 Bad Request'.
Please check the parameters you supplied and try again.
15:16:50 ~/projects/jira-cli (main*)$
```