### PR TITLE
fix: trim whitespace from server and login inputs in jira init

### DIFF
--- a/internal/config/generator.go
+++ b/internal/config/generator.go
@@ -401,10 +401,10 @@ func (c *JiraCLIConfigGenerator) configureServerAndLoginDetails() error {
 		}
 
 		if ans.Server != "" {
-			c.value.server = ans.Server
+			c.value.server = strings.TrimSpace(ans.Server)
 		}
 		if ans.Login != "" {
-			c.value.login = ans.Login
+			c.value.login = strings.TrimSpace(ans.Login)
 		}
 	}
 


### PR DESCRIPTION
## Fix: Trim whitespace from server and login inputs (#878)

### Problem
The `jira init` command fails with "Protocol scheme unsupported by official server" or "401 Unauthorized" errors when users accidentally include leading or trailing whitespace in their server URL or login email inputs.

### Solution
Added `strings.TrimSpace()` calls to sanitize user input for both the server URL and login email/username immediately after capture from interactive prompts. This ensures clean input is passed to URL parsing and authentication functions.

### Changes
- Modified `configureServerAndLoginDetails()` in `internal/config/generator.go`
- Added whitespace trimming for `ans.Server` and `ans.Login` values
- No new dependencies required (uses existing `strings` package)

### Testing
- Verified code compiles successfully
- Linting passes with no errors
- Manual testing recommended with inputs containing leading/trailing whitespace

Fixes #878