### PR TITLE
Add a --board parameter to sprint list

### DIFF
--- a/pkg/jira/board.go
+++ b/pkg/jira/board.go
@@ -38,6 +38,30 @@ func (c *Client) BoardSearch(project, name string) (*BoardResult, error) {
 	return c.board(path)
 }
 
+// BoardByID fetches a single board by its ID.
+func (c *Client) BoardByID(boardID int) (*Board, error) {
+	path := fmt.Sprintf("/board/%d", boardID)
+
+	res, err := c.GetV1(context.Background(), path, nil)
+	if err != nil {
+		return nil, err
+	}
+	if res == nil {
+		return nil, ErrEmptyResponse
+	}
+	defer func() { _ = res.Body.Close() }()
+
+	if res.StatusCode != http.StatusOK {
+		return nil, formatUnexpectedResponse(res)
+	}
+
+	var out Board
+
+	err = json.NewDecoder(res.Body).Decode(&out)
+
+	return &out, err
+}
+
 func (c *Client) board(path string) (*BoardResult, error) {
 	res, err := c.GetV1(context.Background(), path, nil)
 	if err != nil {

--- a/pkg/jira/testdata/board.json
+++ b/pkg/jira/testdata/board.json
@@ -1,0 +1,5 @@
+{
+  "id": 1,
+  "name": "Board 1",
+  "type": "scrum"
+}


### PR DESCRIPTION
Add an optional `--board` parameter that takes in input a board id that overrides the parameter specified in the config file. This avoids the need to edit the config file in case a change of board is needed.

Also implement dynamic retrieval of the board name in case the board parameter is used.

Parameter is added only to `sprint list` command as it is the only one requiring a board at the moment.

Fixes #847 