### PR TITLE
Add support for environment variable to specify config file path

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,15 @@ default.
 #### Shell completion
 Check `jira completion --help` for more info on setting up a bash/zsh shell completion.
 
+#### Multiple projects
+
+The tool honors the `JIRA_CONFIG_FILE` environment variable, which specifies the location of the configuration file:
+
+```sh
+JIRA_CONFIG_FILE=./local_jira_config.yaml jira issue list 
+
+```
+
 ## Usage
 The tool currently comes with an issue, epic, and sprint explorer. The flags are [POSIX-compliant](https://www.gnu.org/software/libc/manual/html_node/Argument-Syntax.html).
 You can combine available flags in any order to create a unique query. For example, the command below will give you high priority issues created this month

--- a/internal/cmd/root/root.go
+++ b/internal/cmd/root/root.go
@@ -42,8 +42,13 @@ var (
 func init() {
 	cobra.OnInitialize(func() {
 		if config != "" {
+			// 1. Command line flag has the highest priority
 			viper.SetConfigFile(config)
+		} else if configFile := os.Getenv("JIRA_CONFIG_FILE"); configFile != "" {
+			// 2. Environment variable has second priority
+			viper.SetConfigFile(configFile)
 		} else {
+			// 3. Default location has the lowest priority
 			home, err := cmdutil.GetConfigHome()
 			if err != nil {
 				cmdutil.Failed("Error: %s", err)
@@ -98,7 +103,7 @@ func NewCmdRoot() *cobra.Command {
 
 	cmd.PersistentFlags().StringVarP(
 		&config, "config", "c", "",
-		fmt.Sprintf("Config file (default is %s/%s/%s.yml)", configHome, jiraConfig.Dir, jiraConfig.FileName),
+		fmt.Sprintf("Config file (default is %s/%s/%s.yml, can be overridden with JIRA_CONFIG_FILE env var)", configHome, jiraConfig.Dir, jiraConfig.FileName),
 	)
 	cmd.PersistentFlags().StringP(
 		"project", "p", "",


### PR DESCRIPTION
Solves #713 #434

This pull request introduces a new environment variable, `JIRA_CONFIG_FILE`, which allows users to specify the path to the configuration file.

A common use case is working with multiple Jira servers across different projects simultaneously. In such scenarios, it’s helpful to maintain separate configuration files to avoid conflicts, especially with credentials.

While the solution proposed in #434 — using the `--config/-c` flag — is a valid option, it requires specifying the argument manually for every command. This approach is prone to errors and adds complexity when writing automated scripts.

Similarly, the solution proposed in #713 — relying on the `XDG_CONFIG_HOME` environment variable — affects a broader range of tools beyond `jira-cli`, which may lead to unintended side effects.

Using a dedicated environment variable like `JIRA_CONFIG_FILE` offers a more isolated, portable, and context-specific solution. It integrates cleanly into different workflows without impacting other tools or requiring repeated CLI arguments.
