### PR TITLE
fix: Update deprecated endpoint

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -138,7 +138,7 @@ func ProxySearch(c *jira.Client, jql string, from, limit uint) (*jira.SearchResu
 	if it == jira.InstallationTypeLocal {
 		issues, err = c.SearchV2(jql, from, limit)
 	} else {
-		issues, err = c.Search(jql, from, limit)
+		issues, err = c.Search(jql, limit)
 	}
 
 	return issues, err

--- a/internal/cmd/epic/list/list.go
+++ b/internal/cmd/epic/list/list.go
@@ -127,6 +127,9 @@ func singleEpicView(flags query.FlagParser, key, project, projectType, server st
 	plain, err := flags.GetBool("plain")
 	cmdutil.ExitIfError(err)
 
+	delimiter, err := flags.GetString("delimiter")
+	cmdutil.ExitIfError(err)
+
 	csv, err := flags.GetBool("csv")
 	cmdutil.ExitIfError(err)
 
@@ -151,6 +154,7 @@ func singleEpicView(flags query.FlagParser, key, project, projectType, server st
 		},
 		Display: view.DisplayFormat{
 			Plain:        plain,
+			Delimiter:    delimiter,
 			CSV:          csv,
 			NoHeaders:    noHeaders,
 			NoTruncate:   noTruncate,

--- a/internal/cmd/epic/list/list.go
+++ b/internal/cmd/epic/list/list.go
@@ -106,7 +106,7 @@ func singleEpicView(flags query.FlagParser, key, project, projectType, server st
 			q.Params().Parent = key
 			q.Params().IssueType = ""
 
-			resp, err = client.Search(q.Get(), q.Params().From, q.Params().Limit)
+			resp, err = client.Search(q.Get(), q.Params().Limit)
 		} else {
 			resp, err = client.EpicIssues(key, q.Get(), q.Params().From, q.Params().Limit)
 		}
@@ -205,7 +205,7 @@ func epicExplorerView(cmd *cobra.Command, flags query.FlagParser, project, proje
 				q.Params().Parent = key
 				q.Params().IssueType = ""
 
-				resp, err = client.Search(q.Get(), q.Params().From, q.Params().Limit)
+				resp, err = client.Search(q.Get(), q.Params().Limit)
 			} else {
 				resp, err = client.EpicIssues(key, "", q.Params().From, q.Params().Limit)
 			}

--- a/internal/cmd/epic/list/list.go
+++ b/internal/cmd/epic/list/list.go
@@ -91,13 +91,13 @@ func singleEpicView(flags query.FlagParser, key, project, projectType, server st
 	err := flags.Set("type", "") // Unset issue type.
 	cmdutil.ExitIfError(err)
 
-	issues, total, err := func() ([]*jira.Issue, int, error) {
+	issues, err := func() ([]*jira.Issue, error) {
 		s := cmdutil.Info("Fetching epic issues...")
 		defer s.Stop()
 
 		q, err := query.NewIssue(project, flags)
 		if err != nil {
-			return nil, 0, err
+			return nil, err
 		}
 
 		var resp *jira.SearchResult
@@ -112,13 +112,13 @@ func singleEpicView(flags query.FlagParser, key, project, projectType, server st
 		}
 
 		if err != nil {
-			return nil, 0, err
+			return nil, err
 		}
-		return resp.Issues, resp.Total, nil
+		return resp.Issues, nil
 	}()
 	cmdutil.ExitIfError(err)
 
-	if total == 0 {
+	if len(issues) == 0 {
 		fmt.Println()
 		cmdutil.Failed("No result found for given query in project %q", project)
 		return
@@ -145,7 +145,6 @@ func singleEpicView(flags query.FlagParser, key, project, projectType, server st
 	v := view.IssueList{
 		Project: project,
 		Server:  server,
-		Total:   total,
 		Data:    issues,
 		Refresh: func() {
 			singleEpicView(flags, key, project, projectType, server, client)
@@ -174,19 +173,19 @@ func epicExplorerView(cmd *cobra.Command, flags query.FlagParser, project, proje
 	q, err := query.NewIssue(project, flags)
 	cmdutil.ExitIfError(err)
 
-	epics, total, err := func() ([]*jira.Issue, int, error) {
+	epics, err := func() ([]*jira.Issue, error) {
 		s := cmdutil.Info("Fetching epics...")
 		defer s.Stop()
 
 		resp, err := api.ProxySearch(client, q.Get(), q.Params().From, q.Params().Limit)
 		if err != nil {
-			return nil, 0, err
+			return nil, err
 		}
-		return resp.Issues, resp.Total, nil
+		return resp.Issues, nil
 	}()
 	cmdutil.ExitIfError(err)
 
-	if total == 0 {
+	if len(epics) == 0 {
 		fmt.Println()
 		cmdutil.Failed("No result found for given query in project %q", project)
 		return
@@ -196,7 +195,6 @@ func epicExplorerView(cmd *cobra.Command, flags query.FlagParser, project, proje
 	cmdutil.ExitIfError(err)
 
 	v := view.EpicList{
-		Total:   total,
 		Project: project,
 		Server:  server,
 		Data:    epics,

--- a/internal/cmd/issue/list/list.go
+++ b/internal/cmd/issue/list/list.go
@@ -109,25 +109,25 @@ func loadList(cmd *cobra.Command, args []string) {
 		cmdutil.ExitIfError(cmd.Flags().Set("jql", searchQuery))
 	}
 
-	issues, total, err := func() ([]*jira.Issue, int, error) {
+	issues, err := func() ([]*jira.Issue, error) {
 		s := cmdutil.Info("Fetching issues...")
 		defer s.Stop()
 
 		q, err := query.NewIssue(project, cmd.Flags())
 		if err != nil {
-			return nil, 0, err
+			return nil, err
 		}
 
 		resp, err := api.ProxySearch(api.DefaultClient(debug), q.Get(), q.Params().From, q.Params().Limit)
 		if err != nil {
-			return nil, 0, err
+			return nil, err
 		}
 
-		return resp.Issues, resp.Total, nil
+		return resp.Issues, nil
 	}()
 	cmdutil.ExitIfError(err)
 
-	if total == 0 {
+	if len(issues) == 0 {
 		fmt.Println()
 		cmdutil.Failed("No result found for given query in project %q", project)
 		return
@@ -173,7 +173,6 @@ func loadList(cmd *cobra.Command, args []string) {
 	v := view.IssueList{
 		Project: project,
 		Server:  server,
-		Total:   total,
 		Data:    issues,
 		Refresh: func() {
 			loadList(cmd, args)

--- a/internal/cmd/sprint/list/list.go
+++ b/internal/cmd/sprint/list/list.go
@@ -93,26 +93,26 @@ func sprintList(cmd *cobra.Command, args []string) {
 }
 
 func singleSprintView(sprintQuery *query.Sprint, flags query.FlagParser, boardID, sprintID int, project, server string, client *jira.Client, sprint *jira.Sprint) {
-	issues, total, err := func() ([]*jira.Issue, int, error) {
+	issues, err := func() ([]*jira.Issue, error) {
 		s := cmdutil.Info("Fetching sprint issues...")
 		defer s.Stop()
 
 		q, err := query.NewIssue(project, flags)
 		if err != nil {
-			return nil, 0, err
+			return nil, err
 		}
 		if sprintQuery.Params().ShowAllIssues {
 			q.Params().JQL = "project IS NOT EMPTY"
 		}
 		resp, err := client.SprintIssues(sprintID, q.Get(), q.Params().From, q.Params().Limit)
 		if err != nil {
-			return nil, 0, err
+			return nil, err
 		}
-		return resp.Issues, resp.Total, nil
+		return resp.Issues, nil
 	}()
 	cmdutil.ExitIfError(err)
 
-	if total == 0 {
+	if len(issues) == 0 {
 		fmt.Println()
 		cmdutil.Failed("No result found for given query in project %q", project)
 		return
@@ -140,28 +140,27 @@ func singleSprintView(sprintQuery *query.Sprint, flags query.FlagParser, boardID
 	if sprint != nil {
 		if sprint.Status == jira.SprintStateFuture {
 			ft = fmt.Sprintf(
-				"Showing %d of %d results for project %q in sprint #%d ➤ %s (Future Sprint)",
-				len(issues), total, project, sprint.ID, sprint.Name,
+				"Showing %d results for project %q in sprint #%d ➤ %s (Future Sprint)",
+				len(issues), project, sprint.ID, sprint.Name,
 			)
 		} else {
 			ft = fmt.Sprintf(
-				"Showing %d of %d results for project %q in sprint #%d ➤ %s (%s - %s)",
-				len(issues), total, project, sprint.ID, sprint.Name,
+				"Showing %d results for project %q in sprint #%d ➤ %s (%s - %s)",
+				len(issues), project, sprint.ID, sprint.Name,
 				cmdutil.FormatDateTimeHuman(sprint.StartDate, time.RFC3339),
 				cmdutil.FormatDateTimeHuman(sprint.EndDate, time.RFC3339),
 			)
 		}
 	} else {
 		ft = fmt.Sprintf(
-			"Showing %d of %d results for project %q in sprint #%d",
-			len(issues), total, project, sprintID,
+			"Showing %d results for project %q in sprint #%d",
+			len(issues), project, sprintID,
 		)
 	}
 
 	v := view.IssueList{
 		Project:    project,
 		Server:     server,
-		Total:      total,
 		Data:       issues,
 		FooterText: ft,
 		Refresh: func() {

--- a/internal/cmd/sprint/list/list.go
+++ b/internal/cmd/sprint/list/list.go
@@ -124,6 +124,9 @@ func singleSprintView(sprintQuery *query.Sprint, flags query.FlagParser, boardID
 	csv, err := flags.GetBool("csv")
 	cmdutil.ExitIfError(err)
 
+	delimiter, err := flags.GetString("delimiter")
+	cmdutil.ExitIfError(err)
+
 	noHeaders, err := flags.GetBool("no-headers")
 	cmdutil.ExitIfError(err)
 
@@ -168,6 +171,7 @@ func singleSprintView(sprintQuery *query.Sprint, flags query.FlagParser, boardID
 		},
 		Display: view.DisplayFormat{
 			Plain:        plain,
+			Delimiter:    delimiter,
 			CSV:          csv,
 			NoHeaders:    noHeaders,
 			NoTruncate:   noTruncate,

--- a/internal/view/epic.go
+++ b/internal/view/epic.go
@@ -70,7 +70,7 @@ func (el *EpicList) data() []tui.PreviewData {
 	data = append(data, tui.PreviewData{
 		Key:  "help",
 		Menu: "?",
-		Contents: func(s string) any {
+		Contents: func(_ string) any {
 			return helpText
 		},
 	})

--- a/internal/view/epic.go
+++ b/internal/view/epic.go
@@ -14,7 +14,6 @@ type EpicIssueFunc func(string) []*jira.Issue
 
 // EpicList is a list view for epics.
 type EpicList struct {
-	Total   int
 	Project string
 	Server  string
 	Data    []*jira.Issue
@@ -33,21 +32,21 @@ func (el *EpicList) Render() error {
 
 	data := el.data()
 	view := tui.NewPreview(
-		tui.WithPreviewFooterText(fmt.Sprintf("Showing %d of %d results for project %q", len(el.Data), el.Total, el.Project)),
+		tui.WithPreviewFooterText(fmt.Sprintf("Showing %d results for project %q", len(el.Data), el.Project)),
 		tui.WithInitialText(helpText),
 		tui.WithSidebarSelectedFunc(navigate(el.Server)),
 		tui.WithContentTableOpts(
 			tui.WithTableStyle(el.Display.TableStyle),
 			tui.WithFixedColumns(el.Display.FixedColumns),
 			tui.WithSelectedFunc(navigate(el.Server)),
-			tui.WithViewModeFunc(func(r, c int, d interface{}) (func() interface{}, func(interface{}) (string, error)) {
-				dataFn := func() interface{} {
+			tui.WithViewModeFunc(func(r, c int, d any) (func() any, func(any) (string, error)) {
+				dataFn := func() any {
 					data := d.(tui.TableData)
 					ci := data.GetIndex(fieldKey)
 					iss, _ := api.ProxyGetIssue(api.DefaultClient(false), data.Get(r, ci), issue.NewNumCommentsFilter(1))
 					return iss
 				}
-				renderFn := func(i interface{}) (string, error) {
+				renderFn := func(i any) (string, error) {
 					iss := Issue{
 						Server:  el.Server,
 						Data:    i.(*jira.Issue),
@@ -71,7 +70,7 @@ func (el *EpicList) data() []tui.PreviewData {
 	data = append(data, tui.PreviewData{
 		Key:  "help",
 		Menu: "?",
-		Contents: func(s string) interface{} {
+		Contents: func(s string) any {
 			return helpText
 		},
 	})
@@ -79,7 +78,7 @@ func (el *EpicList) data() []tui.PreviewData {
 		data = append(data, tui.PreviewData{
 			Key:  issue.Key,
 			Menu: fmt.Sprintf("➤ %s: %s", issue.Key, prepareTitle(issue.Fields.Summary)),
-			Contents: func(key string) interface{} {
+			Contents: func(key string) any {
 				issues := el.Issues(key)
 				return el.tabularize(issues)
 			},

--- a/internal/view/epic_test.go
+++ b/internal/view/epic_test.go
@@ -97,7 +97,6 @@ func TestEpicData(t *testing.T) {
 	}
 
 	epic := EpicList{
-		Total:   2,
 		Project: "TEST",
 		Server:  "https://test.local",
 		Data:    []*jira.Issue{&epic1, &epic2},

--- a/internal/view/issues.go
+++ b/internal/view/issues.go
@@ -29,7 +29,6 @@ type DisplayFormat struct {
 
 // IssueList is a list view for issues.
 type IssueList struct {
-	Total      int
 	Project    string
 	Server     string
 	Data       []*jira.Issue
@@ -62,7 +61,7 @@ func (l *IssueList) Render() error {
 
 	data := l.data()
 	if l.FooterText == "" {
-		l.FooterText = fmt.Sprintf("Showing %d of %d results for project %q", len(data)-1, l.Total, l.Project)
+		l.FooterText = fmt.Sprintf("Showing %d results for project %q", len(data)-1, l.Project)
 	}
 
 	view := tui.NewTable(

--- a/internal/view/issues_test.go
+++ b/internal/view/issues_test.go
@@ -12,7 +12,6 @@ import (
 
 func TestIssueData(t *testing.T) {
 	issue := IssueList{
-		Total:   2,
 		Project: "TEST",
 		Server:  "https://test.local",
 		Data:    getIssues(),
@@ -42,7 +41,6 @@ func TestIssueRenderInPlainView(t *testing.T) {
 	var b bytes.Buffer
 
 	issue := IssueList{
-		Total:   2,
 		Project: "TEST",
 		Server:  "https://test.local",
 		Data:    getIssues(),
@@ -65,7 +63,6 @@ func TestIssueRenderInPlainViewWithCustomDelimiter(t *testing.T) {
 	var b bytes.Buffer
 
 	issue := IssueList{
-		Total:   2,
 		Project: "TEST",
 		Server:  "https://test.local",
 		Data:    getIssues(),
@@ -88,7 +85,6 @@ func TestIssueRenderInPlainViewAndNoTruncate(t *testing.T) {
 	var b bytes.Buffer
 
 	issue := IssueList{
-		Total:   2,
 		Project: "TEST",
 		Server:  "https://test.local",
 		Data:    getIssues(),
@@ -111,7 +107,6 @@ func TestIssueRenderInPlainViewWithoutHeaders(t *testing.T) {
 	var b bytes.Buffer
 
 	issue := IssueList{
-		Total:   2,
 		Project: "TEST",
 		Server:  "https://test.local",
 		Data:    getIssues(),
@@ -135,7 +130,6 @@ func TestIssueRenderInPlainViewWithFewColumns(t *testing.T) {
 	data := getIssues()
 
 	issue := IssueList{
-		Total:   2,
 		Project: "TEST",
 		Server:  "https://test.local",
 		Data:    data,

--- a/pkg/jira/epic_test.go
+++ b/pkg/jira/epic_test.go
@@ -47,9 +47,7 @@ func TestEpicIssues(t *testing.T) {
 	assert.NoError(t, err)
 
 	expected := &SearchResult{
-		StartAt:    0,
-		MaxResults: 50,
-		Total:      3,
+		IsLast: true,
 		Issues: []*Issue{
 			{
 				Key: "TEST-1",

--- a/pkg/jira/search.go
+++ b/pkg/jira/search.go
@@ -16,18 +16,18 @@ type SearchResult struct {
 }
 
 // Search searches for issues using v3 version of the Jira GET /search endpoint.
-func (c *Client) Search(jql string, from, limit uint) (*SearchResult, error) {
+func (c *Client) Search(jql string, limit uint) (*SearchResult, error) {
 	path := fmt.Sprintf("/search/jql?jql=%s&maxResults=%d&fields=*all", url.QueryEscape(jql), limit)
-	return c.search(jql, from, limit, path, apiVersion3)
+	return c.search(path, apiVersion3)
 }
 
 // SearchV2 searches an issues using v2 version of the Jira GET /search endpoint.
 func (c *Client) SearchV2(jql string, from, limit uint) (*SearchResult, error) {
 	path := fmt.Sprintf("/search?jql=%s&startAt=%d&maxResults=%d", url.QueryEscape(jql), from, limit)
-	return c.search(jql, from, limit, path, apiVersion2)
+	return c.search(path, apiVersion2)
 }
 
-func (c *Client) search(jql string, from, limit uint, path, ver string) (*SearchResult, error) {
+func (c *Client) search(path, ver string) (*SearchResult, error) {
 	var (
 		res *http.Response
 		err error

--- a/pkg/jira/search.go
+++ b/pkg/jira/search.go
@@ -52,8 +52,6 @@ func (c *Client) search(path, ver string) (*SearchResult, error) {
 		return nil, formatUnexpectedResponse(res)
 	}
 
-	// b, _ := io.ReadAll(res.Body)
-	// fmt.Println(string(b))
 
 	var out SearchResult
 

--- a/pkg/jira/search.go
+++ b/pkg/jira/search.go
@@ -52,7 +52,6 @@ func (c *Client) search(path, ver string) (*SearchResult, error) {
 		return nil, formatUnexpectedResponse(res)
 	}
 
-
 	var out SearchResult
 
 	err = json.NewDecoder(res.Body).Decode(&out)

--- a/pkg/jira/search_test.go
+++ b/pkg/jira/search_test.go
@@ -48,7 +48,7 @@ func TestSearch(t *testing.T) {
 
 	client := NewClient(Config{Server: server.URL}, WithTimeout(3*time.Second))
 
-	actual, err := client.Search("project=TEST AND status=Done ORDER BY created DESC", 0, 100)
+	actual, err := client.Search("project=TEST AND status=Done ORDER BY created DESC", 100)
 	assert.NoError(t, err)
 
 	expected := &SearchResult{

--- a/pkg/jira/search_test.go
+++ b/pkg/jira/search_test.go
@@ -22,7 +22,7 @@ func TestSearch(t *testing.T) {
 		if apiVersion2 {
 			assert.Equal(t, "/rest/api/2/search", r.URL.Path)
 		} else {
-			assert.Equal(t, "/rest/api/3/search", r.URL.Path)
+			assert.Equal(t, "/rest/api/3/search/jql", r.URL.Path)
 		}
 
 		qs := r.URL.Query()
@@ -32,7 +32,7 @@ func TestSearch(t *testing.T) {
 		} else {
 			assert.Equal(t, url.Values{
 				"jql":        []string{"project=TEST AND status=Done ORDER BY created DESC"},
-				"startAt":    []string{"0"},
+				"fields":     []string{"*all"},
 				"maxResults": []string{"100"},
 			}, qs)
 
@@ -52,9 +52,8 @@ func TestSearch(t *testing.T) {
 	assert.NoError(t, err)
 
 	expected := &SearchResult{
-		StartAt:    0,
-		MaxResults: 50,
-		Total:      3,
+		IsLast:        true,
+		NextPageToken: "",
 		Issues: []*Issue{
 			{
 				Key: "TEST-1",

--- a/pkg/jira/sprint_test.go
+++ b/pkg/jira/sprint_test.go
@@ -219,9 +219,7 @@ func TestSprintIssues(t *testing.T) {
 	assert.NoError(t, err)
 
 	expected := &SearchResult{
-		StartAt:    0,
-		MaxResults: 50,
-		Total:      3,
+		IsLast: true,
 		Issues: []*Issue{
 			{
 				Key: "TEST-1",

--- a/pkg/jira/testdata/search.json
+++ b/pkg/jira/testdata/search.json
@@ -1,8 +1,6 @@
 {
   "expand": "schema,names",
-  "startAt": 0,
-  "maxResults": 50,
-  "total": 3,
+  "isLast": true,
   "issues": [
     {
       "key": "TEST-1",


### PR DESCRIPTION
Fixes #891 

> This PR is a work in progress

> [!IMPORTANT]
>  - The [new API](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-search/#api-rest-api-3-search-jql-get) does not return the total number of entries anymore, so the total issue count is no longer displayed in the search results.
>  - Consequently, the `startAt` parameter in the new API is unsupported. Therefore, the `from` part of the `--paginate=<from>:<limit>` flag is effectively ignored. Users can still paginate using the maxResults parameter (e.g., --paginate=10).