### PR TITLE
feat: add support for user-type custom fields

### DIFF
--- a/internal/cmd/issue/edit/edit.go
+++ b/internal/cmd/issue/edit/edit.go
@@ -163,6 +163,7 @@ func edit(cmd *cobra.Command, args []string) {
 			cmdcommon.ValidateCustomFields(edr.CustomFields, configuredCustomFields)
 			edr.WithCustomFields(configuredCustomFields)
 		}
+		edr.ForInstallationType(viper.GetString("installation"))
 
 		return client.Edit(params.issueKey, &edr)
 	}()

--- a/pkg/jira/customfield.go
+++ b/pkg/jira/customfield.go
@@ -5,6 +5,7 @@ const (
 	customFieldFormatArray   = "array"
 	customFieldFormatNumber  = "number"
 	customFieldFormatProject = "project"
+	customFieldFormatUser    = "user"
 )
 
 type customField map[string]interface{}
@@ -38,4 +39,21 @@ type customFieldTypeProject struct {
 
 type customFieldTypeProjectSet struct {
 	Set customFieldTypeProject `json:"set"`
+}
+
+type customFieldTypeUser struct {
+	Name      *string `json:"name,omitempty"`      // For local (Server/DC) installation.
+	AccountID *string `json:"accountId,omitempty"` // For cloud installation.
+}
+
+type customFieldTypeUserSet struct {
+	Set customFieldTypeUser `json:"set"`
+}
+
+// newCustomFieldTypeUser creates a user field value appropriate for the installation type.
+func newCustomFieldTypeUser(val, installationType string) customFieldTypeUser {
+	if installationType == InstallationTypeLocal {
+		return customFieldTypeUser{Name: &val}
+	}
+	return customFieldTypeUser{AccountID: &val}
 }

--- a/pkg/jira/customfield_test.go
+++ b/pkg/jira/customfield_test.go
@@ -1,0 +1,34 @@
+package jira
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewCustomFieldTypeUserCloud(t *testing.T) {
+	accountID := "5f7e1b2c3d4e5f6a7b8c9d0e"
+	user := newCustomFieldTypeUser(accountID, InstallationTypeCloud)
+
+	assert.Nil(t, user.Name)
+	assert.NotNil(t, user.AccountID)
+	assert.Equal(t, accountID, *user.AccountID)
+}
+
+func TestNewCustomFieldTypeUserLocal(t *testing.T) {
+	username := "john.doe"
+	user := newCustomFieldTypeUser(username, InstallationTypeLocal)
+
+	assert.NotNil(t, user.Name)
+	assert.Nil(t, user.AccountID)
+	assert.Equal(t, username, *user.Name)
+}
+
+func TestNewCustomFieldTypeUserDefaultIsCloud(t *testing.T) {
+	accountID := "5f7e1b2c3d4e5f6a7b8c9d0e"
+	user := newCustomFieldTypeUser(accountID, "")
+
+	assert.Nil(t, user.Name)
+	assert.NotNil(t, user.AccountID)
+	assert.Equal(t, accountID, *user.AccountID)
+}

--- a/pkg/jira/edit_test.go
+++ b/pkg/jira/edit_test.go
@@ -1,0 +1,189 @@
+package jira
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEditWithUserCustomField(t *testing.T) {
+	expectedBody := `{"update":{"customfield_12574":[{"set":{"accountId":"5f7e1b2c"}}]},"fields":{"parent":{}}}`
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/rest/api/2/issue/TEST-1", r.URL.Path)
+		assert.Equal(t, "PUT", r.Method)
+
+		actualBody := new(strings.Builder)
+		_, _ = io.Copy(actualBody, r.Body)
+
+		assert.JSONEq(t, expectedBody, actualBody.String())
+
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	client := NewClient(Config{Server: server.URL}, WithTimeout(3*time.Second))
+
+	edr := EditRequest{
+		CustomFields: map[string]string{
+			"pm-owner": "5f7e1b2c",
+		},
+	}
+	edr.WithCustomFields([]IssueTypeField{
+		{
+			Name: "PM owner",
+			Key:  "customfield_12574",
+			Schema: struct {
+				DataType string `json:"type"`
+				Items    string `json:"items,omitempty"`
+			}{DataType: "user"},
+		},
+	})
+	edr.ForInstallationType(InstallationTypeCloud)
+
+	err := client.Edit("TEST-1", &edr)
+	assert.NoError(t, err)
+}
+
+func TestEditWithUserCustomFieldLocal(t *testing.T) {
+	expectedBody := `{"update":{"customfield_12574":[{"set":{"name":"john.doe"}}]},"fields":{"parent":{}}}`
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/rest/api/2/issue/TEST-1", r.URL.Path)
+
+		actualBody := new(strings.Builder)
+		_, _ = io.Copy(actualBody, r.Body)
+
+		assert.JSONEq(t, expectedBody, actualBody.String())
+
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	client := NewClient(Config{Server: server.URL}, WithTimeout(3*time.Second))
+
+	edr := EditRequest{
+		CustomFields: map[string]string{
+			"pm-owner": "john.doe",
+		},
+	}
+	edr.WithCustomFields([]IssueTypeField{
+		{
+			Name: "PM owner",
+			Key:  "customfield_12574",
+			Schema: struct {
+				DataType string `json:"type"`
+				Items    string `json:"items,omitempty"`
+			}{DataType: "user"},
+		},
+	})
+	edr.ForInstallationType(InstallationTypeLocal)
+
+	err := client.Edit("TEST-1", &edr)
+	assert.NoError(t, err)
+}
+
+func TestEditWithMultiUserCustomField(t *testing.T) {
+	expectedBody := `{"update":{"customfield_10100":[{"set":{"accountId":"user1"}},{"set":{"accountId":"user2"}}]},"fields":{"parent":{}}}`
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/rest/api/2/issue/TEST-1", r.URL.Path)
+
+		actualBody := new(strings.Builder)
+		_, _ = io.Copy(actualBody, r.Body)
+
+		assert.JSONEq(t, expectedBody, actualBody.String())
+
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	client := NewClient(Config{Server: server.URL}, WithTimeout(3*time.Second))
+
+	edr := EditRequest{
+		CustomFields: map[string]string{
+			"reviewers": "user1,user2",
+		},
+	}
+	edr.WithCustomFields([]IssueTypeField{
+		{
+			Name: "Reviewers",
+			Key:  "customfield_10100",
+			Schema: struct {
+				DataType string `json:"type"`
+				Items    string `json:"items,omitempty"`
+			}{DataType: "array", Items: "user"},
+		},
+	})
+	edr.ForInstallationType(InstallationTypeCloud)
+
+	err := client.Edit("TEST-1", &edr)
+	assert.NoError(t, err)
+}
+
+func TestConstructCustomFieldsForEditUser(t *testing.T) {
+	data := &editRequest{}
+
+	fields := map[string]string{
+		"pm-owner": "5f7e1b2c",
+	}
+	configuredFields := []IssueTypeField{
+		{
+			Name: "PM owner",
+			Key:  "customfield_12574",
+			Schema: struct {
+				DataType string `json:"type"`
+				Items    string `json:"items,omitempty"`
+			}{DataType: "user"},
+		},
+	}
+
+	constructCustomFieldsForEdit(fields, configuredFields, InstallationTypeCloud, data)
+
+	result, ok := data.Update.M.customFields["customfield_12574"]
+	assert.True(t, ok)
+
+	b, err := json.Marshal(result)
+	assert.NoError(t, err)
+	assert.JSONEq(t, `[{"set":{"accountId":"5f7e1b2c"}}]`, string(b))
+}
+
+func TestConstructCustomFieldsForEditMultiUser(t *testing.T) {
+	data := &editRequest{}
+
+	fields := map[string]string{
+		"reviewers": "user1,user2",
+	}
+	configuredFields := []IssueTypeField{
+		{
+			Name: "Reviewers",
+			Key:  "customfield_10100",
+			Schema: struct {
+				DataType string `json:"type"`
+				Items    string `json:"items,omitempty"`
+			}{DataType: "array", Items: "user"},
+		},
+	}
+
+	constructCustomFieldsForEdit(fields, configuredFields, InstallationTypeCloud, data)
+
+	result, ok := data.Update.M.customFields["customfield_10100"]
+	assert.True(t, ok)
+
+	b, err := json.Marshal(result)
+	assert.NoError(t, err)
+	assert.JSONEq(t, `[{"set":{"accountId":"user1"}},{"set":{"accountId":"user2"}}]`, string(b))
+}
+
+func TestConstructCustomFieldsForEditEmpty(t *testing.T) {
+	data := &editRequest{}
+
+	constructCustomFieldsForEdit(nil, nil, InstallationTypeCloud, data)
+	assert.Nil(t, data.Update.M.customFields)
+
+	constructCustomFieldsForEdit(map[string]string{}, []IssueTypeField{}, InstallationTypeCloud, data)
+	assert.Nil(t, data.Update.M.customFields)
+}


### PR DESCRIPTION
Adds handling for `user`-type custom fields in both create and edit paths.

## Problem

User-type custom fields passed via `--custom` are silently dropped. The CLI reports "Issue updated" but the field remains null. This happens because the custom field switch statement only handles `option`, `array`, `number`, `project`, and the `default` (string) cases — but Jira's REST API requires user fields to be objects (`{"accountId":"..."}` for Cloud, `{"name":"..."}` for Server/DC), not plain strings.

## Solution

- Add `customFieldTypeUser` and `customFieldTypeUserSet` types following the existing pattern
- Add `newCustomFieldTypeUser()` constructor that branches on Cloud vs Local installation
- Handle `user` schema type for single-user fields in both `constructCustomFields` (create) and `constructCustomFieldsForEdit` (edit)
- Handle `user` items type for multi-user picker arrays in both paths
- Pass `installationType` through to `constructCustomFields` in the create path (edit already had it)
- Convert `if/else` chains to `switch` in the array sub-cases (gocritic lint)

## How to test?

**Unit tests (18 new tests):**
```
go test -race ./pkg/jira/... -run "Custom|Edit|User" -v
```

**Manual verification:**
1. Create a free Jira Cloud instance at atlassian.com
2. Add a "User Picker (single user)" custom field (e.g., "PM owner")
3. Run `jira init` and map the field in config under `issue.fields.custom` with `datatype: user`
4. Create or edit an issue: `jira issue edit TEST-1 --custom "pm-owner=<accountId>" --no-input`
5. Verify the field is set via the Jira UI or REST API

Tested end-to-end on a real Jira Cloud instance.

## Checklist

- [x] Tests added
- [x] Manual verification done
- [x] Backwards compatible (all changed functions are unexported)
- [x] Lint clean (`golangci-lint` 0 issues)

Fixes #798, #758, #579