### PR TITLE
fix: convert Jira wiki nested lists to CommonMark before parsing

### DIFF
--- a/pkg/md/md.go
+++ b/pkg/md/md.go
@@ -1,17 +1,46 @@
 package md
 
 import (
+	"regexp"
+	"strings"
+
 	cf "github.com/kentaro-m/blackfriday-confluence"
 	bf "github.com/russross/blackfriday/v2"
 
 	"github.com/ankitpokhrel/jira-cli/pkg/md/jirawiki"
 )
 
+// jiraNestedListPattern matches Jira wiki nested list syntax: lines starting with
+// two or more asterisks followed by a space (e.g., "** item", "*** sub-item").
+// Single asterisk lines are handled correctly by BlackFriday, so we only need
+// to convert nested lists (2+ asterisks).
+var jiraNestedListPattern = regexp.MustCompile(`^(\*{2,})\s`)
+
+// convertJiraNestedLists converts Jira wiki nested list syntax to CommonMark.
+// Jira uses "** item" for nested lists, but BlackFriday interprets "**" as bold.
+// This function converts "** item" to "\t- item" (tab-indented CommonMark list).
+func convertJiraNestedLists(input string) string {
+	lines := strings.Split(input, "\n")
+	for i, line := range lines {
+		if match := jiraNestedListPattern.FindStringSubmatch(line); match != nil {
+			depth := len(match[1]) // Number of asterisks
+			indent := strings.Repeat("\t", depth-1)
+			rest := strings.TrimPrefix(line, match[0])
+			lines[i] = indent + "- " + rest
+		}
+	}
+	return strings.Join(lines, "\n")
+}
+
 // ToJiraMD translates CommonMark to Jira flavored markdown.
 func ToJiraMD(md string) string {
 	if md == "" {
 		return md
 	}
+
+	// Preprocess: convert Jira wiki nested lists to CommonMark format
+	// so BlackFriday can parse them correctly.
+	md = convertJiraNestedLists(md)
 
 	renderer := &cf.Renderer{Flags: cf.IgnoreMacroEscaping}
 	r := bf.New(bf.WithRenderer(renderer), bf.WithExtensions(bf.CommonExtensions))

--- a/pkg/md/md_test.go
+++ b/pkg/md/md_test.go
@@ -6,6 +6,71 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestConvertJiraNestedLists(t *testing.T) {
+	cases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "single level list unchanged",
+			input:    "* Item 1\n* Item 2",
+			expected: "* Item 1\n* Item 2",
+		},
+		{
+			name:     "nested list converted",
+			input:    "* Item 1\n** Subitem 1\n** Subitem 2",
+			expected: "* Item 1\n\t- Subitem 1\n\t- Subitem 2",
+		},
+		{
+			name:     "deeply nested list",
+			input:    "* Item\n** Level 2\n*** Level 3\n**** Level 4",
+			expected: "* Item\n\t- Level 2\n\t\t- Level 3\n\t\t\t- Level 4",
+		},
+		{
+			name:     "bold text not affected",
+			input:    "**bold text** and more",
+			expected: "**bold text** and more",
+		},
+		{
+			name:     "mixed content",
+			input:    "* Item with **bold**\n** Subitem\n*** Deep item",
+			expected: "* Item with **bold**\n\t- Subitem\n\t\t- Deep item",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, convertJiraNestedLists(tc.input))
+		})
+	}
+}
+
+func TestToJiraMDWithNestedLists(t *testing.T) {
+	cases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "jira wiki nested list",
+			input:    "* Item 1\n** Subitem 1\n** Subitem 2\n* Item 2",
+			expected: "* Item 1\n** Subitem 1\n** Subitem 2\n* Item 2\n\n",
+		},
+		{
+			name:     "three level nesting",
+			input:    "* Level 1\n** Level 2\n*** Level 3",
+			expected: "* Level 1\n** Level 2\n*** Level 3\n\n",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, ToJiraMD(tc.input))
+		})
+	}
+}
+
 func TestToJiraMD(t *testing.T) {
 	jfm := `# H1
 Some _Markdown_ text.


### PR DESCRIPTION
## Summary

Fixes an issue where Jira wiki nested list syntax (`** item`, `*** sub-item`) was not being converted correctly to ADF nested lists when creating or editing issues on Jira Cloud.

**Root cause:** BlackFriday (CommonMark parser) interprets `**` as bold text, not as a nested list marker. Jira wiki uses `** item` for nested lists, but CommonMark expects indentation (`\t- item`).

**Fix:** Added a preprocessing step in `ToJiraMD()` that converts Jira wiki nested list syntax to CommonMark indented lists before passing to BlackFriday.

## Changes

- Added `convertJiraNestedLists()` function that detects lines starting with `**`, `***`, etc. followed by a space and converts them to tab-indented CommonMark lists
- Single asterisk lines (`* item`) are unchanged (already work correctly)
- Bold text (`**bold**`) is not affected (no space after `**`)

## Test plan

- [x] Added unit tests for `convertJiraNestedLists()` 
- [x] Added integration tests for `ToJiraMD()` with nested lists
- [x] All existing tests pass
- [x] Linting passes (0 issues)
- [x] Manually tested on Jira Cloud - nested lists now render correctly