### PR TITLE
fix: align Jira token pre-check with actual token resolution

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -27,19 +27,7 @@ func Client(config jira.Config) *jira.Client {
 	if config.Login == "" {
 		config.Login = viper.GetString("login")
 	}
-	if config.APIToken == "" {
-		config.APIToken = viper.GetString("api_token")
-	}
-	if config.APIToken == "" {
-		netrcConfig, _ := netrc.Read(config.Server, config.Login)
-		if netrcConfig != nil {
-			config.APIToken = netrcConfig.Password
-		}
-	}
-	if config.APIToken == "" {
-		secret, _ := keyring.Get("jira-cli", config.Login)
-		config.APIToken = secret
-	}
+	config.APIToken = GetAPIToken(config)
 	if config.AuthType == nil {
 		authType := jira.AuthType(viper.GetString("auth_type"))
 		config.AuthType = &authType
@@ -68,6 +56,25 @@ func Client(config jira.Config) *jira.Client {
 	)
 
 	return jiraClient
+}
+
+func GetAPIToken(config jira.Config) string {
+	if config.APIToken != "" {
+		return config.APIToken
+	}
+	if apiToken := viper.GetString("api_token"); apiToken != "" {
+		return apiToken
+	}
+
+	if netrcConfig, _ := netrc.Read(config.Server, config.Login); netrcConfig != nil && netrcConfig.Password != "" {
+		return netrcConfig.Password
+	}
+
+	if secret, _ := keyring.Get("jira-cli", config.Login); secret != "" {
+		return secret
+	}
+
+	return ""
 }
 
 // DefaultClient returns default jira client.

--- a/internal/cmd/root/root.go
+++ b/internal/cmd/root/root.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
+	"github.com/ankitpokhrel/jira-cli/api"
 	"github.com/ankitpokhrel/jira-cli/internal/cmd/board"
 	"github.com/ankitpokhrel/jira-cli/internal/cmd/completion"
 	"github.com/ankitpokhrel/jira-cli/internal/cmd/epic"
@@ -24,9 +25,6 @@ import (
 	"github.com/ankitpokhrel/jira-cli/internal/cmdutil"
 	jiraConfig "github.com/ankitpokhrel/jira-cli/internal/config"
 	"github.com/ankitpokhrel/jira-cli/pkg/jira"
-	"github.com/ankitpokhrel/jira-cli/pkg/netrc"
-
-	"github.com/zalando/go-keyring"
 )
 
 const (
@@ -157,17 +155,10 @@ func cmdRequireToken(cmd string) bool {
 }
 
 func checkForJiraToken(server string, login string) {
-	if os.Getenv("JIRA_API_TOKEN") != "" {
-		return
-	}
-
-	netrcConfig, _ := netrc.Read(server, login)
-	if netrcConfig != nil {
-		return
-	}
-
-	secret, _ := keyring.Get("jira-cli", login)
-	if secret != "" {
+	if api.GetAPIToken(jira.Config{
+		Server: server,
+		Login:  login,
+	}) != "" {
 		return
 	}
 


### PR DESCRIPTION
## Summary
- centralize token lookup in `api.GetAPIToken`
- reuse that helper in the root pre-check so config file `api_token` is treated as a valid credential source
- remove duplicated token source checks from `root.go`

## Testing
- `go test ./internal/cmd/root ./api`

## Notes
- Full `go test ./...` still has an existing unrelated failure in `pkg/tui` (`TestGetPager`) in this environment.