### PR TITLE
feat: Add releases Subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -653,6 +653,21 @@ $ jira sprint add
 $ jira sprint add SPRINT_ID ISSUE-1 ISSUE-2
 ```
 
+### Releases
+
+Interact with releases (project versions).  
+Ensure the [feature is enabled](https://support.atlassian.com/jira-software-cloud/docs/enable-releases-and-versions/) on your instance.
+
+#### List
+
+```sh
+# List releases for default project
+$ jira release list
+
+# List releases for specific project
+$ jira release list --project 1000
+```
+
 ### Other commands
 
 <details><summary>Navigate to the project</summary>

--- a/internal/cmd/release/list/list.go
+++ b/internal/cmd/release/list/list.go
@@ -1,0 +1,50 @@
+package list
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/ankitpokhrel/jira-cli/api"
+	"github.com/ankitpokhrel/jira-cli/internal/cmdutil"
+	"github.com/ankitpokhrel/jira-cli/internal/view"
+	"github.com/ankitpokhrel/jira-cli/pkg/jira"
+)
+
+// NewCmdList is a list command.
+func NewCmdList() *cobra.Command {
+	return &cobra.Command{
+		Use:     "list",
+		Short:   "List lists Jira projects versions",
+		Long:    "List lists Jira projects versions that a user has access to.",
+		Aliases: []string{"lists", "ls"},
+		Run:     List,
+	}
+}
+
+// List displays a list view.
+func List(cmd *cobra.Command, _ []string) {
+	project := viper.GetString("project.key")
+	debug, err := cmd.Flags().GetBool("debug")
+	cmdutil.ExitIfError(err)
+
+	releases, total, err := func() ([]*jira.ProjectVersion, int, error) {
+		s := cmdutil.Info("Fetching project versions...")
+		defer s.Stop()
+
+		releases, err := api.DefaultClient(debug).Release(project)
+		if err != nil {
+			return nil, 0, err
+		}
+		return releases, len(releases), nil
+	}()
+	cmdutil.ExitIfError(err)
+
+	if total == 0 {
+		cmdutil.Failed("No releases found.")
+		return
+	}
+
+	v := view.NewRelease(releases)
+
+	cmdutil.ExitIfError(v.Render())
+}

--- a/internal/cmd/release/release.go
+++ b/internal/cmd/release/release.go
@@ -1,0 +1,29 @@
+package release
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/ankitpokhrel/jira-cli/internal/cmd/release/list"
+)
+
+const helpText = `Release manages Jira Project versions. See available commands below.`
+
+// NewCmdRelease is a project command.
+func NewCmdRelease() *cobra.Command {
+	cmd := cobra.Command{
+		Use:         "release",
+		Short:       "Release manages Jira Project versions",
+		Long:        helpText,
+		Annotations: map[string]string{"cmd:main": "true"},
+		Aliases:     []string{"releases"},
+		RunE:        releases,
+	}
+
+	cmd.AddCommand(list.NewCmdList())
+
+	return &cmd
+}
+
+func releases(cmd *cobra.Command, _ []string) error {
+	return cmd.Help()
+}

--- a/internal/cmd/root/root.go
+++ b/internal/cmd/root/root.go
@@ -16,6 +16,7 @@ import (
 	"github.com/ankitpokhrel/jira-cli/internal/cmd/me"
 	"github.com/ankitpokhrel/jira-cli/internal/cmd/open"
 	"github.com/ankitpokhrel/jira-cli/internal/cmd/project"
+	"github.com/ankitpokhrel/jira-cli/internal/cmd/release"
 	"github.com/ankitpokhrel/jira-cli/internal/cmd/serverinfo"
 	"github.com/ankitpokhrel/jira-cli/internal/cmd/sprint"
 	"github.com/ankitpokhrel/jira-cli/internal/cmd/version"
@@ -131,6 +132,7 @@ func addChildCommands(cmd *cobra.Command) {
 		serverinfo.NewCmdServerInfo(),
 		completion.NewCmdCompletion(),
 		version.NewCmdVersion(),
+		release.NewCmdRelease(),
 		man.NewCmdMan(),
 	)
 }

--- a/internal/view/release.go
+++ b/internal/view/release.go
@@ -1,0 +1,84 @@
+package view
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"text/tabwriter"
+
+	"github.com/ankitpokhrel/jira-cli/pkg/jira"
+	"github.com/ankitpokhrel/jira-cli/pkg/tui"
+)
+
+// ProjectOption is a functional option to wrap project properties.
+type ProjectVersionOptions func(*Release)
+
+// Project is a project view.
+type Release struct {
+	data   []*jira.ProjectVersion
+	writer io.Writer
+	buf    *bytes.Buffer
+}
+
+// NewProject initializes a project.
+func NewRelease(data []*jira.ProjectVersion, opts ...ProjectVersionOptions) *Release {
+	r := Release{
+		data: data,
+		buf:  new(bytes.Buffer),
+	}
+	r.writer = tabwriter.NewWriter(r.buf, 0, tabWidth, 1, '\t', 0)
+
+	for _, opt := range opts {
+		opt(&r)
+	}
+	return &r
+}
+
+// WithProjectWriter sets a writer for the project.
+func WithReleaseWriter(w io.Writer) ProjectVersionOptions {
+	return func(r *Release) {
+		r.writer = w
+	}
+}
+
+// Render renders the project view.
+func (r Release) Render() error {
+	r.printHeader()
+
+	for _, d := range r.data {
+		desc := ""
+		if d.Description != nil {
+			desc = fmt.Sprint(d.Description)
+		}
+		_, _ = fmt.Fprintf(r.writer, "%v\t%v\t%v\t%v\n", d.ID, prepareTitle(d.Name), d.Released, desc)
+	}
+	if _, ok := r.writer.(*tabwriter.Writer); ok {
+		err := r.writer.(*tabwriter.Writer).Flush()
+		if err != nil {
+			return err
+		}
+	}
+
+	return tui.PagerOut(r.buf.String())
+}
+
+func (r Release) header() []string {
+	return []string{
+		"ID",
+		"NAME",
+		"RELEASED",
+		"DESCRIPTION",
+	}
+}
+
+func (r Release) printHeader() {
+	headers := r.header()
+	end := len(headers) - 1
+	for i, h := range headers {
+		_, _ = fmt.Fprintf(r.writer, "%s", h)
+		if i != end {
+			_, _ = fmt.Fprintf(r.writer, "\t")
+		}
+	}
+	_, _ = fmt.Fprintln(r.writer)
+}

--- a/internal/view/release_test.go
+++ b/internal/view/release_test.go
@@ -1,0 +1,34 @@
+package view
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/ankitpokhrel/jira-cli/pkg/jira"
+)
+
+func TestReleaseRender(t *testing.T) {
+	var b bytes.Buffer
+
+	//nolint:unused
+	type lead struct {
+		Name string `json:"displayName"`
+	}
+
+	data := []*jira.ProjectVersion{
+		{ID: "1000", Name: "First", Released: true, Description: "Release A"},
+		{ID: "1001", Name: "Second", Released: false, Description: "Release B"},
+		{ID: "1002", Name: "Third", Released: false, Description: "Release C"},
+	}
+	project := NewRelease(data, WithReleaseWriter(&b))
+	assert.NoError(t, project.Render())
+
+	expected := `ID	NAME	RELEASED	DESCRIPTION
+1000	First	true	Release A
+1001	Second	false	Release B
+1002	Third	false	Release C
+`
+	assert.Equal(t, expected, b.String())
+}

--- a/pkg/jira/release.go
+++ b/pkg/jira/release.go
@@ -1,0 +1,31 @@
+package jira
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+// Release fetches response from /project/{projectIdOrKey}/version endpoint.
+func (c *Client) Release(project string) ([]*ProjectVersion, error) {
+	path := fmt.Sprintf("/project/%s/versions", project)
+	res, err := c.Get(context.Background(), path, nil)
+	if err != nil {
+		return nil, err
+	}
+	if res == nil {
+		return nil, ErrEmptyResponse
+	}
+	defer func() { _ = res.Body.Close() }()
+
+	if res.StatusCode != http.StatusOK {
+		return nil, formatUnexpectedResponse(res)
+	}
+
+	var out []*ProjectVersion
+
+	err = json.NewDecoder(res.Body).Decode(&out)
+
+	return out, err
+}

--- a/pkg/jira/release_test.go
+++ b/pkg/jira/release_test.go
@@ -1,0 +1,70 @@
+package jira
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestReleases(t *testing.T) {
+	var unexpectedStatusCode bool
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/rest/api/3/project/1000/versions", r.URL.Path)
+
+		if unexpectedStatusCode {
+			w.WriteHeader(400)
+		} else {
+
+			resp, err := os.ReadFile("./testdata/releases.json")
+			assert.NoError(t, err)
+
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(200)
+			_, _ = w.Write(resp)
+		}
+	}))
+	defer server.Close()
+
+	client := NewClient(Config{Server: server.URL}, WithTimeout(3*time.Second))
+
+	actual, err := client.Release("1000")
+	assert.NoError(t, err)
+
+	expected := []*ProjectVersion{
+		{
+			ID:          "1000",
+			Description: "Release A",
+			Name:        "First",
+			Archived:    false,
+			Released:    true,
+			ProjectID:   1000,
+		},
+		{
+			ID:          "1001",
+			Description: "Release B",
+			Name:        "Second",
+			Archived:    false,
+			Released:    false,
+			ProjectID:   1000,
+		},
+		{
+			ID:          "1002",
+			Description: "Release C",
+			Name:        "Third",
+			Archived:    true,
+			Released:    false,
+			ProjectID:   1000,
+		},
+	}
+	assert.Equal(t, expected, actual)
+
+	unexpectedStatusCode = true
+
+	_, err = client.Release("1000")
+	assert.Error(t, &ErrUnexpectedResponse{}, err)
+}

--- a/pkg/jira/testdata/releases.json
+++ b/pkg/jira/testdata/releases.json
@@ -1,0 +1,26 @@
+[
+    {
+        "id": "1000",
+        "description": "Release A",
+        "name": "First",
+        "archived": false,
+        "released": true,
+        "projectId": 1000
+    },
+    {
+        "id": "1001",
+        "description": "Release B",
+        "name": "Second",
+        "archived": false,
+        "released": false,
+        "projectId": 1000
+    },
+    {
+        "id": "1002",
+        "description": "Release C",
+        "name": "Third",
+        "archived": true,
+        "released": false,
+        "projectId": 1000
+    }
+]

--- a/pkg/jira/types.go
+++ b/pkg/jira/types.go
@@ -36,6 +36,16 @@ type Project struct {
 	Type string `json:"style"`
 }
 
+// ProjectVersion holds project version info.
+type ProjectVersion struct {
+	Archived    bool        `json:"archived"`
+	Description interface{} `json:"description"`
+	ID          string      `json:"id"`
+	Name        string      `json:"name"`
+	ProjectID   int         `json:"projectId"`
+	Released    bool        `json:"released"`
+}
+
 // Board holds board info.
 type Board struct {
 	ID   int    `json:"id"`


### PR DESCRIPTION
Add a subcommand for interacting with Jira releases (project versions)
using the non paginated API endpoint (which provides less
information compared to the paginated endpoint).
