### PR TITLE
Add cookie-based authentication support

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,12 +119,17 @@ See [FAQs](https://github.com/ankitpokhrel/jira-cli/discussions/categories/faqs)
 
 #### Authentication types
 
-The tool supports `basic`, `bearer` (Personal Access Token), and `mtls` (Client Certificates) authentication types. Basic auth is used by
-default.
+The tool supports `basic`, `bearer` (Personal Access Token), `mtls` (Client Certificates), and `cookie` (Session Cookie) authentication types. Basic auth is used by default.
 
 * If you want to use PAT, you need to set `JIRA_AUTH_TYPE` as `bearer`.
 * If you want to use `mtls` run `jira init`. Select installation type `Local`, and then select authentication type as `mtls`.
   * In case `JIRA_API_TOKEN` variable is set it will be used together with `mtls`.
+* If your Jira is behind SSO, a reverse proxy, or requires client certificate authentication, use `cookie` auth:
+  1. Run `jira init`, select `Local` installation, then select `cookie` as authentication type.
+  2. Sign in to Jira in your browser (authenticate via SSO/certificate as needed).
+  3. Copy the `JSESSIONID` cookie value from your browser's DevTools.
+  4. Paste it when prompted. The cookie is validated and stored in your system keychain.
+  * When your session expires, run `jira refresh` to update the cookie without re-running full setup.
 
 #### Shell completion
 Check `jira completion --help` for more info on setting up a bash/zsh shell completion.

--- a/internal/cmd/refresh/refresh.go
+++ b/internal/cmd/refresh/refresh.go
@@ -1,0 +1,92 @@
+package refresh
+
+import (
+	"fmt"
+
+	"github.com/AlecAivazis/survey/v2"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"github.com/zalando/go-keyring"
+
+	"github.com/ankitpokhrel/jira-cli/internal/cmdutil"
+	"github.com/ankitpokhrel/jira-cli/pkg/jira"
+)
+
+// NewCmdRefresh is a refresh command.
+func NewCmdRefresh() *cobra.Command {
+	return &cobra.Command{
+		Use:   "refresh",
+		Short: "Refresh session cookie for cookie-based authentication",
+		Long: `Refresh session cookie for cookie-based authentication.
+
+This command is only applicable when using 'cookie' auth type.
+It allows you to update your JSESSIONID without re-running the full 'jira init' setup.`,
+		Run: refresh,
+	}
+}
+
+func refresh(cmd *cobra.Command, _ []string) {
+	authType := viper.GetString("auth_type")
+	if authType != string(jira.AuthTypeCookie) {
+		cmdutil.Failed("This command is only for cookie-based authentication (current auth_type: %s)", authType)
+		return
+	}
+
+	server := viper.GetString("server")
+	login := viper.GetString("login")
+
+	if server == "" || login == "" {
+		cmdutil.Failed("Missing server or login in config. Please run 'jira init' first.")
+		return
+	}
+
+	fmt.Println("Refresh session cookie for", server)
+	fmt.Println()
+	fmt.Println("1. Open", server, "in a browser")
+	fmt.Println("2. Sign in (authenticate via SSO/certificate as needed)")
+	fmt.Println("3. Open browser DevTools (F12) → Application/Storage → Cookies")
+	fmt.Println("4. Find the cookie named 'JSESSIONID' and copy its value")
+	fmt.Println()
+
+	var sessionCookie string
+	prompt := &survey.Password{
+		Message: "Paste JSESSIONID value:",
+		Help:    "The session cookie will be validated and stored securely in your system keychain",
+	}
+
+	if err := survey.AskOne(prompt, &sessionCookie, survey.WithValidator(survey.Required)); err != nil {
+		cmdutil.Failed("Failed to read input: %s", err.Error())
+		return
+	}
+
+	// Validate cookie
+	s := cmdutil.Info("Validating session cookie...")
+
+	client := jira.NewClient(jira.Config{
+		Server:   server,
+		APIToken: sessionCookie,
+		AuthType: &[]jira.AuthType{jira.AuthTypeCookie}[0],
+	})
+
+	me, err := client.Me()
+	if err != nil {
+		s.Stop()
+		cmdutil.Failed("Failed to validate cookie: %s", err.Error())
+		return
+	}
+	s.Stop()
+
+	// Verify it's the same user
+	if me.Login != login {
+		cmdutil.Failed("Cookie belongs to user '%s' but config expects '%s'", me.Login, login)
+		return
+	}
+
+	// Store in keychain
+	if err := keyring.Set("jira-cli", login, sessionCookie); err != nil {
+		cmdutil.Failed("Failed to store session cookie in keychain: %s", err.Error())
+		return
+	}
+
+	cmdutil.Success("Session refreshed for %s (%s)", me.Name, me.Login)
+}

--- a/internal/cmd/root/root.go
+++ b/internal/cmd/root/root.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ankitpokhrel/jira-cli/internal/cmd/me"
 	"github.com/ankitpokhrel/jira-cli/internal/cmd/open"
 	"github.com/ankitpokhrel/jira-cli/internal/cmd/project"
+	"github.com/ankitpokhrel/jira-cli/internal/cmd/refresh"
 	"github.com/ankitpokhrel/jira-cli/internal/cmd/release"
 	"github.com/ankitpokhrel/jira-cli/internal/cmd/serverinfo"
 	"github.com/ankitpokhrel/jira-cli/internal/cmd/sprint"
@@ -84,8 +85,9 @@ func NewCmdRoot() *cobra.Command {
 				return
 			}
 
-			// mTLS doesn't need Jira API Token.
-			if viper.GetString("auth_type") != string(jira.AuthTypeMTLS) {
+			// mTLS and cookie auth don't need token check here (retrieved from env/keychain).
+			authType := viper.GetString("auth_type")
+			if authType != string(jira.AuthTypeMTLS) && authType != string(jira.AuthTypeCookie) {
 				checkForJiraToken(viper.GetString("server"), viper.GetString("login"))
 			}
 
@@ -140,6 +142,7 @@ func addChildCommands(cmd *cobra.Command) {
 		version.NewCmdVersion(),
 		release.NewCmdRelease(),
 		man.NewCmdMan(),
+		refresh.NewCmdRefresh(),
 	)
 }
 
@@ -151,6 +154,7 @@ func cmdRequireToken(cmd string) bool {
 		"version",
 		"completion",
 		"man",
+		"refresh",
 	}
 	return !slices.Contains(allowList, cmd)
 }

--- a/pkg/jira/client.go
+++ b/pkg/jira/client.go
@@ -281,6 +281,13 @@ func (c *Client) request(ctx context.Context, method, endpoint string, body []by
 		}
 	case string(AuthTypeBearer):
 		req.Header.Add("Authorization", "Bearer "+c.token)
+	case string(AuthTypeCookie):
+		if c.token != "" {
+			req.AddCookie(&http.Cookie{
+				Name:  "JSESSIONID",
+				Value: c.token,
+			})
+		}
 	case string(AuthTypeBasic):
 		req.SetBasicAuth(c.login, c.token)
 	}

--- a/pkg/jira/types.go
+++ b/pkg/jira/types.go
@@ -11,6 +11,8 @@ const (
 	AuthTypeBearer AuthType = "bearer"
 	// AuthTypeMTLS is a mTLS auth.
 	AuthTypeMTLS AuthType = "mtls"
+	// AuthTypeCookie is a session cookie auth.
+	AuthTypeCookie AuthType = "cookie"
 )
 
 // AuthType is a jira authentication type.


### PR DESCRIPTION
**What does this PR solve?**

Adds cookie-based authentication (`auth_type: cookie`) for on-premise Jira installations that use SSO, reverse proxy, or client certificate authentication.

This is useful when:
- Your Jira is behind an enterprise proxy that handles authentication (e.g., with YubiKey/smart card)
- You authenticate via SSO/certificates and get a session cookie
- Basic auth or PAT aren't available options

**Changes:**
- Add `AuthTypeCookie` constant to `pkg/jira/types.go`
- Add JSESSIONID cookie handling in `pkg/jira/client.go`
- Add `cookie` option to auth type selection in config generator
- Add `configureCookie()` function that validates and stores session cookie in keychain
- Add `jira refresh` command for easy session cookie renewal (no need to re-run full `jira init`)
- Update README with cookie auth documentation

**How to test?**

1. Run `jira init` and select "Local" installation
2. Select "cookie" as authentication type
3. Enter your Jira server URL
4. Sign in to Jira in browser (via SSO/certificate)
5. Copy JSESSIONID cookie from browser DevTools
6. Paste when prompted - cookie is validated and stored in keychain
7. Use CLI normally. When session expires, run `jira refresh`

**Checklist**

- [x] I have added/updated enough tests related to my changes.
- [x] I have also manually checked and verified that my changes fix the issue and doesn't break any other functionalities.
- [x] My changes are backwards compatible.