### PR TITLE
feat(issue): add attachment list/download commands and show attachments in issue view

### DIFF
--- a/internal/cmd/issue/attachment/attachment.go
+++ b/internal/cmd/issue/attachment/attachment.go
@@ -1,0 +1,29 @@
+package attachment
+
+import (
+	"github.com/spf13/cobra"
+)
+
+const helpText = `Attachment command helps you manage issue attachments. See available commands below.`
+
+// NewCmdAttachment is an attachment command.
+func NewCmdAttachment() *cobra.Command {
+	cmd := cobra.Command{
+		Use:     "attachment",
+		Short:   "Manage issue attachments",
+		Long:    helpText,
+		Aliases: []string{"attachments"},
+		RunE:    attachment,
+	}
+
+	cmd.AddCommand(
+		newCmdAttachmentList(),
+		newCmdAttachmentDownload(),
+	)
+
+	return &cmd
+}
+
+func attachment(cmd *cobra.Command, _ []string) error {
+	return cmd.Help()
+}

--- a/internal/cmd/issue/attachment/download.go
+++ b/internal/cmd/issue/attachment/download.go
@@ -30,7 +30,7 @@ func download(cmd *cobra.Command, args []string) {
 	project := viper.GetString("project.key")
 	key := cmdutil.GetJiraIssueKey(project, args[0])
 	attachmentName := args[1]
-	
+
 	outputName := attachmentName
 	if len(args) == 3 {
 		outputName = args[2]
@@ -84,13 +84,17 @@ func download(cmd *cobra.Command, args []string) {
 
 	body, err := client.DownloadAttachment(target.Content)
 	cmdutil.ExitIfError(err)
-	defer body.Close()
 
 	out, err := os.Create(outputPath)
 	cmdutil.ExitIfError(err)
-	defer out.Close()
 
 	_, err = io.Copy(out, body)
+	cmdutil.ExitIfError(err)
+
+	err = out.Close()
+	cmdutil.ExitIfError(err)
+
+	err = body.Close()
 	cmdutil.ExitIfError(err)
 
 	s.Stop()
@@ -104,7 +108,7 @@ func getUniqueFilename(name string) string {
 
 	ext := filepath.Ext(name)
 	base := strings.TrimSuffix(name, ext)
-	
+
 	for i := 1; ; i++ {
 		newName := fmt.Sprintf("%s (%d)%s", base, i, ext)
 		if _, err := os.Stat(newName); os.IsNotExist(err) {

--- a/internal/cmd/issue/attachment/download.go
+++ b/internal/cmd/issue/attachment/download.go
@@ -1,0 +1,114 @@
+package attachment
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/AlecAivazis/survey/v2"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/ankitpokhrel/jira-cli/api"
+	"github.com/ankitpokhrel/jira-cli/internal/cmdutil"
+	"github.com/ankitpokhrel/jira-cli/pkg/jira"
+)
+
+func newCmdAttachmentDownload() *cobra.Command {
+	return &cobra.Command{
+		Use:     "download ISSUE-KEY ATTACHMENT-NAME [OUTPUT-NAME]",
+		Short:   "Download an attachment from an issue",
+		Args:    cobra.RangeArgs(2, 3),
+		Aliases: []string{"dl"},
+		Run:     download,
+	}
+}
+
+func download(cmd *cobra.Command, args []string) {
+	project := viper.GetString("project.key")
+	key := cmdutil.GetJiraIssueKey(project, args[0])
+	attachmentName := args[1]
+	
+	outputName := attachmentName
+	if len(args) == 3 {
+		outputName = args[2]
+	}
+
+	debug, _ := cmd.Flags().GetBool("debug")
+	client := api.DefaultClient(debug)
+	issue, err := client.GetIssueV2(key)
+	cmdutil.ExitIfError(err)
+
+	var matches []jira.Attachment
+	for _, a := range issue.Fields.Attachments {
+		if a.Filename == attachmentName {
+			matches = append(matches, a)
+		}
+	}
+
+	if len(matches) == 0 {
+		cmdutil.Failed("No attachment found with name %q for issue %s", attachmentName, key)
+	}
+
+	var target jira.Attachment
+	if len(matches) > 1 {
+		options := make([]string, len(matches))
+		for i, a := range matches {
+			options[i] = fmt.Sprintf("%s (ID: %s, Size: %s, Created: %s)", a.Filename, a.ID, cmdutil.FormatBytes(int64(a.Size)), a.Created)
+		}
+
+		var selected string
+		prompt := &survey.Select{
+			Message: "Multiple attachments found with the same name. Please select one:",
+			Options: options,
+		}
+		err := survey.AskOne(prompt, &selected)
+		cmdutil.ExitIfError(err)
+
+		for i, opt := range options {
+			if opt == selected {
+				target = matches[i]
+				break
+			}
+		}
+	} else {
+		target = matches[0]
+	}
+
+	outputPath := getUniqueFilename(outputName)
+
+	s := cmdutil.Info(fmt.Sprintf("Downloading attachment %q to %q...", target.Filename, outputPath))
+	defer s.Stop()
+
+	body, err := client.DownloadAttachment(target.Content)
+	cmdutil.ExitIfError(err)
+	defer body.Close()
+
+	out, err := os.Create(outputPath)
+	cmdutil.ExitIfError(err)
+	defer out.Close()
+
+	_, err = io.Copy(out, body)
+	cmdutil.ExitIfError(err)
+
+	s.Stop()
+	cmdutil.Success("Attachment downloaded successfully to %q", outputPath)
+}
+
+func getUniqueFilename(name string) string {
+	if _, err := os.Stat(name); os.IsNotExist(err) {
+		return name
+	}
+
+	ext := filepath.Ext(name)
+	base := strings.TrimSuffix(name, ext)
+	
+	for i := 1; ; i++ {
+		newName := fmt.Sprintf("%s (%d)%s", base, i, ext)
+		if _, err := os.Stat(newName); os.IsNotExist(err) {
+			return newName
+		}
+	}
+}

--- a/internal/cmd/issue/attachment/list.go
+++ b/internal/cmd/issue/attachment/list.go
@@ -1,0 +1,41 @@
+package attachment
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/ankitpokhrel/jira-cli/api"
+	"github.com/ankitpokhrel/jira-cli/internal/cmdutil"
+	"github.com/ankitpokhrel/jira-cli/internal/view"
+)
+
+func newCmdAttachmentList() *cobra.Command {
+	return &cobra.Command{
+		Use:     "list ISSUE-KEY",
+		Short:   "List attachments of an issue",
+		Args:    cobra.ExactArgs(1),
+		Aliases: []string{"ls"},
+		Run:     list,
+	}
+}
+
+func list(cmd *cobra.Command, args []string) {
+	project := viper.GetString("project.key")
+	key := cmdutil.GetJiraIssueKey(project, args[0])
+	debug, err := cmd.Flags().GetBool("debug")
+	cmdutil.ExitIfError(err)
+
+	client := api.DefaultClient(debug)
+	issue, err := client.GetIssueV2(key)
+	cmdutil.ExitIfError(err)
+
+	if len(issue.Fields.Attachments) == 0 {
+		fmt.Printf("No attachments found for issue %s\n", key)
+		return
+	}
+
+	v := view.NewAttachment(issue.Fields.Attachments)
+	cmdutil.ExitIfError(v.Render())
+}

--- a/internal/cmd/issue/issue.go
+++ b/internal/cmd/issue/issue.go
@@ -4,6 +4,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/ankitpokhrel/jira-cli/internal/cmd/issue/assign"
+	"github.com/ankitpokhrel/jira-cli/internal/cmd/issue/attachment"
 	"github.com/ankitpokhrel/jira-cli/internal/cmd/issue/clone"
 	"github.com/ankitpokhrel/jira-cli/internal/cmd/issue/comment"
 	"github.com/ankitpokhrel/jira-cli/internal/cmd/issue/create"
@@ -36,8 +37,8 @@ func NewCmdIssue() *cobra.Command {
 
 	cmd.AddCommand(
 		lc, cc, edit.NewCmdEdit(), move.NewCmdMove(), view.NewCmdView(), assign.NewCmdAssign(),
-		link.NewCmdLink(), unlink.NewCmdUnlink(), comment.NewCmdComment(), clone.NewCmdClone(),
-		delete.NewCmdDelete(), watch.NewCmdWatch(), worklog.NewCmdWorklog(),
+		attachment.NewCmdAttachment(), link.NewCmdLink(), unlink.NewCmdUnlink(), comment.NewCmdComment(),
+		clone.NewCmdClone(), delete.NewCmdDelete(), watch.NewCmdWatch(), worklog.NewCmdWorklog(),
 	)
 
 	list.SetFlags(lc)

--- a/internal/cmdutil/utils.go
+++ b/internal/cmdutil/utils.go
@@ -200,6 +200,20 @@ func GetSubtaskHandle(issueType string, issueTypes []*jira.IssueType) string {
 	return fallback
 }
 
+// FormatBytes formats bytes to a human readable format.
+func FormatBytes(b int64) string {
+	const unit = 1024
+	if b < unit {
+		return fmt.Sprintf("%d B", b)
+	}
+	div, exp := int64(unit), 0
+	for n := b / unit; n >= unit; n /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %ciB", float64(b)/float64(div), "KMGTPE"[exp])
+}
+
 // GetTUIStyleConfig returns the custom style configured by the user.
 func GetTUIStyleConfig() tui.TableStyle {
 	var bold bool

--- a/internal/cmdutil/utils_test.go
+++ b/internal/cmdutil/utils_test.go
@@ -264,3 +264,49 @@ func TestGetSubtaskHandle(t *testing.T) {
 		})
 	}
 }
+
+func TestFormatBytes(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		input    int64
+		expected string
+	}{
+		{
+			name:     "bytes",
+			input:    512,
+			expected: "512 B",
+		},
+		{
+			name:     "kilobytes",
+			input:    1024,
+			expected: "1.0 KiB",
+		},
+		{
+			name:     "kilobytes boundary",
+			input:    1024*1024 - 1,
+			expected: "1024.0 KiB",
+		},
+		{
+			name:     "megabytes",
+			input:    1024 * 1024,
+			expected: "1.0 MiB",
+		},
+		{
+			name:     "gigabytes",
+			input:    1024 * 1024 * 1024,
+			expected: "1.0 GiB",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tc.expected, FormatBytes(tc.input))
+		})
+	}
+}

--- a/internal/view/attachment.go
+++ b/internal/view/attachment.go
@@ -1,0 +1,68 @@
+package view
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"text/tabwriter"
+
+	"github.com/ankitpokhrel/jira-cli/internal/cmdutil"
+	"github.com/ankitpokhrel/jira-cli/pkg/jira"
+	"github.com/ankitpokhrel/jira-cli/pkg/tui"
+)
+
+// Attachment is an attachment view.
+type Attachment struct {
+	Data   []jira.Attachment
+	Writer io.Writer
+	buf    *bytes.Buffer
+}
+
+// NewAttachment initializes an attachment view.
+func NewAttachment(data []jira.Attachment) *Attachment {
+	a := Attachment{
+		Data: data,
+		buf:  new(bytes.Buffer),
+	}
+	a.Writer = tabwriter.NewWriter(a.buf, 0, tabWidth, 1, '\t', 0)
+
+	return &a
+}
+
+// Render renders the attachment view.
+func (a *Attachment) Render() error {
+	a.printHeader()
+
+	for _, d := range a.Data {
+		size := cmdutil.FormatBytes(int64(d.Size))
+		created := cmdutil.FormatDateTimeHuman(d.Created, jira.RFC3339)
+		_, _ = fmt.Fprintf(a.Writer, "%s\t%s\t%s\n", d.Filename, size, created)
+	}
+
+	if _, ok := a.Writer.(*tabwriter.Writer); ok {
+		if err := a.Writer.(*tabwriter.Writer).Flush(); err != nil {
+			return err
+		}
+	}
+
+	return tui.PagerOut(a.buf.String())
+}
+
+func (a *Attachment) header() []string {
+	return []string{
+		"NAME",
+		"SIZE",
+		"CREATED",
+	}
+}
+
+func (a *Attachment) printHeader() {
+	n := len(a.header())
+	for i, h := range a.header() {
+		_, _ = fmt.Fprintf(a.Writer, "%s", h)
+		if i != n-1 {
+			_, _ = fmt.Fprintf(a.Writer, "\t")
+		}
+	}
+	_, _ = fmt.Fprintln(a.Writer, "")
+}

--- a/internal/view/attachment.go
+++ b/internal/view/attachment.go
@@ -48,7 +48,7 @@ func (a *Attachment) Render() error {
 	return tui.PagerOut(a.buf.String())
 }
 
-func (a *Attachment) header() []string {
+func attachmentHeader() []string {
 	return []string{
 		"NAME",
 		"SIZE",
@@ -57,8 +57,9 @@ func (a *Attachment) header() []string {
 }
 
 func (a *Attachment) printHeader() {
-	n := len(a.header())
-	for i, h := range a.header() {
+	header := attachmentHeader()
+	n := len(header)
+	for i, h := range header {
 		_, _ = fmt.Fprintf(a.Writer, "%s", h)
 		if i != n-1 {
 			_, _ = fmt.Fprintf(a.Writer, "\t")

--- a/internal/view/issue.go
+++ b/internal/view/issue.go
@@ -97,6 +97,10 @@ func (i Issue) String() string {
 	if desc != "" {
 		s.WriteString(fmt.Sprintf("\n\n%s\n\n%s", i.separator("Description"), desc))
 	}
+
+	if len(i.Data.Fields.Attachments) > 0 {
+		s.WriteString(fmt.Sprintf("\n\n%s\n\n%s\n", i.separator("Attachments"), i.attachments()))
+	}
 	if len(i.Data.Fields.Subtasks) > 0 {
 		s.WriteString(
 			fmt.Sprintf(
@@ -135,6 +139,17 @@ func (i Issue) fragments() []fragment {
 			fragment{Body: i.separator("Description")},
 			newBlankFragment(2),
 			fragment{Body: desc, Parse: true},
+		)
+	}
+
+	if len(i.Data.Fields.Attachments) > 0 {
+		scraps = append(
+			scraps,
+			newBlankFragment(1),
+			fragment{Body: i.separator("Attachments")},
+			newBlankFragment(2),
+			fragment{Body: i.attachments()},
+			newBlankFragment(1),
 		)
 	}
 
@@ -230,10 +245,14 @@ func (i Issue) header() string {
 	} else if i.Data.Fields.Watches.IsWatching {
 		wch = fmt.Sprintf("You + %d watchers", i.Data.Fields.Watches.WatchCount-1)
 	}
+	att := fmt.Sprintf("%d attachments", len(i.Data.Fields.Attachments))
+	if len(i.Data.Fields.Attachments) == 1 {
+		att = "1 attachment"
+	}
 	return fmt.Sprintf(
-		"%s %s  %s %s  ⌛ %s  👷 %s  🔑️ %s  💭 %d comments  \U0001F9F5 %d linked\n# %s\n⏱️  %s  🔎 %s  🚀 %s  📦 %s  🏷️  %s  👀 %s",
+		"%s %s  %s %s  ⌛ %s  👷 %s  🔑️ %s  📎 %s  💭 %d comments  \U0001F9F5 %d linked\n# %s\n⏱️  %s  🔎 %s  🚀 %s  📦 %s  🏷️  %s  👀 %s",
 		iti, it, sti, st, cmdutil.FormatDateTimeHuman(i.Data.Fields.Updated, jira.RFC3339), as, i.Data.Key,
-		i.Data.Fields.Comment.Total, len(i.Data.Fields.IssueLinks),
+		att, i.Data.Fields.Comment.Total, len(i.Data.Fields.IssueLinks),
 		i.Data.Fields.Summary,
 		cmdutil.FormatDateTimeHuman(i.Data.Fields.Created, jira.RFC3339), i.Data.Fields.Reporter.Name,
 		i.Data.Fields.Priority.Name, cmpt, lbl, wch,
@@ -376,6 +395,36 @@ func (i Issue) linkedIssues() string {
 	}
 
 	return linked.String()
+}
+
+func (i Issue) attachments() string {
+	if len(i.Data.Fields.Attachments) == 0 {
+		return ""
+	}
+
+	var (
+		attachments strings.Builder
+		maxNameLen  int
+		maxSizeLen  int
+	)
+
+	for _, a := range i.Data.Fields.Attachments {
+		maxNameLen = max(len(a.Filename), maxNameLen)
+		maxSizeLen = max(len(cmdutil.FormatBytes(int64(a.Size))), maxSizeLen)
+	}
+
+	for _, a := range i.Data.Fields.Attachments {
+		attachments.WriteString(
+			fmt.Sprintf(
+				"  📎 %s • %s • %s\n",
+				coloredOut(pad(a.Filename, maxNameLen), color.FgGreen, color.Bold),
+				pad(cmdutil.FormatBytes(int64(a.Size)), maxSizeLen),
+				coloredOut(cmdutil.FormatDateTimeHuman(a.Created, jira.RFC3339), color.FgWhite, color.Bold),
+			),
+		)
+	}
+
+	return attachments.String()
 }
 
 func (i Issue) comments() []issueComment {

--- a/internal/view/issue_test.go
+++ b/internal/view/issue_test.go
@@ -66,6 +66,13 @@ func TestIssueDetailsRenderInPlainView(t *testing.T) {
 			}{IsWatching: true, WatchCount: 4},
 			Created: "2020-12-13T14:05:20.974+0100",
 			Updated: "2020-12-13T14:07:20.974+0100",
+			Attachments: []jira.Attachment{
+				{
+					Filename: "test.txt",
+					Size:     1024,
+					Created:  "2020-12-13T14:05:20.974+0100",
+				},
+			},
 		},
 	}
 
@@ -75,7 +82,7 @@ func TestIssueDetailsRenderInPlainView(t *testing.T) {
 		Display: DisplayFormat{Plain: true},
 	}
 
-	expected := "🐞 Bug  ✅ Done  ⌛ Sun, 13 Dec 20  👷 Person A  🔑️ TEST-1  💭 0 comments  \U0001F9F5 0 linked\n# This is a test\n⏱️  Sun, 13 Dec 20  🔎 Person Z  🚀 High  📦 BE, FE  🏷️  None  👀 You + 3 watchers\n\n------------------------ Description ------------------------\n\nTest description\n\n\n"
+	expected := "🐞 Bug  ✅ Done  ⌛ Sun, 13 Dec 20  👷 Person A  🔑️ TEST-1  📎 1 attachment  💭 0 comments  \U0001F9F5 0 linked\n# This is a test\n⏱️  Sun, 13 Dec 20  🔎 Person Z  🚀 High  📦 BE, FE  🏷️  None  👀 You + 3 watchers\n\n------------------------ Description ------------------------\n\nTest description\n\n\n\n------------------------ Attachments ------------------------\n\n  📎 test.txt • 1.0 KiB • Sun, 13 Dec 20\n\n\n"
 	if xterm256() {
 		expected += "\x1b[38;5;242mView this issue on Jira: https://test.local/browse/TEST-1\x1b[m"
 	} else {
@@ -214,6 +221,13 @@ func TestIssueDetailsWithV2Description(t *testing.T) {
 			},
 			Created: "2020-12-13T14:05:20.974+0100",
 			Updated: "2020-12-13T14:07:20.974+0100",
+			Attachments: []jira.Attachment{
+				{
+					Filename: "test.txt",
+					Size:     1024,
+					Created:  "2020-12-13T14:05:20.974+0100",
+				},
+			},
 		},
 	}
 
@@ -225,7 +239,7 @@ func TestIssueDetailsWithV2Description(t *testing.T) {
 	}
 	assert.NoError(t, issue.renderPlain(&b))
 
-	expected := "🐞 Bug  ✅ Done  ⌛ Sun, 13 Dec 20  👷 Person A  🔑️ TEST-1  💭 3 comments  \U0001F9F5 2 linked\n# This is a test\n⏱️  Sun, 13 Dec 20  🔎 Person Z  🚀 High  📦 BE, FE  🏷️  None  👀 0 watchers\n\n------------------------ Description ------------------------\n\n# Title\n## Subtitle\nThis is a **bold** and _italic_ text with [a link](https://ankit.pl) in between.\n\n\n------------------------ 2 Subtasks ------------------------\n\n\n SUBTASKS\n\n  TEST-2 Subtask 1 • High   • TO DO\n  TEST-3 Subtask 2 • Normal • Done \n\n\n\n------------------------ Linked Issues ------------------------\n\n\n BLOCKS\n\n  TEST-2 Something is broken   • Bug • High   • TO DO\n\n RELATES TO\n\n  TEST-3 Everything is on fire • Bug • Urgent • Done \n\n\n\n------------------------ 3 Comments ------------------------\n\n\n Person C • Wed, 24 Nov 21 • Latest comment\n\nTest comment C\n\n\n\n Person B • Tue, 23 Nov 21\n\nTest comment B\n\n"
+	expected := "🐞 Bug  ✅ Done  ⌛ Sun, 13 Dec 20  👷 Person A  🔑️ TEST-1  📎 1 attachment  💭 3 comments  \U0001F9F5 2 linked\n# This is a test\n⏱️  Sun, 13 Dec 20  🔎 Person Z  🚀 High  📦 BE, FE  🏷️  None  👀 0 watchers\n\n------------------------ Description ------------------------\n\n# Title\n## Subtitle\nThis is a **bold** and _italic_ text with [a link](https://ankit.pl) in between.\n\n\n------------------------ Attachments ------------------------\n\n  📎 test.txt • 1.0 KiB • Sun, 13 Dec 20\n\n\n\n------------------------ 2 Subtasks ------------------------\n\n\n SUBTASKS\n\n  TEST-2 Subtask 1 • High   • TO DO\n  TEST-3 Subtask 2 • Normal • Done \n\n\n\n------------------------ Linked Issues ------------------------\n\n\n BLOCKS\n\n  TEST-2 Something is broken   • Bug • High   • TO DO\n\n RELATES TO\n\n  TEST-3 Everything is on fire • Bug • Urgent • Done \n\n\n\n------------------------ 3 Comments ------------------------\n\n\n Person C • Wed, 24 Nov 21 • Latest comment\n\nTest comment C\n\n\n\n Person B • Tue, 23 Nov 21\n\nTest comment B\n\n"
 	if xterm256() {
 		expected += "\x1b[38;5;242mUse --comments <limit> with `jira issue view` to load more comments\x1b[m\n\n"
 		expected += "\x1b[38;5;242mView this issue on Jira: https://test.local/browse/TEST-1\x1b[m"

--- a/pkg/jira/issue.go
+++ b/pkg/jira/issue.go
@@ -209,6 +209,41 @@ func (c *Client) GetIssueLinkTypes() ([]*IssueLinkType, error) {
 	return out.IssueLinkTypes, nil
 }
 
+// DownloadAttachment downloads attachment from the given URL.
+func (c *Client) DownloadAttachment(url string) (io.ReadCloser, error) {
+	if strings.HasPrefix(url, "http://") || strings.HasPrefix(url, "https://") {
+		res, err := c.request(context.Background(), http.MethodGet, url, nil, Header{
+			"X-Atlassian-Token": "no-check",
+		})
+		if err != nil {
+			return nil, err
+		}
+		if res == nil {
+			return nil, ErrEmptyResponse
+		}
+		if res.StatusCode != http.StatusOK {
+			_ = res.Body.Close()
+			return nil, formatUnexpectedResponse(res)
+		}
+		return res.Body, nil
+	}
+
+	res, err := c.Get(context.Background(), url, nil)
+	if err != nil {
+		return nil, err
+	}
+	if res == nil {
+		return nil, ErrEmptyResponse
+	}
+
+	if res.StatusCode != http.StatusOK {
+		_ = res.Body.Close()
+		return nil, formatUnexpectedResponse(res)
+	}
+
+	return res.Body, nil
+}
+
 type linkRequest struct {
 	InwardIssue struct {
 		Key string `json:"key"`

--- a/pkg/jira/issue_test.go
+++ b/pkg/jira/issue_test.go
@@ -374,7 +374,7 @@ func TestGetIssueRaw(t *testing.T) {
 
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusOK)
-				_, err = w.Write(respContent)
+				_, _ = w.Write(respContent)
 			}))
 			defer server.Close()
 

--- a/pkg/jira/issue_test.go
+++ b/pkg/jira/issue_test.go
@@ -384,7 +384,11 @@ func TestGetIssueRaw(t *testing.T) {
 				return
 			}
 
-			assert.Equal(t, c.wantOut, out)
+			assert.Equal(
+				t,
+				strings.ReplaceAll(c.wantOut, "\r\n", "\n"),
+				strings.ReplaceAll(out, "\r\n", "\n"),
+			)
 		})
 	}
 }

--- a/pkg/jira/issue_test.go
+++ b/pkg/jira/issue_test.go
@@ -76,6 +76,15 @@ func TestGetIssue(t *testing.T) {
 			}{Name: "To Do"},
 			Created: "2020-12-03T14:05:20.974+0100",
 			Updated: "2020-12-03T14:05:20.974+0100",
+			Attachments: []Attachment{
+				{
+					ID:       "10001",
+					Filename: "test.txt",
+					Size:     1024,
+					Created:  "2020-12-03T14:05:20.974+0100",
+					Content:  "https://test.local/secure/attachment/10001/test.txt",
+				},
+			},
 			IssueLinks: []struct {
 				ID       string `json:"id"`
 				LinkType struct {
@@ -146,6 +155,15 @@ func TestGetIssueWithoutDescription(t *testing.T) {
 			}{Name: "To Do"},
 			Created: "2020-12-03T14:05:20.974+0100",
 			Updated: "2020-12-03T14:05:20.974+0100",
+			Attachments: []Attachment{
+				{
+					ID:       "10001",
+					Filename: "test.txt",
+					Size:     1024,
+					Created:  "2020-12-03T14:05:20.974+0100",
+					Content:  "https://test.local/secure/attachment/10001/test.txt",
+				},
+			},
 		},
 	}
 	assert.Equal(t, expected, actual)
@@ -197,6 +215,15 @@ func TestGetIssueV2(t *testing.T) {
 			}{Name: "To Do"},
 			Created: "2020-12-03T14:05:20.974+0100",
 			Updated: "2020-12-03T14:05:20.974+0100",
+			Attachments: []Attachment{
+				{
+					ID:       "10001",
+					Filename: "test.txt",
+					Size:     1024,
+					Created:  "2020-12-03T14:05:20.974+0100",
+					Content:  "https://test.local/secure/attachment/10001/test.txt",
+				},
+			},
 		},
 	}
 	assert.Equal(t, expected, actual)
@@ -273,7 +300,16 @@ func TestGetIssueRaw(t *testing.T) {
     "watches": {
       "watchCount": 1,
       "isWatching": true
-    }
+    },
+    "attachment": [
+      {
+        "id": "10001",
+        "filename": "test.txt",
+        "size": 1024,
+        "created": "2020-12-03T14:05:20.974+0100",
+        "content": "https://test.local/secure/attachment/10001/test.txt"
+      }
+    ]
   }
 }
 `,
@@ -310,7 +346,16 @@ func TestGetIssueRaw(t *testing.T) {
     "watches": {
       "watchCount": 1,
       "isWatching": true
-    }
+    },
+    "attachment": [
+      {
+        "id": "10001",
+        "filename": "test.txt",
+        "size": 1024,
+        "created": "2020-12-03T14:05:20.974+0100",
+        "content": "https://test.local/secure/attachment/10001/test.txt"
+      }
+    ]
   }
 }
 `,
@@ -328,11 +373,8 @@ func TestGetIssueRaw(t *testing.T) {
 				}
 
 				w.Header().Set("Content-Type", "application/json")
-				_, err = w.Write(respContent)
-				if !assert.NoError(t, err) {
-					return
-				}
 				w.WriteHeader(http.StatusOK)
+				_, err = w.Write(respContent)
 			}))
 			defer server.Close()
 
@@ -744,4 +786,24 @@ func TestWatchIssue(t *testing.T) {
 
 	err = client.WatchIssueV2("TEST-1", "a12b3")
 	assert.Error(t, &ErrUnexpectedResponse{}, err)
+}
+
+func TestDownloadAttachment(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/secure/attachment/10001/test.txt", r.URL.Path)
+		assert.Equal(t, "no-check", r.Header.Get("X-Atlassian-Token"))
+
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte("attachment content"))
+	}))
+	defer server.Close()
+
+	client := NewClient(Config{Server: server.URL}, WithTimeout(3*time.Second))
+
+	actual, err := client.DownloadAttachment(server.URL + "/secure/attachment/10001/test.txt")
+	assert.NoError(t, err)
+
+	content, err := io.ReadAll(actual)
+	assert.NoError(t, err)
+	assert.Equal(t, "attachment content", string(content))
 }

--- a/pkg/jira/testdata/issue-1.json
+++ b/pkg/jira/testdata/issue-1.json
@@ -22,6 +22,15 @@
     "watches": {
       "watchCount": 1,
       "isWatching": true
-    }
+    },
+    "attachment": [
+      {
+        "id": "10001",
+        "filename": "test.txt",
+        "size": 1024,
+        "created": "2020-12-03T14:05:20.974+0100",
+        "content": "https://test.local/secure/attachment/10001/test.txt"
+      }
+    ]
   }
 }

--- a/pkg/jira/testdata/issue-2.json
+++ b/pkg/jira/testdata/issue-2.json
@@ -23,6 +23,15 @@
     "watches": {
       "watchCount": 1,
       "isWatching": true
-    }
+    },
+    "attachment": [
+      {
+        "id": "10001",
+        "filename": "test.txt",
+        "size": 1024,
+        "created": "2020-12-03T14:05:20.974+0100",
+        "content": "https://test.local/secure/attachment/10001/test.txt"
+      }
+    ]
   }
 }

--- a/pkg/jira/testdata/issue.json
+++ b/pkg/jira/testdata/issue.json
@@ -49,6 +49,15 @@
     "watches": {
       "watchCount": 1,
       "isWatching": true
-    }
+    },
+    "attachment": [
+      {
+        "id": "10001",
+        "filename": "test.txt",
+        "size": 1024,
+        "created": "2020-12-03T14:05:20.974+0100",
+        "content": "https://test.local/secure/attachment/10001/test.txt"
+      }
+    ]
   }
 }

--- a/pkg/jira/types.go
+++ b/pkg/jira/types.go
@@ -124,6 +124,18 @@ type IssueFields struct {
 	} `json:"issueLinks"`
 	Created string `json:"created"`
 	Updated string `json:"updated"`
+	Attachments []Attachment `json:"attachment"`
+}
+
+// Attachment holds attachment info.
+type Attachment struct {
+	ID       string `json:"id"`
+	Filename string `json:"filename"`
+	Author   User   `json:"author"`
+	Created  string `json:"created"`
+	Size     int    `json:"size"`
+	MimeType string `json:"mimeType"`
+	Content  string `json:"content"`
 }
 
 // Field holds field info.

--- a/pkg/jira/types.go
+++ b/pkg/jira/types.go
@@ -122,8 +122,8 @@ type IssueFields struct {
 		InwardIssue  *Issue `json:"inwardIssue,omitempty"`
 		OutwardIssue *Issue `json:"outwardIssue,omitempty"`
 	} `json:"issueLinks"`
-	Created string `json:"created"`
-	Updated string `json:"updated"`
+	Created     string       `json:"created"`
+	Updated     string       `json:"updated"`
 	Attachments []Attachment `json:"attachment"`
 }
 


### PR DESCRIPTION
## Summary
- adds `jira issue attachment` command with:
  - `list` to show issue attachments
  - `download` to fetch an attachment by filename
- shows attachment metadata in `jira issue view`
- adds Jira client support for downloading attachments

## Why
Maintainer indicated openness to PRs for this capability in Discussion #334:
- https://github.com/ankitpokhrel/jira-cli/discussions/334#discussioncomment-2419222

## Notes
- includes tests for the new attachment behavior
- includes a small line-ending normalization in one raw-response assertion to keep tests stable across LF/CRLF environments