### PR TITLE
issue_994: Add optional role/group comment visibility via REST v3 and CLI flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -520,6 +520,10 @@ $ jira issue comment add ISSUE-1 "My comment body"
 # Same as above but as an internal comment
 $ jira issue comment add ISSUE-1 "My comment body" --internal
 
+# Restrict visibility to a project role or group (Jira REST API v3; mutually exclusive with --internal)
+$ jira issue comment add ISSUE-1 "Team note" --visibility-role Developers
+$ jira issue comment add ISSUE-1 "Team note" --visibility-group jira-developers
+
 # Load comment from template file
 $ jira issue comment add ISSUE-1 --template /path/to/template.tmpl
 
@@ -529,6 +533,9 @@ $ jira issue comment add ISSUE-1 --template -
 # Or, use pipe to read input directly from standard input
 $ echo "Comment from stdin" | jira issue comment add ISSUE-1
 ```
+
+> [!NOTE]
+> `--visibility-role` and `--visibility-group` use Jira REST API v3 with an ADF comment body derived from plain text (paragraphs split on blank lines; single newlines become line breaks). The default path still converts markdown to Jira wiki via REST API v2.
 
 > [!NOTE]
 > For the comment body, the positional argument always takes precedence over the `--template` flag if both of them are passed. In the

--- a/internal/cmd/issue/comment/add/add.go
+++ b/internal/cmd/issue/comment/add/add.go
@@ -34,6 +34,10 @@ $ jira issue comment add ISSUE-1 --template -
 # Or, use pipe to read input directly from standard input
 $ echo "Comment from stdin" | jira issue comment add ISSUE-1
 
+# Restrict visibility to a project role or group (REST API v3; mutually exclusive with --internal)
+$ jira issue comment add ISSUE-1 "Team note" --visibility-role Developers
+$ jira issue comment add ISSUE-1 "Team note" --visibility-group jira-developers
+
 # Positional argument takes precedence over the template flag
 # The example below will add "comment from arg" as a comment
 $ jira issue comment add ISSUE-1 "comment from arg" --template /path/to/template.tmpl`
@@ -57,6 +61,8 @@ func NewCmdCommentAdd() *cobra.Command {
 	cmd.Flags().StringP("template", "T", "", "Path to a file to read comment body from")
 	cmd.Flags().Bool("no-input", false, "Disable prompt for non-required fields")
 	cmd.Flags().Bool("internal", false, "Make comment internal")
+	cmd.Flags().String("visibility-role", "", "Restrict comment visibility to this project role (REST v3; mutually exclusive with --internal and --visibility-group)")
+	cmd.Flags().String("visibility-group", "", "Restrict comment visibility to this group (REST v3; mutually exclusive with --internal and --visibility-role)")
 
 	return &cmd
 }
@@ -103,7 +109,12 @@ func add(cmd *cobra.Command, args []string) {
 		s := cmdutil.Info("Adding comment")
 		defer s.Stop()
 
-		return client.AddIssueComment(ac.params.issueKey, ac.params.body, ac.params.internal)
+		opts := jira.IssueCommentOptions{
+			Internal:        ac.params.internal,
+			VisibilityRole:  ac.params.visibilityRole,
+			VisibilityGroup: ac.params.visibilityGroup,
+		}
+		return client.AddIssueCommentOpts(ac.params.issueKey, ac.params.body, opts)
 	}()
 	cmdutil.ExitIfError(err)
 
@@ -119,12 +130,14 @@ func add(cmd *cobra.Command, args []string) {
 }
 
 type addParams struct {
-	issueKey string
-	body     string
-	template string
-	noInput  bool
-	internal bool
-	debug    bool
+	issueKey        string
+	body            string
+	template        string
+	noInput         bool
+	internal        bool
+	visibilityRole  string
+	visibilityGroup string
+	debug           bool
 }
 
 func parseArgsAndFlags(args []string, flags query.FlagParser) *addParams {
@@ -150,13 +163,21 @@ func parseArgsAndFlags(args []string, flags query.FlagParser) *addParams {
 	internal, err := flags.GetBool("internal")
 	cmdutil.ExitIfError(err)
 
+	visibilityRole, err := flags.GetString("visibility-role")
+	cmdutil.ExitIfError(err)
+
+	visibilityGroup, err := flags.GetString("visibility-group")
+	cmdutil.ExitIfError(err)
+
 	return &addParams{
-		issueKey: issueKey,
-		body:     body,
-		template: template,
-		noInput:  noInput,
-		internal: internal,
-		debug:    debug,
+		issueKey:        issueKey,
+		body:            body,
+		template:        template,
+		noInput:         noInput,
+		internal:        internal,
+		visibilityRole:  visibilityRole,
+		visibilityGroup: visibilityGroup,
+		debug:           debug,
 	}
 }
 

--- a/pkg/jira/issue.go
+++ b/pkg/jira/issue.go
@@ -309,9 +309,135 @@ type issueCommentRequest struct {
 	Properties []issueCommentProperty `json:"properties"`
 }
 
+type commentVisibility struct {
+	Type  string `json:"type"`
+	Value string `json:"value"`
+}
+
+type issueCommentRequestV3 struct {
+	Body       *adf.ADF           `json:"body"`
+	Visibility *commentVisibility `json:"visibility,omitempty"`
+}
+
+// IssueCommentOptions configures AddIssueCommentOpts.
+type IssueCommentOptions struct {
+	Internal        bool
+	VisibilityRole  string
+	VisibilityGroup string
+}
+
+func (o IssueCommentOptions) visibility() *commentVisibility {
+	role := strings.TrimSpace(o.VisibilityRole)
+	group := strings.TrimSpace(o.VisibilityGroup)
+	switch {
+	case role != "":
+		return &commentVisibility{Type: "role", Value: role}
+	case group != "":
+		return &commentVisibility{Type: "group", Value: group}
+	default:
+		return nil
+	}
+}
+
+// Validate checks flag combinations for issue comments.
+func (o IssueCommentOptions) Validate() error {
+	role := strings.TrimSpace(o.VisibilityRole)
+	group := strings.TrimSpace(o.VisibilityGroup)
+	if role != "" && group != "" {
+		return fmt.Errorf("jira: visibility role and visibility group are mutually exclusive")
+	}
+	if o.Internal && (role != "" || group != "") {
+		return fmt.Errorf("jira: internal comments cannot be combined with role or group visibility")
+	}
+	return nil
+}
+
+// commentPlainToADF builds a minimal Atlassian Document body from plain text (paragraphs split on
+// blank lines; single newlines become hard breaks). Used for REST v3 comments when setting visibility.
+func commentPlainToADF(text string) *adf.ADF {
+	text = strings.ReplaceAll(text, "\r\n", "\n")
+	text = strings.TrimRight(text, "\n")
+	if text == "" {
+		return &adf.ADF{
+			Version: 1,
+			DocType: "doc",
+			Content: []*adf.Node{
+				{NodeType: adf.NodeParagraph, Content: []*adf.Node{}},
+			},
+		}
+	}
+	blocks := strings.Split(text, "\n\n")
+	var content []*adf.Node
+	for _, block := range blocks {
+		block = strings.TrimSpace(block)
+		if block == "" {
+			continue
+		}
+		lines := strings.Split(block, "\n")
+		inline := make([]*adf.Node, 0, len(lines)*2-1)
+		for i, line := range lines {
+			if i > 0 {
+				inline = append(inline, &adf.Node{NodeType: adf.InlineNodeHardBreak})
+			}
+			inline = append(inline, &adf.Node{
+				NodeType:  adf.ChildNodeText,
+				NodeValue: adf.NodeValue{Text: line},
+			})
+		}
+		content = append(content, &adf.Node{
+			NodeType: adf.NodeParagraph,
+			Content:  inline,
+		})
+	}
+	if len(content) == 0 {
+		content = []*adf.Node{{NodeType: adf.NodeParagraph, Content: []*adf.Node{}}}
+	}
+	return &adf.ADF{Version: 1, DocType: "doc", Content: content}
+}
+
 // AddIssueComment adds comment to an issue using POST /issue/{key}/comment endpoint.
 func (c *Client) AddIssueComment(key, comment string, internal bool) error {
-	body, err := json.Marshal(&issueCommentRequest{Body: md.ToJiraMD(comment), Properties: []issueCommentProperty{{Key: "sd.public.comment", Value: issueCommentPropertyValue{Internal: internal}}}})
+	return c.AddIssueCommentOpts(key, comment, IssueCommentOptions{Internal: internal})
+}
+
+// AddIssueCommentOpts adds a comment like AddIssueComment. When VisibilityRole or VisibilityGroup is set,
+// it uses REST API v3 with an ADF body and a visibility restriction (mutually exclusive with Internal).
+func (c *Client) AddIssueCommentOpts(key, comment string, opts IssueCommentOptions) error {
+	if err := opts.Validate(); err != nil {
+		return err
+	}
+
+	vis := opts.visibility()
+	if vis != nil {
+		req := issueCommentRequestV3{
+			Body:       commentPlainToADF(comment),
+			Visibility: vis,
+		}
+		body, err := json.Marshal(&req)
+		if err != nil {
+			return err
+		}
+
+		path := fmt.Sprintf("/issue/%s/comment", key)
+		res, err := c.Post(context.Background(), path, body, Header{
+			"Accept":       "application/json",
+			"Content-Type": "application/json",
+		})
+		if err != nil {
+			return err
+		}
+		if res == nil {
+			return ErrEmptyResponse
+		}
+		defer func() { _ = res.Body.Close() }()
+
+		if res.StatusCode != http.StatusCreated {
+			return formatUnexpectedResponse(res)
+		}
+		return nil
+	}
+
+	body, err := json.Marshal(&issueCommentRequest{Body: md.ToJiraMD(comment), Properties: []issueCommentProperty{{Key: "sd.public.comment", Value: issueCommentPropertyValue{Internal: opts.Internal}}}})
 	if err != nil {
 		return err
 	}

--- a/pkg/jira/issue_test.go
+++ b/pkg/jira/issue_test.go
@@ -554,6 +554,62 @@ func TestAddIssueComment(t *testing.T) {
 	assert.Error(t, &ErrUnexpectedResponse{}, err)
 }
 
+func TestIssueCommentOptions_Validate(t *testing.T) {
+	t.Parallel()
+
+	assert.NoError(t, (IssueCommentOptions{}).Validate())
+	assert.NoError(t, (IssueCommentOptions{Internal: true}).Validate())
+	assert.NoError(t, (IssueCommentOptions{VisibilityRole: "Developers"}).Validate())
+	assert.NoError(t, (IssueCommentOptions{VisibilityGroup: "jira-developers"}).Validate())
+
+	err := (IssueCommentOptions{Internal: true, VisibilityRole: "Developers"}).Validate()
+	assert.Error(t, err)
+
+	err = (IssueCommentOptions{VisibilityRole: "Developers", VisibilityGroup: "jira-developers"}).Validate()
+	assert.Error(t, err)
+}
+
+func TestAddIssueCommentOpts_visibilityUsesV3(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, "/rest/api/3/issue/TEST-1/comment", r.URL.Path)
+
+		actualBody := new(strings.Builder)
+		_, _ = io.Copy(actualBody, r.Body)
+
+		expectedBody := `{"body":{"version":1,"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"hello"}]}]},"visibility":{"type":"role","value":"Developers"}}`
+		assert.JSONEq(t, expectedBody, actualBody.String())
+
+		w.WriteHeader(201)
+	}))
+	defer server.Close()
+
+	client := NewClient(Config{Server: server.URL}, WithTimeout(3*time.Second))
+
+	err := client.AddIssueCommentOpts("TEST-1", "hello", IssueCommentOptions{VisibilityRole: "Developers"})
+	assert.NoError(t, err)
+}
+
+func TestAddIssueCommentOpts_visibilityGroupUsesV3(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/rest/api/3/issue/TEST-1/comment", r.URL.Path)
+
+		actualBody := new(strings.Builder)
+		_, _ = io.Copy(actualBody, r.Body)
+
+		expectedBody := `{"body":{"version":1,"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"x"}]}]},"visibility":{"type":"group","value":"jira-developers"}}`
+		assert.JSONEq(t, expectedBody, actualBody.String())
+
+		w.WriteHeader(201)
+	}))
+	defer server.Close()
+
+	client := NewClient(Config{Server: server.URL}, WithTimeout(3*time.Second))
+
+	err := client.AddIssueCommentOpts("TEST-1", "x", IssueCommentOptions{VisibilityGroup: "jira-developers"})
+	assert.NoError(t, err)
+}
+
 func TestAddIssueWorklog(t *testing.T) {
 	var unexpectedStatusCode bool
 


### PR DESCRIPTION
## Summary

Adds optional **`--visibility-role`** and **`--visibility-group`** flags to `jira issue comment add`. When either is set, the client uses Jira REST **v3** `POST /rest/api/3/issue/{issueIdOrKey}/comment` with a **`visibility`** object (`type` + `value` only) and a valid **v3** comment body.

When neither flag is set, behavior is **unchanged** (existing v2 flow, markdown handling, `--internal` / `sd.public.comment` unchanged).

Fixes #994.

## Behavior

| Case | Behavior |
|------|----------|
| No visibility flags | Same as today (REST v2, existing comment body handling). |
| `--visibility-role <name>` | v3 endpoint; `visibility`: `{ "type": "role", "value": "<name>" }`. |
| `--visibility-group <name>` | v3 endpoint; `visibility`: `{ "type": "group", "value": "<name>" }`. |

- **`--visibility-role` and `--visibility-group` are mutually exclusive** with each other.
- **`--internal` is mutually exclusive** with `--visibility-role` / `--visibility-group` (calling them together exits with a clear error; avoids ambiguous precedence).

## Notes

- Jira Cloud **`identifier` and `value` are mutually exclusive** in `visibility`; this PR uses only **`type` + `value`** for role/group visibility (matches Cloud behavior and avoids HTTP 400 from sending both).

## Testing

- [ ] Manual: add comment without flags → unchanged.
- [ ] Manual: `--visibility-role` / `--visibility-group` → comment restricted as expected on Jira Cloud.
- [ ] Error paths: conflicting flags rejected with readable message.

---

Refs: [Add comment (v3)](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-comments/#api-rest-api-3-issue-issueidorkey-comment-post)