### PR TITLE
feat: add worklog list command

### DIFF
--- a/internal/cmd/issue/worklog/list/list.go
+++ b/internal/cmd/issue/worklog/list/list.go
@@ -1,0 +1,111 @@
+package list
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/ankitpokhrel/jira-cli/api"
+	"github.com/ankitpokhrel/jira-cli/internal/cmdutil"
+	"github.com/ankitpokhrel/jira-cli/internal/query"
+	"github.com/ankitpokhrel/jira-cli/internal/view"
+	"github.com/ankitpokhrel/jira-cli/pkg/jira"
+)
+
+const (
+	helpText = `List displays worklogs for an issue.`
+	examples = `$ jira issue worklog list ISSUE-1
+
+# List worklogs in plain mode
+$ jira issue worklog list ISSUE-1 --plain
+
+# List worklogs in table mode
+$ jira issue worklog list ISSUE-1 --table`
+)
+
+// NewCmdWorklogList is a worklog list command.
+func NewCmdWorklogList() *cobra.Command {
+	cmd := cobra.Command{
+		Use:     "list ISSUE-KEY",
+		Short:   "List worklogs for an issue",
+		Long:    helpText,
+		Example: examples,
+		Aliases: []string{"ls"},
+		Annotations: map[string]string{
+			"help:args": "ISSUE-KEY\tIssue key to list worklogs for, eg: ISSUE-1",
+		},
+		Run: list,
+	}
+
+	cmd.Flags().SortFlags = false
+
+	cmd.Flags().Bool("plain", false, "Display output in plain mode")
+	cmd.Flags().Bool("table", false, "Display output in table mode")
+
+	return &cmd
+}
+
+func list(cmd *cobra.Command, args []string) {
+	params := parseArgsAndFlags(args, cmd.Flags())
+	client := api.DefaultClient(params.debug)
+
+	if params.issueKey == "" {
+		cmdutil.Failed("Issue key is required")
+	}
+
+	worklogs, err := func() (*jira.WorklogResponse, error) {
+		s := cmdutil.Info(fmt.Sprintf("Fetching worklogs for issue %s...", params.issueKey))
+		defer s.Stop()
+
+		return client.GetIssueWorklogs(params.issueKey)
+	}()
+	cmdutil.ExitIfError(err)
+
+	if worklogs.Total == 0 {
+		fmt.Println("No worklogs found")
+		return
+	}
+
+	server := viper.GetString("server")
+	project := viper.GetString("project.key")
+
+	v := view.WorklogList{
+		Project:  project,
+		Server:   server,
+		Worklogs: worklogs.Worklogs,
+		Total:    worklogs.Total,
+		Display:  params.display,
+	}
+
+	cmdutil.ExitIfError(v.Render())
+}
+
+type listParams struct {
+	issueKey string
+	display  view.DisplayFormat
+	debug    bool
+}
+
+func parseArgsAndFlags(args []string, flags query.FlagParser) *listParams {
+	var issueKey string
+
+	if len(args) >= 1 {
+		issueKey = cmdutil.GetJiraIssueKey(viper.GetString("project.key"), args[0])
+	}
+
+	debug, err := flags.GetBool("debug")
+	cmdutil.ExitIfError(err)
+
+	plain, err := flags.GetBool("plain")
+	cmdutil.ExitIfError(err)
+
+	_, err = flags.GetBool("table")
+	cmdutil.ExitIfError(err)
+
+	return &listParams{
+		issueKey: issueKey,
+		display:  view.DisplayFormat{Plain: plain},
+		debug:    debug,
+	}
+}

--- a/internal/cmd/issue/worklog/worklog.go
+++ b/internal/cmd/issue/worklog/worklog.go
@@ -4,6 +4,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/ankitpokhrel/jira-cli/internal/cmd/issue/worklog/add"
+	"github.com/ankitpokhrel/jira-cli/internal/cmd/issue/worklog/list"
 )
 
 const helpText = `Worklog command helps you manage issue worklogs. See available commands below.`
@@ -19,6 +20,7 @@ func NewCmdWorklog() *cobra.Command {
 	}
 
 	cmd.AddCommand(add.NewCmdWorklogAdd())
+	cmd.AddCommand(list.NewCmdWorklogList())
 
 	return &cmd
 }

--- a/internal/view/worklog.go
+++ b/internal/view/worklog.go
@@ -1,0 +1,161 @@
+package view
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/ankitpokhrel/jira-cli/pkg/jira"
+)
+
+const (
+	worklogFieldID          = "ID"
+	worklogFieldAuthor      = "AUTHOR"
+	worklogFieldStarted     = "STARTED"
+	worklogFieldTimeSpent   = "TIME SPENT"
+	worklogFieldCreated     = "CREATED"
+	worklogFieldUpdated     = "UPDATED"
+	worklogFieldComment     = "COMMENT"
+)
+
+// WorklogList is a list view for worklogs.
+type WorklogList struct {
+	Project  string
+	Server   string
+	Worklogs []jira.Worklog
+	Total    int
+	Display  DisplayFormat
+}
+
+// Render renders the worklog list view.
+func (wl WorklogList) Render() error {
+	if wl.Display.Plain {
+		return wl.renderPlain(os.Stdout)
+	}
+	return wl.renderTable()
+}
+
+func (wl WorklogList) renderPlain(w io.Writer) error {
+	for i, worklog := range wl.Worklogs {
+		fmt.Fprintf(w, "Worklog #%d\n", i+1)
+		fmt.Fprintf(w, "  ID:          %s\n", worklog.ID)
+		fmt.Fprintf(w, "  Author:      %s\n", worklog.Author.Name)
+		fmt.Fprintf(w, "  Started:     %s\n", formatWorklogDate(worklog.Started))
+		fmt.Fprintf(w, "  Time Spent:  %s (%d seconds)\n", worklog.TimeSpent, worklog.TimeSpentSeconds)
+		fmt.Fprintf(w, "  Created:     %s\n", formatWorklogDate(worklog.Created))
+		fmt.Fprintf(w, "  Updated:     %s\n", formatWorklogDate(worklog.Updated))
+		
+		if worklog.Comment != nil {
+			comment := extractWorklogComment(worklog.Comment)
+			if comment != "" {
+				fmt.Fprintf(w, "  Comment:     %s\n", truncateString(comment, 60))
+			}
+		}
+		
+		fmt.Fprintln(w)
+	}
+
+	fmt.Fprintf(w, "Total worklogs: %d\n", wl.Total)
+	
+	return nil
+}
+
+func (wl WorklogList) renderTable() error {
+	data := wl.data()
+	tw := tabwriter.NewWriter(os.Stdout, 0, tabWidth, 1, '\t', 0)
+
+	headers := []string{
+		worklogFieldID,
+		worklogFieldAuthor,
+		worklogFieldStarted,
+		worklogFieldTimeSpent,
+		worklogFieldCreated,
+	}
+	fmt.Fprintln(tw, strings.Join(headers, "\t"))
+
+	for _, row := range data {
+		fmt.Fprintln(tw, strings.Join(row, "\t"))
+	}
+
+	return tw.Flush()
+}
+
+func (wl WorklogList) data() [][]string {
+	var data [][]string
+
+	for _, worklog := range wl.Worklogs {
+		data = append(data, []string{
+			worklog.ID,
+			worklog.Author.Name,
+			formatWorklogDate(worklog.Started),
+			worklog.TimeSpent,
+			formatWorklogDate(worklog.Created),
+		})
+	}
+
+	return data
+}
+
+func formatWorklogDate(dateStr string) string {
+	formats := []string{
+		time.RFC3339,
+		jira.RFC3339,
+		jira.RFC3339MilliLayout,
+		"2006-01-02T15:04:05.000-0700",
+	}
+
+	for _, format := range formats {
+		if t, err := time.Parse(format, dateStr); err == nil {
+			return t.Format("2006-01-02 15:04")
+		}
+	}
+
+	return dateStr
+}
+
+func extractWorklogComment(comment interface{}) string {
+	if comment == nil {
+		return ""
+	}
+
+	switch v := comment.(type) {
+	case string:
+		return v
+	case map[string]interface{}:
+		// Handle ADF format
+		if content, ok := v["content"].([]interface{}); ok {
+			var text strings.Builder
+			extractTextFromADF(content, &text)
+			return text.String()
+		}
+	}
+
+	return ""
+}
+
+func extractTextFromADF(content []interface{}, builder *strings.Builder) {
+	for _, item := range content {
+		if node, ok := item.(map[string]interface{}); ok {
+			if nodeType, ok := node["type"].(string); ok {
+				if nodeType == "text" {
+					if text, ok := node["text"].(string); ok {
+						builder.WriteString(text)
+					}
+				}
+			}
+			if subContent, ok := node["content"].([]interface{}); ok {
+				extractTextFromADF(subContent, builder)
+			}
+		}
+	}
+}
+
+func truncateString(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen-3] + "..."
+}

--- a/internal/view/worklog_test.go
+++ b/internal/view/worklog_test.go
@@ -1,0 +1,287 @@
+package view
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/ankitpokhrel/jira-cli/pkg/jira"
+)
+
+func TestWorklogList_Render(t *testing.T) {
+	tests := []struct {
+		name     string
+		worklogs []jira.Worklog
+		display  DisplayFormat
+		wantErr  bool
+	}{
+		{
+			name:     "empty worklogs",
+			worklogs: []jira.Worklog{},
+			display:  DisplayFormat{Plain: true},
+			wantErr:  false,
+		},
+		{
+			name: "single worklog plain mode",
+			worklogs: []jira.Worklog{
+				{
+					ID: "12345",
+					Author: jira.User{
+						Name: "John Doe",
+					},
+					Started:          "2024-11-05T10:30:00.000+0000",
+					TimeSpent:        "2h 30m",
+					TimeSpentSeconds: 9000,
+					Created:          "2024-11-05T10:30:00.000+0000",
+					Updated:          "2024-11-05T10:30:00.000+0000",
+					Comment:          "Test comment",
+				},
+			},
+			display: DisplayFormat{Plain: true},
+			wantErr: false,
+		},
+		{
+			name: "multiple worklogs table mode",
+			worklogs: []jira.Worklog{
+				{
+					ID: "12345",
+					Author: jira.User{
+						Name: "John Doe",
+					},
+					Started:          "2024-11-05T10:30:00.000+0000",
+					TimeSpent:        "2h 30m",
+					TimeSpentSeconds: 9000,
+					Created:          "2024-11-05T10:30:00.000+0000",
+					Updated:          "2024-11-05T10:30:00.000+0000",
+				},
+				{
+					ID: "12346",
+					Author: jira.User{
+						Name: "Jane Smith",
+					},
+					Started:          "2024-11-05T14:00:00.000+0000",
+					TimeSpent:        "1h 15m",
+					TimeSpentSeconds: 4500,
+					Created:          "2024-11-05T14:00:00.000+0000",
+					Updated:          "2024-11-05T14:00:00.000+0000",
+				},
+			},
+			display: DisplayFormat{Plain: false},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			wl := WorklogList{
+				Project:  "TEST",
+				Server:   "https://test.atlassian.net",
+				Worklogs: tt.worklogs,
+				Total:    len(tt.worklogs),
+				Display:  tt.display,
+			}
+
+			// Just test that it doesn't panic or error
+			// Full output testing would require capturing stdout
+			err := wl.Render()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("WorklogList.Render() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestFormatWorklogDate(t *testing.T) {
+	tests := []struct {
+		name     string
+		dateStr  string
+		wantFmt  string
+		wantFail bool
+	}{
+		{
+			name:    "RFC3339 with milliseconds",
+			dateStr: "2024-11-05T10:30:00.000+0000",
+			wantFmt: "2024-11-05 10:30",
+		},
+		{
+			name:    "RFC3339",
+			dateStr: "2024-11-05T10:30:00Z",
+			wantFmt: "2024-11-05 10:30",
+		},
+		{
+			name:     "invalid date",
+			dateStr:  "invalid",
+			wantFmt:  "invalid", // Should return original string
+			wantFail: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatWorklogDate(tt.dateStr)
+			if got != tt.wantFmt {
+				t.Errorf("formatWorklogDate() = %v, want %v", got, tt.wantFmt)
+			}
+		})
+	}
+}
+
+func TestExtractWorklogComment(t *testing.T) {
+	tests := []struct {
+		name    string
+		comment interface{}
+		want    string
+	}{
+		{
+			name:    "nil comment",
+			comment: nil,
+			want:    "",
+		},
+		{
+			name:    "string comment",
+			comment: "Simple text comment",
+			want:    "Simple text comment",
+		},
+		{
+			name: "ADF comment with text",
+			comment: map[string]interface{}{
+				"type":    "doc",
+				"version": 1,
+				"content": []interface{}{
+					map[string]interface{}{
+						"type": "paragraph",
+						"content": []interface{}{
+							map[string]interface{}{
+								"type": "text",
+								"text": "ADF formatted text",
+							},
+						},
+					},
+				},
+			},
+			want: "ADF formatted text",
+		},
+		{
+			name: "ADF comment empty",
+			comment: map[string]interface{}{
+				"type":    "doc",
+				"version": 1,
+				"content": []interface{}{},
+			},
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractWorklogComment(tt.comment)
+			if got != tt.want {
+				t.Errorf("extractWorklogComment() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTruncateString(t *testing.T) {
+	tests := []struct {
+		name   string
+		s      string
+		maxLen int
+		want   string
+	}{
+		{
+			name:   "short string",
+			s:      "short",
+			maxLen: 10,
+			want:   "short",
+		},
+		{
+			name:   "exact length",
+			s:      "1234567890",
+			maxLen: 10,
+			want:   "1234567890",
+		},
+		{
+			name:   "long string",
+			s:      "This is a very long string that needs truncation",
+			maxLen: 20,
+			want:   "This is a very lo...",
+		},
+		{
+			name:   "empty string",
+			s:      "",
+			maxLen: 10,
+			want:   "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := truncateString(tt.s, tt.maxLen)
+			if got != tt.want {
+				t.Errorf("truncateString() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestWorklogList_Data(t *testing.T) {
+	wl := WorklogList{
+		Worklogs: []jira.Worklog{
+			{
+				ID: "12345",
+				Author: jira.User{
+					Name: "John Doe",
+				},
+				Started:   "2024-11-05T10:30:00.000+0000",
+				TimeSpent: "2h 30m",
+				Created:   "2024-11-05T10:30:00.000+0000",
+			},
+		},
+	}
+
+	data := wl.data()
+	
+	if len(data) != 1 {
+		t.Errorf("Expected 1 row, got %d", len(data))
+	}
+
+	if len(data[0]) != 5 {
+		t.Errorf("Expected 5 columns, got %d", len(data[0]))
+	}
+
+	if data[0][0] != "12345" {
+		t.Errorf("Expected ID '12345', got '%s'", data[0][0])
+	}
+
+	if data[0][1] != "John Doe" {
+		t.Errorf("Expected author 'John Doe', got '%s'", data[0][1])
+	}
+}
+
+func TestExtractTextFromADF(t *testing.T) {
+	content := []interface{}{
+		map[string]interface{}{
+			"type": "paragraph",
+			"content": []interface{}{
+				map[string]interface{}{
+					"type": "text",
+					"text": "Hello ",
+				},
+				map[string]interface{}{
+					"type": "text",
+					"text": "World",
+				},
+			},
+		},
+	}
+
+	var builder strings.Builder
+	extractTextFromADF(content, &builder)
+	
+	got := builder.String()
+	want := "Hello World"
+	
+	if got != want {
+		t.Errorf("extractTextFromADF() = %v, want %v", got, want)
+	}
+}


### PR DESCRIPTION
- Add 'jira issue worklog list' command to list worklogs for an issue
- Implement GetIssueWorklogs() method in jira client
- Add Worklog and WorklogResponse types
- Create worklog view with plain and table display modes
- Add comprehensive unit tests for worklog functionality
- Support both ADF and plain text comment formats
- Include documentation for the new feature
- Add analysis document for Jira API requests

## Example of command output:
$jira issue worklog list XXX-231 --table
ID	AUTHOR	STARTED			TIME SPENT	CREATED
35668		2025-10-28 10:05	6h 45m		2025-11-05 09:51
35696		2025-10-29 13:45	7h 45m		2025-11-05 13:45
35697		2025-10-30 13:45	7h 45m		2025-11-05 13:45
35698		2025-10-31 13:45	5h 45m		2025-11-05 13:45

$jira issue worklog list XXX-231 --plain
Worklog #1
  ID:          35668
  Author:
  Started:     2025-10-28 10:05
  Time Spent:  6h 45m (24300 seconds)
  Created:     2025-11-05 09:51
  Updated:     2025-11-05 13:45

Worklog #2
  ID:          35696
  Author:
  Started:     2025-10-29 13:45
  Time Spent:  7h 45m (27900 seconds)
  Created:     2025-11-05 13:45
  Updated:     2025-11-05 13:45

Worklog #3
  ID:          35697
  Author:
  Started:     2025-10-30 13:45
  Time Spent:  7h 45m (27900 seconds)
  Created:     2025-11-05 13:45
  Updated:     2025-11-05 13:45

Worklog #4
  ID:          35698
  Author:
  Started:     2025-10-31 13:45
  Time Spent:  5h 45m (20700 seconds)
  Created:     2025-11-05 13:45
  Updated:     2025-11-05 13:45