### PR TITLE
fix: usernames can be 2 chars

### DIFF
--- a/internal/config/generator.go
+++ b/internal/config/generator.go
@@ -380,7 +380,7 @@ func (c *JiraCLIConfigGenerator) configureServerAndLoginDetails() error {
 					if !ok {
 						return errInvalidUser
 					}
-					if len(str) < 3 || len(str) > 254 {
+					if len(str) < 2 || len(str) > 254 {
 						return errInvalidUser
 					}
 


### PR DESCRIPTION
Valid usernames can be only two characters.  Don't exclude these users from using this tool!