### PR TITLE
feat: add --markdown and --no-emoji flags to issue view

### DIFF
--- a/internal/cmd/issue/view/view.go
+++ b/internal/cmd/issue/view/view.go
@@ -24,13 +24,17 @@ $ jira issue view ISSUE-1 --comments 5
 $ jira issue view ISSUE-1 --raw
 
 # Get raw markdown output (no terminal formatting)
-$ jira issue view ISSUE-1 --markdown`
+$ jira issue view ISSUE-1 --markdown
+
+# Replace emoji with text labels
+$ jira issue view ISSUE-1 --no-emoji`
 
 	flagRaw      = "raw"
 	flagDebug    = "debug"
 	flagComments = "comments"
 	flagPlain    = "plain"
 	flagMarkdown = "markdown"
+	flagNoEmoji  = "no-emoji"
 
 	configProject = "project.key"
 	configServer  = "server"
@@ -57,6 +61,7 @@ func NewCmdView() *cobra.Command {
 	cmd.Flags().Bool(flagPlain, false, "Display output in plain mode")
 	cmd.Flags().Bool(flagRaw, false, "Print raw Jira API response")
 	cmd.Flags().Bool(flagMarkdown, false, "Print raw markdown without terminal formatting")
+	cmd.Flags().Bool(flagNoEmoji, false, "Replace emoji with text labels")
 
 	return &cmd
 }
@@ -119,10 +124,13 @@ func viewPretty(cmd *cobra.Command, args []string) {
 	markdown, err := cmd.Flags().GetBool(flagMarkdown)
 	cmdutil.ExitIfError(err)
 
+	noEmoji, err := cmd.Flags().GetBool(flagNoEmoji)
+	cmdutil.ExitIfError(err)
+
 	v := tuiView.Issue{
 		Server:  viper.GetString(configServer),
 		Data:    iss,
-		Display: tuiView.DisplayFormat{Plain: plain, Markdown: markdown},
+		Display: tuiView.DisplayFormat{Plain: plain, Markdown: markdown, NoEmoji: noEmoji},
 		Options: tuiView.IssueOption{NumComments: comments},
 	}
 	cmdutil.ExitIfError(v.Render())

--- a/internal/view/issue.go
+++ b/internal/view/issue.go
@@ -203,6 +203,9 @@ func (i Issue) separator(msg string) string {
 }
 
 func (i Issue) header() string {
+	if i.Display.NoEmoji {
+		return i.headerNoEmoji()
+	}
 	as := i.Data.Fields.Assignee.Name
 	if as == "" {
 		as = "Unassigned"
@@ -236,6 +239,40 @@ func (i Issue) header() string {
 	return fmt.Sprintf(
 		"%s %s  %s %s  ⌛ %s  👷 %s  🔑️ %s  💭 %d comments  \U0001F9F5 %d linked\n# %s\n⏱️  %s  🔎 %s  🚀 %s  📦 %s  🏷️  %s  👀 %s",
 		iti, it, sti, st, cmdutil.FormatDateTimeHuman(i.Data.Fields.Updated, jira.RFC3339), as, i.Data.Key,
+		i.Data.Fields.Comment.Total, len(i.Data.Fields.IssueLinks),
+		i.Data.Fields.Summary,
+		cmdutil.FormatDateTimeHuman(i.Data.Fields.Created, jira.RFC3339), i.Data.Fields.Reporter.Name,
+		i.Data.Fields.Priority.Name, cmpt, lbl, wch,
+	)
+}
+
+func (i Issue) headerNoEmoji() string {
+	as := i.Data.Fields.Assignee.Name
+	if as == "" {
+		as = "Unassigned"
+	}
+	lbl := "None"
+	if len(i.Data.Fields.Labels) > 0 {
+		lbl = strings.Join(i.Data.Fields.Labels, ", ")
+	}
+	components := make([]string, 0, len(i.Data.Fields.Components))
+	for _, c := range i.Data.Fields.Components {
+		components = append(components, c.Name)
+	}
+	cmpt := "None"
+	if len(components) > 0 {
+		cmpt = strings.Join(components, ", ")
+	}
+	wch := fmt.Sprintf("Watchers: %d", i.Data.Fields.Watches.WatchCount)
+	if i.Data.Fields.Watches.WatchCount == 1 && i.Data.Fields.Watches.IsWatching {
+		wch = "Watchers: You"
+	} else if i.Data.Fields.Watches.IsWatching {
+		wch = fmt.Sprintf("Watchers: You + %d", i.Data.Fields.Watches.WatchCount-1)
+	}
+	return fmt.Sprintf(
+		"[%s] [%s] Updated: %s  Assignee: %s  Key: %s  Comments: %d  Linked: %d\n# %s\nCreated: %s  Reporter: %s  Priority: %s  Components: %s  Labels: %s  %s",
+		i.Data.Fields.IssueType.Name, i.Data.Fields.Status.Name,
+		cmdutil.FormatDateTimeHuman(i.Data.Fields.Updated, jira.RFC3339), as, i.Data.Key,
 		i.Data.Fields.Comment.Total, len(i.Data.Fields.IssueLinks),
 		i.Data.Fields.Summary,
 		cmdutil.FormatDateTimeHuman(i.Data.Fields.Created, jira.RFC3339), i.Data.Fields.Reporter.Name,

--- a/internal/view/issues.go
+++ b/internal/view/issues.go
@@ -26,6 +26,7 @@ type DisplayFormat struct {
 	TableStyle   tui.TableStyle
 	Timezone     string
 	Markdown     bool
+	NoEmoji      bool
 }
 
 // IssueList is a list view for issues.


### PR DESCRIPTION
## Summary

Adds two new flags to `jira issue view` for better control over output formatting:

- `--markdown` — Raw markdown output without glamour terminal rendering
- `--no-emoji` — Replace emoji with bracketed text labels

## Motivation

The current output always processes through glamour, which adds ANSI formatting even with `--plain`. Users who want to pipe issue content to files, other tools, or LLMs need clean markdown without terminal artifacts.

The emoji in headers can also cause issues with:
- Terminals/fonts that don't render emoji well
- Text processing tools
- Users who simply prefer text-only output

## Examples

```bash
# Raw markdown (no glamour processing)
$ jira issue view ISSUE-1 --markdown

# Text labels instead of emoji
$ jira issue view ISSUE-1 --no-emoji

# Both combined for clean text output
$ jira issue view ISSUE-1 --markdown --no-emoji
```

### Output with `--no-emoji`:
```
[Sub-task] [Backlog] Updated: Tue, 09 Dec 25  Assignee: Unassigned  Key: ATH-1665  Comments: 0  Linked: 0
# Issue Summary
Created: Tue, 09 Dec 25  Reporter: Name  Priority: Medium  Components: None  Labels: None  Watchers: 1
```

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/view/...` passes
- [x] Manual testing with real Jira issues
- [x] Verified `--markdown` outputs clean markdown without ANSI codes
- [x] Verified `--no-emoji` replaces all emoji with text labels
- [x] Verified flags work together