### PR TITLE
fix: handle escaped commas in custom field array values

### DIFF
--- a/pkg/jira/create.go
+++ b/pkg/jira/create.go
@@ -247,7 +247,7 @@ func constructCustomFields(fields map[string]string, configuredFields []IssueTyp
 			case customFieldFormatProject:
 				data.Fields.M.customFields[configured.Key] = customFieldTypeProject{Value: val}
 			case customFieldFormatArray:
-				pieces := strings.Split(strings.TrimSpace(val), ",")
+				pieces := splitUnescapedCommas(val)
 				if configured.Schema.Items == customFieldFormatOption {
 					items := make([]customFieldTypeOption, 0)
 					for _, p := range pieces {

--- a/pkg/jira/customfield.go
+++ b/pkg/jira/customfield.go
@@ -55,7 +55,8 @@ func splitUnescapedCommas(s string) []string {
 	escaped := false
 
 	for i := 0; i < len(s); i++ {
-		if escaped {
+		switch {
+		case escaped:
 			if s[i] == ',' {
 				current.WriteByte(',')
 			} else {
@@ -63,12 +64,12 @@ func splitUnescapedCommas(s string) []string {
 				current.WriteByte(s[i])
 			}
 			escaped = false
-		} else if s[i] == '\\' {
+		case s[i] == '\\':
 			escaped = true
-		} else if s[i] == ',' {
+		case s[i] == ',':
 			result = append(result, strings.TrimSpace(current.String()))
 			current.Reset()
-		} else {
+		default:
 			current.WriteByte(s[i])
 		}
 	}

--- a/pkg/jira/customfield.go
+++ b/pkg/jira/customfield.go
@@ -1,5 +1,7 @@
 package jira
 
+import "strings"
+
 const (
 	customFieldFormatOption  = "option"
 	customFieldFormatArray   = "array"
@@ -38,4 +40,43 @@ type customFieldTypeProject struct {
 
 type customFieldTypeProjectSet struct {
 	Set customFieldTypeProject `json:"set"`
+}
+
+// splitUnescapedCommas splits a string on commas that are not escaped with backslash.
+// Escaped commas (\,) are unescaped in the resulting strings.
+func splitUnescapedCommas(s string) []string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return []string{}
+	}
+
+	var result []string
+	var current strings.Builder
+	escaped := false
+
+	for i := 0; i < len(s); i++ {
+		if escaped {
+			if s[i] == ',' {
+				current.WriteByte(',')
+			} else {
+				current.WriteByte('\\')
+				current.WriteByte(s[i])
+			}
+			escaped = false
+		} else if s[i] == '\\' {
+			escaped = true
+		} else if s[i] == ',' {
+			result = append(result, strings.TrimSpace(current.String()))
+			current.Reset()
+		} else {
+			current.WriteByte(s[i])
+		}
+	}
+
+	if escaped {
+		current.WriteByte('\\')
+	}
+
+	result = append(result, strings.TrimSpace(current.String()))
+	return result
 }

--- a/pkg/jira/edit.go
+++ b/pkg/jira/edit.go
@@ -378,7 +378,7 @@ func constructCustomFieldsForEdit(fields map[string]string, configuredFields []I
 			case customFieldFormatProject:
 				data.Update.M.customFields[configured.Key] = []customFieldTypeProjectSet{{Set: customFieldTypeProject{Value: val}}}
 			case customFieldFormatArray:
-				pieces := strings.Split(strings.TrimSpace(val), ",")
+				pieces := splitUnescapedCommas(val)
 				if configured.Schema.Items == customFieldFormatOption {
 					items := make([]customFieldTypeOptionAddRemove, 0)
 					for _, p := range pieces {

--- a/pkg/jira/edit_test.go
+++ b/pkg/jira/edit_test.go
@@ -1,0 +1,96 @@
+package jira
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type editTestServer struct{ code int }
+
+func (e *editTestServer) serve(t *testing.T, expectedBody string) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/rest/api/2/issue/TEST-123", r.URL.Path)
+		assert.Equal(t, "PUT", r.Method)
+		assert.Equal(t, "application/json", r.Header.Get("Accept"))
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+
+		actualBody := new(strings.Builder)
+		_, _ = io.Copy(actualBody, r.Body)
+
+		assert.JSONEq(t, expectedBody, actualBody.String())
+
+		w.WriteHeader(e.code)
+	}))
+}
+
+func TestEditWithCustomFieldArrayEscapedComma(t *testing.T) {
+	expectedBody := `{"update":{"customfield_10050":["WL: Tools, Development and Support"]},"fields":{"parent":{}}}`
+	testServer := editTestServer{code: 204}
+	server := testServer.serve(t, expectedBody)
+	defer server.Close()
+
+	client := NewClient(Config{Server: server.URL}, WithTimeout(3*time.Second))
+
+	customFields := []IssueTypeField{
+		{
+			Name: "Work Category",
+			Key:  "customfield_10050",
+			Schema: struct {
+				DataType string `json:"type"`
+				Items    string `json:"items,omitempty"`
+			}{
+				DataType: "array",
+				Items:    "string",
+			},
+		},
+	}
+
+	requestData := EditRequest{
+		CustomFields: map[string]string{
+			"work-category": `WL: Tools\, Development and Support`,
+		},
+	}
+	requestData.WithCustomFields(customFields)
+
+	err := client.Edit("TEST-123", &requestData)
+	assert.NoError(t, err)
+}
+
+func TestEditWithCustomFieldArrayMultipleValues(t *testing.T) {
+	expectedBody := `{"update":{"customfield_10051":["Value 1","Value 2, with comma","Value 3"]},"fields":{"parent":{}}}`
+	testServer := editTestServer{code: 204}
+	server := testServer.serve(t, expectedBody)
+	defer server.Close()
+
+	client := NewClient(Config{Server: server.URL}, WithTimeout(3*time.Second))
+
+	customFields := []IssueTypeField{
+		{
+			Name: "Multi Value Field",
+			Key:  "customfield_10051",
+			Schema: struct {
+				DataType string `json:"type"`
+				Items    string `json:"items,omitempty"`
+			}{
+				DataType: "array",
+				Items:    "string",
+			},
+		},
+	}
+
+	requestData := EditRequest{
+		CustomFields: map[string]string{
+			"multi-value-field": `Value 1,Value 2\, with comma,Value 3`,
+		},
+	}
+	requestData.WithCustomFields(customFields)
+
+	err := client.Edit("TEST-123", &requestData)
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
Custom field array values can now contain commas by escaping them with a backslash (\,). Previously, values like "WL: Tools, Development and Support" would be incorrectly split into multiple array elements.

For example, `jira issue create --custom work-category='WL: Tools, Development and Support' ...` would get split into `WL: Tools` and ` Development and Support`, so I'd get an error back from my Jira saying that those don't exist as valid options for that multi-select field.

Changes:
- Added splitUnescapedCommas() function to handle escaped commas
- Updated constructCustomFields() in create.go
- Updated constructCustomFieldsForEdit() in edit.go
- Added test coverage for both create and edit operations