### PR TITLE
feat: Respect API token for `mtls` auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ default.
 
 * If you want to use PAT, you need to set `JIRA_AUTH_TYPE` as `bearer`.
 * If you want to use `mtls` run `jira init`. Select installation type `Local`, and then select authentication type as `mtls`.
+  * In case `JIRA_API_TOKEN` variable is set it will be used together with `mtls`.
 
 #### Shell completion
 Check `jira completion --help` for more info on setting up a bash/zsh shell completion.

--- a/pkg/jira/client.go
+++ b/pkg/jira/client.go
@@ -275,6 +275,10 @@ func (c *Client) request(ctx context.Context, method, endpoint string, body []by
 	// When need to compare using `String()` here, it is used to handle cases where the
 	// authentication type might be empty, ensuring it defaults to the appropriate value.
 	switch c.authType.String() {
+	case string(AuthTypeMTLS):
+		if c.token != "" {
+			req.Header.Add("Authorization", "Bearer "+c.token)
+		}
 	case string(AuthTypeBearer):
 		req.Header.Add("Authorization", "Bearer "+c.token)
 	case string(AuthTypeBasic):


### PR DESCRIPTION
Going with `mtls` doesn't necessarily mean API token to be obsolete. Hence, this PR would make CLI incorporate API token if it is present..



The program was tested solely for our own use cases, which might differ from yours.

<sub>Lucas Zanella [lucas.zanella@mercedes-benz.com](mailto:lucas.zanella@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH, [imprint](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)</sub>