### PR TITLE
fix: --show-all-issues should preserve user JQL filter

### DIFF
--- a/internal/cmd/sprint/list/list.go
+++ b/internal/cmd/sprint/list/list.go
@@ -102,7 +102,11 @@ func singleSprintView(sprintQuery *query.Sprint, flags query.FlagParser, boardID
 			return nil, err
 		}
 		if sprintQuery.Params().ShowAllIssues {
-			q.Params().JQL = "project IS NOT EMPTY"
+			if q.Params().JQL != "" {
+				q.Params().JQL = "project IS NOT EMPTY AND " + q.Params().JQL
+			} else {
+				q.Params().JQL = "project IS NOT EMPTY"
+			}
 		}
 		resp, err := client.SprintIssues(sprintID, q.Get(), q.Params().From, q.Params().Limit)
 		if err != nil {
@@ -271,7 +275,11 @@ func getIssueQuery(project string, flags query.FlagParser, showAll bool) (string
 		return "", err
 	}
 	if showAll {
-		q.Params().JQL = "project IS NOT EMPTY"
+		if q.Params().JQL != "" {
+			q.Params().JQL = "project IS NOT EMPTY AND " + q.Params().JQL
+		} else {
+			q.Params().JQL = "project IS NOT EMPTY"
+		}
 	}
 	return q.Get(), nil
 }


### PR DESCRIPTION
## Summary
- When using `--show-all-issues` with `jira sprint list`, the flag now preserves any user-specified JQL filter
- Previously, `--show-all-issues` would overwrite the user's custom JQL with `project IS NOT EMPTY`, discarding any `--jql` argument
- The fix combines `project IS NOT EMPTY` with the user's JQL using `AND` when both are present

Closes #969