### PR TITLE
fix: --plain flag should imply --table in sprint list

### DIFF
--- a/internal/cmd/sprint/list/list.go
+++ b/internal/cmd/sprint/list/list.go
@@ -258,7 +258,7 @@ func sprintExplorerView(sprintQuery *query.Sprint, flags query.FlagParser, board
 	table, err := flags.GetBool("table")
 	cmdutil.ExitIfError(err)
 
-	if table || tui.IsDumbTerminal() || tui.IsNotTTY() {
+	if table || plain || tui.IsDumbTerminal() || tui.IsNotTTY() {
 		cmdutil.ExitIfError(v.RenderInTable())
 	} else {
 		cmdutil.ExitIfError(v.Render())


### PR DESCRIPTION
## Summary

- When using `jira sprint list --plain`, the `--plain` flag was ignored because only `--table` was checked in the TUI vs table mode decision
- This adds `plain` to the branching condition in `sprintExplorerView()` so that `--plain` bypasses the TUI explorer and renders a plain table

## Details

In `internal/cmd/sprint/list/list.go`, the condition that decides between TUI explorer and table output was:

```go
if table || tui.IsDumbTerminal() || tui.IsNotTTY() {
```

Changed to:

```go
if table || plain || tui.IsDumbTerminal() || tui.IsNotTTY() {
```

The `plain` variable was already read from flags earlier in the same function (line 215) and passed to `view.DisplayFormat`, so this is a minimal, safe addition.

Closes #968