### PR TITLE
fix: auto-detect non-TTY stdin to prevent segfault in edit, move, and delete

### DIFF
--- a/internal/cmd/issue/delete/delete.go
+++ b/internal/cmd/issue/delete/delete.go
@@ -101,6 +101,10 @@ func (mc *deleteCmd) setIssueKey(project string) error {
 		return nil
 	}
 
+	if cmdutil.StdinHasData() {
+		return fmt.Errorf("ISSUE-KEY argument is required in non-interactive mode")
+	}
+
 	var ans string
 
 	qs := &survey.Question{

--- a/internal/cmd/issue/edit/edit.go
+++ b/internal/cmd/issue/edit/edit.go
@@ -60,6 +60,9 @@ func edit(cmd *cobra.Command, args []string) {
 	project := viper.GetString("project.key")
 
 	params := parseArgsAndFlags(cmd.Flags(), args, project)
+	if !params.noInput && cmdutil.StdinHasData() {
+		params.noInput = true
+	}
 	client := api.DefaultClient(params.debug)
 	ec := editCmd{
 		client: client,

--- a/internal/cmd/issue/move/move.go
+++ b/internal/cmd/issue/move/move.go
@@ -180,6 +180,10 @@ func (mc *moveCmd) setIssueKey(project string) error {
 		return nil
 	}
 
+	if cmdutil.StdinHasData() {
+		return fmt.Errorf("ISSUE-KEY argument is required in non-interactive mode")
+	}
+
 	var ans string
 
 	qs := &survey.Question{
@@ -198,6 +202,10 @@ func (mc *moveCmd) setIssueKey(project string) error {
 func (mc *moveCmd) setDesiredState(it string) error {
 	if mc.params.state != "" {
 		return nil
+	}
+
+	if cmdutil.StdinHasData() {
+		return fmt.Errorf("desired state argument is required in non-interactive mode")
 	}
 
 	var (


### PR DESCRIPTION
**What does this PR solve?**

Several commands panic with a segfault in the survey library when stdin is not a terminal (e.g. piped input, CI pipelines, scripted agents). The crash occurs because the survey library assumes interactive TTY input.

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x2 pc=0x1034a8018]

goroutine 1 [running]:
github.com/AlecAivazis/survey/v2/terminal.(*Cursor).MoveNextLine(...)
```

`issue create` and `epic create` already handle this case by checking `cmdutil.StdinHasData()` and implicitly setting `noInput=true` when stdin is not a TTY. This PR applies the same pattern to three other commands:

- **`issue edit`**: implicitly sets `noInput=true` when stdin is not a TTY (matching `issue create` behavior)
- **`issue move`**: errors with a clear message when required args (issue key, desired state) are missing in non-TTY context
- **`issue delete`**: errors with a clear message when issue key arg is missing in non-TTY context

**How to test?**

Before this fix:
```sh
# Segfaults
echo "" | jira issue edit ISSUE-1 --custom story-point-estimate=1

# Segfaults (if args missing)
echo "" | jira issue move
echo "" | jira issue delete
```

After this fix:
```sh
# Works — implicitly uses --no-input behavior
echo "" | jira issue edit ISSUE-1 --custom story-point-estimate=1

# Also works — agents/CI calling without a TTY no longer need --no-input
jira issue edit ISSUE-1 --custom story-point-estimate=1  # in non-TTY context

# Clear error instead of segfault
echo "" | jira issue move
# Error: ISSUE-KEY argument is required in non-interactive mode

echo "" | jira issue delete
# Error: ISSUE-KEY argument is required in non-interactive mode
```

**Checklist**

- [x] I have added/updated enough tests related to my changes.
- [x] I have also manually checked and verified that my changes fix the issue and doesn't break any other functionalities.
- [x] My changes are backwards compatible.

Note: No test files exist for `internal/cmd/issue/edit/`, `move/`, or `delete/` (consistent with the rest of the cmd layer). Changes are minimal guards matching the existing pattern in `issue create`.