### PR TITLE
fix: use `tview.Escape` with standard square brackets

### DIFF
--- a/internal/view/board_test.go
+++ b/internal/view/board_test.go
@@ -14,7 +14,7 @@ func TestBoardRender(t *testing.T) {
 
 	data := []*jira.Board{
 		{ID: 1, Name: "First", Type: "scrum"},
-		{ID: 2, Name: "⦗2⦘ Second", Type: "kanban"},
+		{ID: 2, Name: "[2] Second", Type: "kanban"},
 		{ID: 3, Name: "Third", Type: "nextgen"},
 	}
 	board := NewBoard(data, WithBoardWriter(&b))
@@ -22,7 +22,7 @@ func TestBoardRender(t *testing.T) {
 
 	expected := `ID	NAME	TYPE
 1	First	scrum
-2	⦗2⦘ Second	kanban
+2	[2[] Second	kanban
 3	Third	nextgen
 `
 	assert.Equal(t, expected, b.String())

--- a/internal/view/epic_test.go
+++ b/internal/view/epic_test.go
@@ -135,7 +135,7 @@ func TestEpicData(t *testing.T) {
 		},
 		{
 			Key:  "TEST-2",
-			Menu: "➤ TEST-2: ⦗EPIC⦘ This is another test",
+			Menu: "➤ TEST-2: [EPIC[] This is another test",
 			Contents: tui.TableData{
 				[]string{
 					"TYPE", "KEY", "SUMMARY", "STATUS", "ASSIGNEE", "REPORTER", "PRIORITY", "RESOLUTION",

--- a/internal/view/helper.go
+++ b/internal/view/helper.go
@@ -12,6 +12,7 @@ import (
 	"github.com/charmbracelet/glamour"
 	"github.com/fatih/color"
 	"github.com/mgutz/ansi"
+	"github.com/rivo/tview"
 
 	"github.com/ankitpokhrel/jira-cli/internal/cmdutil"
 	"github.com/ankitpokhrel/jira-cli/pkg/browser"
@@ -23,12 +24,12 @@ const (
 	tabWidth = 8
 	helpText = `USAGE
 	-----
-	
-	The layout contains 2 sections, viz: Sidebar and Contents screen.  
-	
+
+	The layout contains 2 sections, viz: Sidebar and Contents screen.
+
 	You can use up and down arrow keys or 'j' and 'k' letters to navigate through the sidebar.
 	Press 'w' or Tab to toggle focus between the sidebar and the contents screen.
-	
+
 	On contents screen:
 	  - Use arrow keys or 'j', 'k', 'h', and 'l' letters to navigate through the issue list.
 	  - Use 'g' and 'SHIFT+G' to quickly navigate to the top and bottom respectively.
@@ -36,7 +37,7 @@ const (
 	  - Press 'c' to copy issue URL to the system clipboard.
 	  - Press 'CTRL+K' to copy issue key to the system clipboard.
 	  - Hit ENTER to open the selected issue in a browser.
-	
+
 	Press 'q' / ESC / CTRL+C to quit.`
 
 	tableHelpText = `[default]ACTIONS AVAILABLE IN THE TUI
@@ -111,16 +112,7 @@ func formatDateTime(dt, format, tz string) string {
 
 func prepareTitle(text string) string {
 	text = strings.TrimSpace(text)
-
-	// Single word within big brackets like [BE] is treated as a
-	// tag and is not parsed by tview creating a gap in the text.
-	//
-	// We will handle this with a little trick by replacing
-	// big brackets with similar-looking unicode characters.
-	text = strings.ReplaceAll(text, "[", "⦗")
-	text = strings.ReplaceAll(text, "]", "⦘")
-
-	return text
+	return tview.Escape(text)
 }
 
 func issueKeyFromTuiData(r int, d interface{}) string {

--- a/internal/view/helper.go
+++ b/internal/view/helper.go
@@ -24,12 +24,12 @@ const (
 	tabWidth = 8
 	helpText = `USAGE
 	-----
-
-	The layout contains 2 sections, viz: Sidebar and Contents screen.
-
+	
+	The layout contains 2 sections, viz: Sidebar and Contents screen.  
+	
 	You can use up and down arrow keys or 'j' and 'k' letters to navigate through the sidebar.
 	Press 'w' or Tab to toggle focus between the sidebar and the contents screen.
-
+	
 	On contents screen:
 	  - Use arrow keys or 'j', 'k', 'h', and 'l' letters to navigate through the issue list.
 	  - Use 'g' and 'SHIFT+G' to quickly navigate to the top and bottom respectively.
@@ -37,7 +37,7 @@ const (
 	  - Press 'c' to copy issue URL to the system clipboard.
 	  - Press 'CTRL+K' to copy issue key to the system clipboard.
 	  - Hit ENTER to open the selected issue in a browser.
-
+	
 	Press 'q' / ESC / CTRL+C to quit.`
 
 	tableHelpText = `[default]ACTIONS AVAILABLE IN THE TUI

--- a/internal/view/helper_test.go
+++ b/internal/view/helper_test.go
@@ -92,7 +92,7 @@ func TestPrepareTitle(t *testing.T) {
 		{
 			name:     "it replace big brackets in title",
 			input:    "[BUG] This is a bug",
-			expected: "⦗BUG⦘ This is a bug",
+			expected: "[BUG[] This is a bug",
 		},
 	}
 

--- a/internal/view/project_test.go
+++ b/internal/view/project_test.go
@@ -27,7 +27,7 @@ func TestProjectRender(t *testing.T) {
 
 	expected := `KEY	NAME	TYPE	LEAD
 FRST	First	classic	Person A
-SCND	⦗2⦘ Second	next-gen	Person B
+SCND	[2[] Second	next-gen	Person B
 THIRD	Third	classic	Person C
 `
 	assert.Equal(t, expected, b.String())

--- a/internal/view/sprint.go
+++ b/internal/view/sprint.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ankitpokhrel/jira-cli/pkg/jira"
 	"github.com/ankitpokhrel/jira-cli/pkg/jira/filter/issue"
 	"github.com/ankitpokhrel/jira-cli/pkg/tui"
+	"github.com/rivo/tview"
 )
 
 // SprintIssueFunc provides issues in the sprint.
@@ -117,13 +118,13 @@ func (sl *SprintList) data() []tui.PreviewData {
 
 		data = append(data, tui.PreviewData{
 			Key: fmt.Sprintf("%d-%d-%s", bid, sid, s.StartDate),
-			Menu: fmt.Sprintf(
-				"➤ #%d %s: ⦗%s - %s⦘",
+			Menu: tview.Escape(fmt.Sprintf(
+				"➤ #%d %s: [%s - %s]",
 				s.ID,
 				prepareTitle(s.Name),
 				cmdutil.FormatDateTimeHuman(s.StartDate, time.RFC3339),
 				cmdutil.FormatDateTimeHuman(s.EndDate, time.RFC3339),
-			),
+			)),
 			Contents: func(key string) interface{} {
 				issues := sl.Issues(bid, sid)
 				return sl.tabularize(issues)

--- a/internal/view/sprint_test.go
+++ b/internal/view/sprint_test.go
@@ -98,7 +98,7 @@ func TestSprintPreviewLayoutData(t *testing.T) {
 		},
 		{
 			Key:  "1-1-2020-12-07T16:12:00.000Z",
-			Menu: "➤ #1 Sprint 1: ⦗Mon, 07 Dec 20 - Sun, 13 Dec 20⦘",
+			Menu: "➤ #1 Sprint 1: [Mon, 07 Dec 20 - Sun, 13 Dec 20[]",
 			Contents: tui.TableData{
 				[]string{
 					"TYPE", "KEY", "SUMMARY", "STATUS", "ASSIGNEE", "REPORTER", "PRIORITY", "RESOLUTION",
@@ -112,7 +112,7 @@ func TestSprintPreviewLayoutData(t *testing.T) {
 		},
 		{
 			Key:  "1-2-2020-12-13T16:12:00.000Z",
-			Menu: "➤ #2 Sprint 2: ⦗Sun, 13 Dec 20 - Sat, 19 Dec 20⦘",
+			Menu: "➤ #2 Sprint 2: [Sun, 13 Dec 20 - Sat, 19 Dec 20[]",
 			Contents: tui.TableData{
 				[]string{
 					"TYPE", "KEY", "SUMMARY", "STATUS", "ASSIGNEE", "REPORTER", "PRIORITY", "RESOLUTION",
@@ -141,6 +141,7 @@ func TestSprintPreviewLayoutData(t *testing.T) {
 		case tui.TableData:
 			assert.Equal(t, expected[i].Contents.(tui.TableData), d.Contents(d.Key))
 		}
+
 	}
 }
 


### PR DESCRIPTION
The original implementation of `prepareTitle`, as well as the date ranges for sprints, used nonstandard brackets `⦗⦘` as replacements for square brackets `[]` in a hack to work around `tview` interpreting square brackets as format tags. This was causing visual problems for some powerline fonts.

The [documentation](https://pkg.go.dev/github.com/rivo/tview) for `tview` mentions that bracketed strings may be escaped by typing `[text[]` instead of `[text]`, and the package provides `tview.Escape(str)` to perform that conversion.

This change switches to using the escape function. I tried to minimize the amount of things I was touching, which also means that the expected strings in tests are a bit ugly.
