### PR TITLE
Allow adding internal comment on JSD

### DIFF
--- a/README.md
+++ b/README.md
@@ -492,7 +492,7 @@ $ jira issue comment add
 $ jira issue comment add ISSUE-1 "My comment body"
 
 # Same as above but as an internal comment
-$ jira issue comment add ISSUE-1 "My comment body" -internal
+$ jira issue comment add ISSUE-1 "My comment body" --internal
 
 # Load comment from template file
 $ jira issue comment add ISSUE-1 --template /path/to/template.tmpl

--- a/README.md
+++ b/README.md
@@ -491,6 +491,9 @@ $ jira issue comment add
 # Pass required parameters to skip prompt
 $ jira issue comment add ISSUE-1 "My comment body"
 
+# Same as above but as an internal comment
+$ jira issue comment add ISSUE-1 "My comment body" -internal
+
 # Load comment from template file
 $ jira issue comment add ISSUE-1 --template /path/to/template.tmpl
 

--- a/internal/cmd/issue/comment/add/add.go
+++ b/internal/cmd/issue/comment/add/add.go
@@ -56,6 +56,7 @@ func NewCmdCommentAdd() *cobra.Command {
 	cmd.Flags().Bool("web", false, "Open issue in web browser after adding comment")
 	cmd.Flags().StringP("template", "T", "", "Path to a file to read comment body from")
 	cmd.Flags().Bool("no-input", false, "Disable prompt for non-required fields")
+	cmd.Flags().Bool("internal", false, "Make comment internal")
 
 	return &cmd
 }
@@ -102,7 +103,7 @@ func add(cmd *cobra.Command, args []string) {
 		s := cmdutil.Info("Adding comment")
 		defer s.Stop()
 
-		return client.AddIssueComment(ac.params.issueKey, ac.params.body)
+		return client.AddIssueComment(ac.params.issueKey, ac.params.body, ac.params.internal)
 	}()
 	cmdutil.ExitIfError(err)
 
@@ -122,6 +123,7 @@ type addParams struct {
 	body     string
 	template string
 	noInput  bool
+	internal bool
 	debug    bool
 }
 
@@ -145,11 +147,15 @@ func parseArgsAndFlags(args []string, flags query.FlagParser) *addParams {
 	noInput, err := flags.GetBool("no-input")
 	cmdutil.ExitIfError(err)
 
+	internal, err := flags.GetBool("internal")
+	cmdutil.ExitIfError(err)
+
 	return &addParams{
 		issueKey: issueKey,
 		body:     body,
 		template: template,
 		noInput:  noInput,
+		internal: internal,
 		debug:    debug,
 	}
 }

--- a/pkg/jira/issue.go
+++ b/pkg/jira/issue.go
@@ -296,13 +296,22 @@ func (c *Client) GetLinkID(inwardIssue, outwardIssue string) (string, error) {
 	return "", fmt.Errorf("no link found between provided issues")
 }
 
+type issueCommentPropertyValue struct {
+	Internal bool `json:"internal"`
+}
+
+type issueCommentProperty struct {
+	Key   string                    `json:"key"`
+	Value issueCommentPropertyValue `json:"value"`
+}
 type issueCommentRequest struct {
-	Body string `json:"body"`
+	Body       string                 `json:"body"`
+	Properties []issueCommentProperty `json:"properties"`
 }
 
 // AddIssueComment adds comment to an issue using POST /issue/{key}/comment endpoint.
-func (c *Client) AddIssueComment(key, comment string) error {
-	body, err := json.Marshal(&issueCommentRequest{Body: md.ToJiraMD(comment)})
+func (c *Client) AddIssueComment(key, comment string, internal bool) error {
+	body, err := json.Marshal(&issueCommentRequest{Body: md.ToJiraMD(comment), Properties: []issueCommentProperty{{Key: "sd.public.comment", Value: issueCommentPropertyValue{Internal: internal}}}})
 	if err != nil {
 		return err
 	}

--- a/pkg/jira/issue_test.go
+++ b/pkg/jira/issue_test.go
@@ -531,7 +531,7 @@ func TestAddIssueComment(t *testing.T) {
 		actualBody := new(strings.Builder)
 		_, _ = io.Copy(actualBody, r.Body)
 
-		expectedBody := `{"body":"comment"}`
+		expectedBody := `{"body":"comment","properties":[{"key":"sd.public.comment","value":{"internal":false}}]}`
 
 		assert.Equal(t, expectedBody, actualBody.String())
 
@@ -545,12 +545,12 @@ func TestAddIssueComment(t *testing.T) {
 
 	client := NewClient(Config{Server: server.URL}, WithTimeout(3*time.Second))
 
-	err := client.AddIssueComment("TEST-1", "comment")
+	err := client.AddIssueComment("TEST-1", "comment", false)
 	assert.NoError(t, err)
 
 	unexpectedStatusCode = true
 
-	err = client.AddIssueComment("TEST-1", "comment")
+	err = client.AddIssueComment("TEST-1", "comment", false)
 	assert.Error(t, &ErrUnexpectedResponse{}, err)
 }
 


### PR DESCRIPTION
`issue comment add` currently only allows creating public comments.
This MR makes it so creating internal comments is possible using the `--internal` flag , useful on Jira Service Management/Desk.