### PR TITLE
fix: case insensitive sub-task comparison

### DIFF
--- a/pkg/jira/create.go
+++ b/pkg/jira/create.go
@@ -153,7 +153,7 @@ func (*Client) getRequestData(req *CreateRequest) *createRequest {
 			subtaskField = req.SubtaskField
 		}
 
-		if req.projectType == ProjectTypeNextGen || data.Fields.M.IssueType.Name == subtaskField {
+		if req.projectType == ProjectTypeNextGen || strings.EqualFold(data.Fields.M.IssueType.Name, subtaskField) {
 			data.Fields.M.Parent = &struct {
 				Key string `json:"key"`
 			}{Key: req.ParentIssueKey}


### PR DESCRIPTION
Within my cloud installation, the jira init command pulls the handle and name just fine but my administrator configured the name as "Sub-task" and the handle as "Sub-Task" which fails the equal check and causes failures with the parent key assignment. 

```
- id: "10093"
  name: Sub-task
  handle: Sub-Task
  subtask: true
```

This PR addresses this by using an EqualFold so case insensitive matching is done for the issue type check. 