### PR TITLE
feat(custom-fields): Add support for CMDB object fields

### DIFF
--- a/pkg/jira/customfield.go
+++ b/pkg/jira/customfield.go
@@ -1,10 +1,11 @@
 package jira
 
 const (
-	customFieldFormatOption  = "option"
-	customFieldFormatArray   = "array"
-	customFieldFormatNumber  = "number"
-	customFieldFormatProject = "project"
+	customFieldFormatOption     = "option"
+	customFieldFormatArray      = "array"
+	customFieldFormatNumber     = "number"
+	customFieldFormatProject    = "project"
+	customFieldFormatCMDBObject = "cmdb-object-field"
 )
 
 type customField map[string]interface{}


### PR DESCRIPTION
## Summary                                                                                
  - Adds support for CMDB (Assets/Insight) object custom fields which require JSON array    
  format                                                                                    
  - Previously, CMDB field values were passed as escaped strings, causing `expected Object` 
  errors from the Jira API                                                                  
  - Handles CMDB fields in both create and edit operations                                  
                                                                                            
## Problem
  When creating/editing issues with CMDB object fields:                                     
  ```bash                                                                                   
  jira issue create --custom cycle='[{"workspaceId":"...","objectId":"24"}]' -s "Test"
```

The CLI would send the value as an escaped string instead of a parsed JSON object:        
  {"customfield_15259": "[{\"workspaceId\":\"...\"}]"}  // Wrong - escaped string           
  {"customfield_15259": [{"workspaceId":"..."}]}       // Correct - JSON array              
                                                                                            
Changes
  1. pkg/jira/customfield.go - Added customFieldFormatCMDBObject constant                   
  2. pkg/jira/create.go - Handle CMDB fields in constructCustomFields()                     
  3. pkg/jira/edit.go - Handle CMDB fields in constructCustomFieldsForEdit()                
                                                                                            
Test plan
  - make ci passes (lint + tests)                                                           
  - Manually tested in production Jira instance