### PR TITLE
Introduce multi-project filter support

### DIFF
--- a/pkg/jql/jql.go
+++ b/pkg/jql/jql.go
@@ -27,9 +27,9 @@ type JQL struct {
 func NewJQL(project string) *JQL {
 	var f string
 	if strings.HasPrefix(project, "(") && strings.HasSuffix(project, ")") {
-		f = "project=%q"
-	} else {
 		f = "project in %s"
+	} else {
+		f = "project=%q"
 	}
 	return &JQL{
 		project: project,


### PR DESCRIPTION
This doesn't change the init procedure, but enables advanced users to add multiple project keys in the config.yaml so they can see issues from more than one project in the default view without appending a custom query every time they want to see a dashboard.