### PR TITLE
fix: Prefer config file api_token over JIRA_API_TOKEN env var

### DIFF
--- a/internal/cmd/root/root.go
+++ b/internal/cmd/root/root.go
@@ -60,12 +60,19 @@ func init() {
 			viper.SetConfigType(jiraConfig.FileType)
 		}
 
+		if err := viper.ReadInConfig(); err == nil {
+			if debug {
+				fmt.Printf("Using config file: %s\n", viper.ConfigFileUsed())
+			}
+
+			// Preserve config file token before AutomaticEnv binds JIRA_API_TOKEN.
+			if token := viper.GetString("api_token"); token != "" {
+				viper.Set("api_token", token)
+			}
+		}
+
 		viper.AutomaticEnv()
 		viper.SetEnvPrefix("jira")
-
-		if err := viper.ReadInConfig(); err == nil && debug {
-			fmt.Printf("Using config file: %s\n", viper.ConfigFileUsed())
-		}
 	})
 }
 


### PR DESCRIPTION
## Problem

When using `--config` or `JIRA_CONFIG_FILE` to specify a different Jira account, the `JIRA_API_TOKEN` environment variable overrides the `api_token` from the config file. This causes issue list to return empty results when the env var token does not have access to the project.

## Root Cause

`viper.AutomaticEnv()` was called after `ReadInConfig()`, but since viper treats env vars with higher priority by default, the config file value was being overwritten.

## Solution

After reading the config file, explicitly preserve the `api_token` value using `viper.Set()` before calling `AutomaticEnv()`. This ensures the config file token takes precedence when explicitly set.

## Testing

Tested with multiple Jira accounts where:
- `JIRA_API_TOKEN` is set to account A
- `--config` specifies account B with a different `api_token`

Before: Returns empty results (uses account A token)
After: Returns correct results (uses account B token from config file)