### PR TITLE
ci: add Docker image build provenance attestation

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,6 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      attestations: write
+      id-token: write
       packages: write
 
     steps:
@@ -43,6 +45,7 @@ jobs:
           platforms: linux/amd64,linux/arm64,linux/arm/v6,linux/arm/v7,linux/arm/v8
 
       - name: Build and push Docker image
+        id: push
         uses: docker/build-push-action@v5
         with:
           context: .
@@ -51,3 +54,10 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64,linux/arm64,linux/arm/v6,linux/arm/v7,linux/arm/v8
+
+      - name: Generate build provenance attestation
+        uses: actions/attest-build-provenance@v3
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true


### PR DESCRIPTION
## Summary
This PR adds GitHub build provenance attestation to the Docker publish workflow.

It updates the existing GHCR publish job so the workflow can generate and publish a provenance attestation for the pushed container image. This gives downstream users a verifiable link between the published image and the GitHub Actions workflow run and commit that produced it.

The recent widely publicized Linux xz backdoor incident is a classic example of "clean source code, but the released pre-compiled binaries were compromised." This illustrates the crucial importance of the credibility of "released artifacts" within the software supply chain. Problems don't necessarily only arise at the public source code level; they can also occur in the actual built, packaged, and distributed binary artifacts. The Provenance mechanism provides this kind of "source verifiability," helping downstream users confirm that the files they receive come from the expected official build chain.

- add the permissions required for GitHub artifact attestations in the Docker publish workflow
- capture the pushed image digest from `docker/build-push-action`
- generate and publish a build provenance attestation for the GHCR image

## Validation
- parsed `.github/workflows/docker.yml` locally (`python3` + YAML parser)
- confirmed the workflow references `steps.push.outputs.digest`

## Notes
- this is the minimal provenance integration for the existing GHCR publish workflow
- release binaries are not covered yet because the repository does not currently have a GoReleaser release workflow wired up in GitHub Actions