### PR TITLE
fix(init): fall back to project issueTypes when createmeta is unavail…

### DIFF
--- a/internal/config/generator.go
+++ b/internal/config/generator.go
@@ -1,7 +1,9 @@
 package config
 
 import (
+	"errors"
 	"fmt"
+	"net/http"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -639,6 +641,17 @@ func (c *JiraCLIConfigGenerator) configureIssueTypes() error {
 		Expand:   "projects.issuetypes.fields",
 	})
 	if err != nil {
+		if code, ok := isCreateMetaFallbackEligible(err); ok {
+			cmdutil.Warn("Call to Metadata API endpoint is fialing; thus, using alternative API endpoint: project issue types (expand=issueTypes).")
+
+			its, ferr := c.jiraClient.ProjectIssueTypes(c.value.project.Key)
+			if ferr != nil {
+				return fmt.Errorf("failed to fetch issue types via fallback endpoint after createmeta returned %d: %w", code, ferr)
+			}
+
+			c.value.issueTypes = its
+			return nil
+		}
 		return err
 	}
 	if len(meta.Projects) == 0 || len(meta.Projects[0].IssueTypes) == 0 {
@@ -671,6 +684,17 @@ func (c *JiraCLIConfigGenerator) configureIssueTypesForJiraServerV9() error {
 		Expand:   "projects.issuetypes.fields",
 	})
 	if err != nil {
+		if code, ok := isCreateMetaFallbackEligible(err); ok {
+			cmdutil.Warn("Call to Metadata API endpoint is fialing; thus, using alternative API endpoint: project issue types (expand=issueTypes).")
+
+			its, ferr := c.jiraClient.ProjectIssueTypes(c.value.project.Key)
+			if ferr != nil {
+				return fmt.Errorf("failed to fetch issue types via fallback endpoint after createmeta returned %d: %w", code, ferr)
+			}
+
+			c.value.issueTypes = its
+			return nil
+		}
 		return err
 	}
 	if len(meta.Values) == 0 {
@@ -691,6 +715,19 @@ func (c *JiraCLIConfigGenerator) configureIssueTypesForJiraServerV9() error {
 	c.value.issueTypes = issueTypes
 
 	return nil
+}
+
+func isCreateMetaFallbackEligible(err error) (int, bool) {
+	var uerr *jira.ErrUnexpectedResponse
+	if !errors.As(err, &uerr) {
+		return 0, false
+	}
+	switch uerr.StatusCode {
+	case http.StatusNotFound, http.StatusForbidden, http.StatusUnauthorized:
+		return uerr.StatusCode, true
+	default:
+		return uerr.StatusCode, false
+	}
 }
 
 func (c *JiraCLIConfigGenerator) configureFields() error {

--- a/pkg/jira/project_issuetypes.go
+++ b/pkg/jira/project_issuetypes.go
@@ -1,0 +1,43 @@
+package jira
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+)
+
+type projectIssueTypesResponse struct {
+	IssueTypes []*IssueType `json:"issueTypes"`
+}
+
+// ProjectIssueTypes fetches issue types for a given project using
+// GET /rest/api/2/project/{projectKey}?expand=issueTypes.
+//
+// This endpoint does not provide create-screen field requirements (unlike createmeta),
+// but it can be used as a fallback when createmeta is not available.
+func (c *Client) ProjectIssueTypes(projectKey string) ([]*IssueType, error) {
+	path := fmt.Sprintf("/project/%s?expand=%s", url.PathEscape(projectKey), url.QueryEscape("issueTypes"))
+
+	res, err := c.GetV2(context.Background(), path, nil)
+	if err != nil {
+		return nil, err
+	}
+	if res == nil {
+		return nil, ErrEmptyResponse
+	}
+	defer func() { _ = res.Body.Close() }()
+
+	if res.StatusCode != http.StatusOK {
+		return nil, formatUnexpectedResponse(res)
+	}
+
+	var out projectIssueTypesResponse
+	if err := json.NewDecoder(res.Body).Decode(&out); err != nil {
+		return nil, err
+	}
+
+	return out.IssueTypes, nil
+}
+

--- a/pkg/jira/project_issuetypes.go
+++ b/pkg/jira/project_issuetypes.go
@@ -40,4 +40,3 @@ func (c *Client) ProjectIssueTypes(projectKey string) ([]*IssueType, error) {
 
 	return out.IssueTypes, nil
 }
-

--- a/pkg/jira/project_issuetypes_test.go
+++ b/pkg/jira/project_issuetypes_test.go
@@ -1,0 +1,52 @@
+package jira
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProjectIssueTypes(t *testing.T) {
+	var unexpectedStatusCode bool
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/rest/api/2/project/TEST", r.URL.Path)
+
+		qs := r.URL.Query()
+		if unexpectedStatusCode {
+			w.WriteHeader(401)
+			return
+		}
+
+		assert.Equal(t, url.Values{
+			"expand": []string{"issueTypes"},
+		}, qs)
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"issueTypes": [
+				{"id": "1", "name": "Task", "subtask": false},
+				{"id": "2", "name": "Sub-task", "subtask": true}
+			]
+		}`))
+	}))
+	defer server.Close()
+
+	client := NewClient(Config{Server: server.URL}, WithTimeout(3*time.Second))
+
+	actual, err := client.ProjectIssueTypes("TEST")
+	assert.NoError(t, err)
+	assert.Equal(t, []*IssueType{
+		{ID: "1", Name: "Task", Subtask: false},
+		{ID: "2", Name: "Sub-task", Subtask: true},
+	}, actual)
+
+	unexpectedStatusCode = true
+	_, err = client.ProjectIssueTypes("TEST")
+	assert.Error(t, &ErrUnexpectedResponse{}, err)
+}
+

--- a/pkg/jira/project_issuetypes_test.go
+++ b/pkg/jira/project_issuetypes_test.go
@@ -49,4 +49,3 @@ func TestProjectIssueTypes(t *testing.T) {
 	_, err = client.ProjectIssueTypes("TEST")
 	assert.Error(t, &ErrUnexpectedResponse{}, err)
 }
-


### PR DESCRIPTION
**Problem statement**

In some corporate Jira Data Center deployments, the Jira REST metadata endpoint GET /rest/api/2/issue/createmeta is restricted/disabled (commonly returning 401/403/404). Today jira init treats this call as mandatory, so init fails even though the instance is otherwise usable.

**What’s changing**

jira init now uses a fallback strategy for configuring issue types:

  • It still tries the existing metadata call (createmeta) first.
  • If that call fails with 401/403/404, it falls back to:
     • GET /rest/api/2/project/{projectKey}?expand=issueTypes
  • The response is used to populate issue.types in the generated config, allowing jira init to complete successfully.

A warning is printed to make it clear the metadata endpoint is failing and that the alternative endpoint is being used.

**Why this approach**

  • project?expand=issueTypes is commonly allowed in locked-down DC environments.
  • It provides enough information to populate issue.types for interactive flows (e.g. issue type selection) even when createmeta is blocked.
  • It avoids introducing new permissions requirements.

**Notes / limitations**

  • This fallback does not provide create-screen required-field metadata (which createmeta can provide). Jira will still enforce required fields at create time.

 **Test plan**

  • go test ./...