### PR TITLE
feat: add custom HTTP header support

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -61,6 +61,11 @@ func Client(config jira.Config) *jira.Client {
 		config.MTLSConfig.ClientKey = viper.GetString("mtls.client_key")
 	}
 
+	// Custom Headers
+	if config.CustomHeaders == nil {
+		config.CustomHeaders = viper.GetStringMapString("custom_headers")
+	}
+
 	jiraClient = jira.NewClient(
 		config,
 		jira.WithTimeout(clientTimeout),

--- a/pkg/jira/client.go
+++ b/pkg/jira/client.go
@@ -105,25 +105,27 @@ type MTLSConfig struct {
 
 // Config is a jira config.
 type Config struct {
-	Server     string
-	Login      string
-	APIToken   string
-	AuthType   *AuthType
-	Insecure   *bool
-	Debug      bool
-	MTLSConfig MTLSConfig
+	Server        string
+	Login         string
+	APIToken      string
+	AuthType      *AuthType
+	Insecure      *bool
+	Debug         bool
+	MTLSConfig    MTLSConfig
+	CustomHeaders map[string]string
 }
 
 // Client is a jira client.
 type Client struct {
-	transport http.RoundTripper
-	insecure  bool
-	server    string
-	login     string
-	authType  *AuthType
-	token     string
-	timeout   time.Duration
-	debug     bool
+	transport     http.RoundTripper
+	insecure      bool
+	server        string
+	login         string
+	authType      *AuthType
+	token         string
+	timeout       time.Duration
+	debug         bool
+	customHeaders map[string]string
 }
 
 // ClientFunc decorates option for client.
@@ -132,11 +134,12 @@ type ClientFunc func(*Client)
 // NewClient instantiates new jira client.
 func NewClient(c Config, opts ...ClientFunc) *Client {
 	client := Client{
-		server:   strings.TrimSuffix(c.Server, "/"),
-		login:    c.Login,
-		token:    c.APIToken,
-		authType: c.AuthType,
-		debug:    c.Debug,
+		server:        strings.TrimSuffix(c.Server, "/"),
+		login:         c.Login,
+		token:         c.APIToken,
+		authType:      c.AuthType,
+		debug:         c.Debug,
+		customHeaders: c.CustomHeaders,
 	}
 
 	for _, opt := range opts {
@@ -263,6 +266,11 @@ func (c *Client) request(ctx context.Context, method, endpoint string, body []by
 	}()
 
 	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+
+	// Apply custom headers from config.
+	for k, v := range c.customHeaders {
 		req.Header.Set(k, v)
 	}
 


### PR DESCRIPTION
## Summary

Add support for custom HTTP headers in API requests via config file. This enables jira-cli to work with Jira instances behind Cloudflare Access or other reverse proxies that require custom authentication headers.

## Use Case

Jira instances protected by Cloudflare Access require a `cf-access-token` header (obtained via `cloudflared access token`) in addition to standard Jira authentication. Without custom header support, requests are blocked at the network layer before reaching Jira.

## Configuration

```yaml
# ~/.config/.jira/.config.yml
server: https://jira.example.com
login: user@example.com
auth_type: bearer
installation: Local
custom_headers:
  cf-access-token: "<token from cloudflared>"
project:
  key: MYPROJECT
```

## Changes

- Add `CustomHeaders` field to `Config` and `Client` structs in `pkg/jira/client.go`
- Load `custom_headers` from config file via viper in `api/client.go`
- Apply custom headers to all HTTP requests