### PR TITLE
feat: new option description issue view plain mode

### DIFF
--- a/internal/cmd/issue/view/view.go
+++ b/internal/cmd/issue/view/view.go
@@ -23,10 +23,11 @@ $ jira issue view ISSUE-1 --comments 5
 # Get the raw JSON data
 $ jira issue view ISSUE-1 --raw`
 
-	flagRaw      = "raw"
-	flagDebug    = "debug"
-	flagComments = "comments"
-	flagPlain    = "plain"
+	flagRaw         = "raw"
+	flagDebug       = "debug"
+	flagComments    = "comments"
+	flagPlain       = "plain"
+	flagDescription = "description"
 
 	configProject = "project.key"
 	configServer  = "server"
@@ -51,6 +52,7 @@ func NewCmdView() *cobra.Command {
 
 	cmd.Flags().Uint(flagComments, 1, "Show N comments")
 	cmd.Flags().Bool(flagPlain, false, "Display output in plain mode")
+	cmd.Flags().Bool(flagDescription, false, "Displays only the issue description. Works only with --plain")
 	cmd.Flags().Bool(flagRaw, false, "Print raw Jira API response")
 
 	return &cmd
@@ -111,11 +113,14 @@ func viewPretty(cmd *cobra.Command, args []string) {
 	plain, err := cmd.Flags().GetBool(flagPlain)
 	cmdutil.ExitIfError(err)
 
+	description, err := cmd.Flags().GetBool(flagDescription)
+	cmdutil.ExitIfError(err)
+
 	v := tuiView.Issue{
 		Server:  viper.GetString(configServer),
 		Data:    iss,
 		Display: tuiView.DisplayFormat{Plain: plain},
-		Options: tuiView.IssueOption{NumComments: comments},
+		Options: tuiView.IssueOption{NumComments: comments, Description: description},
 	}
 	cmdutil.ExitIfError(v.Render())
 }

--- a/internal/view/issue.go
+++ b/internal/view/issue.go
@@ -43,6 +43,7 @@ type issueComment struct {
 // IssueOption is filtering options for an issue.
 type IssueOption struct {
 	NumComments uint
+	Description bool
 }
 
 // Issue is a list view for issues.
@@ -90,6 +91,11 @@ func (i Issue) RenderedOut(renderer *glamour.TermRenderer) (string, error) {
 
 func (i Issue) String() string {
 	var s strings.Builder
+
+	if i.Options.Description {
+		s.WriteString(i.description())
+		return s.String()
+	}
 
 	s.WriteString(i.header())
 

--- a/internal/view/issue_test.go
+++ b/internal/view/issue_test.go
@@ -87,6 +87,51 @@ func TestIssueDetailsRenderInPlainView(t *testing.T) {
 	assert.Equal(t, tui.TextData(expected), tui.TextData(actual))
 }
 
+func TestIssueDescriptionRenderInPlainView(t *testing.T) {
+	t.Parallel()
+
+	var b bytes.Buffer
+
+	data := &jira.Issue{
+		Key: "TEST-VIEW-DESCRIPTION",
+		Fields: jira.IssueFields{
+			Summary: "Test view description",
+			Resolution: struct {
+				Name string `json:"name"`
+			}{Name: "Fixed"},
+			Description: &adf.ADF{
+				Version: 1,
+				DocType: "doc",
+				Content: []*adf.Node{
+					{
+						NodeType: "paragraph",
+						Content: []*adf.Node{
+							{NodeType: "text", NodeValue: adf.NodeValue{Text: "Test view description"}},
+						},
+					},
+				},
+			},
+			IssueType: jira.IssueType{Name: "Bug"},
+			Created:   "2020-12-13T14:05:20.974+0100",
+			Updated:   "2020-12-13T14:07:20.974+0100",
+		},
+	}
+
+	issue := Issue{
+		Server:  "https://test.local",
+		Data:    data,
+		Display: DisplayFormat{Plain: true},
+		Options: IssueOption{Description: true},
+	}
+
+	expected := issue.description()
+
+	actual := issue.String()
+
+	assert.NoError(t, issue.renderPlain(&b))
+	assert.Equal(t, tui.TextData(expected), tui.TextData(actual))
+}
+
 func TestIssueDetailsWithV2Description(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
### Description

This PR adds support for displaying only the issue description when the `--plain` flag is used. This is useful for scripts, piping, or users who prefer a minimal output format.

### Changes

- Added a new output mode that shows **only the issue description**.
- This feature is **available exclusively with the `--plain` flag** to ensure consistent, non-formatted output.

### Usage

```bash
jira issue view ISSUE-123 --plain --description
```