### PR TITLE
fix(comment): move markdown conversion to command layer, add --raw flag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,5 @@
 on:
+  workflow_dispatch:
   pull_request:
     types: [opened, synchronize, reopened]
   release:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,7 +2,6 @@ name: Publish a Docker image
 run-name: Docker image for ${{ github.ref_name }}
 
 on:
-  workflow_dispatch:
   release:
     types: [published, prereleased]
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,65 @@
+name: Release
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  release:
+    name: Semantic Release
+    runs-on: ubuntu-latest
+    outputs:
+      new_release_published: ${{ steps.semantic.outputs.new_release_published }}
+      new_release_version: ${{ steps.semantic.outputs.new_release_version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Semantic Release
+        id: semantic
+        uses: cycjimmy/semantic-release-action@v4
+        with:
+          extra_plugins: |
+            @semantic-release/changelog
+            @semantic-release/git
+            conventional-changelog-conventionalcommits
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  goreleaser:
+    name: Build & Upload Binaries
+    needs: release
+    if: needs.release.outputs.new_release_published == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: v${{ needs.release.outputs.new_release_version }}
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '^1.25.6'
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          version: '~> v2'
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: v${{ needs.release.outputs.new_release_version }}
+          ref: ${{ needs.release.outputs.new_release_version }}
 
       - name: Setup Go
         uses: actions/setup-go@v5

--- a/.github/workflows/upstream-watch.yml
+++ b/.github/workflows/upstream-watch.yml
@@ -1,0 +1,126 @@
+name: Upstream Watch
+
+on:
+  schedule:
+    - cron: '0 7 * * *'  # daily at 07:00 UTC
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  issues: write
+
+env:
+  UPSTREAM: ankitpokhrel/jira-cli
+
+jobs:
+  check:
+    name: Check upstream activity
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Add upstream remote
+        run: |
+          git remote add upstream "https://github.com/${{ env.UPSTREAM }}.git"
+          git fetch upstream main --tags --quiet
+
+      - name: Detect new commits
+        id: commits
+        run: |
+          BASE=$(git merge-base HEAD upstream/main 2>/dev/null || echo "")
+          UPSTREAM_HEAD=$(git rev-parse upstream/main)
+
+          if [ -z "$BASE" ]; then
+            echo "count=unknown" >> "$GITHUB_OUTPUT"
+            echo "summary=Could not determine merge-base" >> "$GITHUB_OUTPUT"
+          elif [ "$BASE" = "$UPSTREAM_HEAD" ]; then
+            echo "count=0" >> "$GITHUB_OUTPUT"
+            echo "summary=Up to date with upstream" >> "$GITHUB_OUTPUT"
+          else
+            COUNT=$(git rev-list --count "$BASE".."$UPSTREAM_HEAD")
+            LOG=$(git log --oneline "$BASE".."$UPSTREAM_HEAD" | head -20)
+            echo "count=$COUNT" >> "$GITHUB_OUTPUT"
+
+            # write multi-line log to output
+            {
+              echo "log<<LOGEOF"
+              echo "$LOG"
+              echo "LOGEOF"
+            } >> "$GITHUB_OUTPUT"
+            echo "summary=$COUNT new commit(s) on upstream main" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Detect new releases
+        id: releases
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # get latest upstream release tag
+          LATEST=$(gh api "repos/${{ env.UPSTREAM }}/releases/latest" --jq '.tag_name' 2>/dev/null || echo "")
+
+          if [ -z "$LATEST" ]; then
+            echo "new=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # check if we have this tag as an ancestor
+          if git merge-base --is-ancestor "$LATEST" HEAD 2>/dev/null; then
+            echo "new=false" >> "$GITHUB_OUTPUT"
+          else
+            RELEASE_DATE=$(gh api "repos/${{ env.UPSTREAM }}/releases/latest" --jq '.published_at')
+            echo "new=true" >> "$GITHUB_OUTPUT"
+            echo "tag=$LATEST" >> "$GITHUB_OUTPUT"
+            echo "date=$RELEASE_DATE" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create or update tracking issue
+        if: steps.commits.outputs.count != '0' || steps.releases.outputs.new == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TITLE="upstream: new activity detected"
+          LABEL="upstream-watch"
+
+          # ensure label exists
+          gh label create "$LABEL" --description "Automated upstream tracking" --color "0E8A16" 2>/dev/null || true
+
+          # build issue body
+          BODY="## Upstream Activity Report
+
+          **Checked**: $(date -u '+%Y-%m-%d %H:%M UTC')
+          **Upstream**: [${{ env.UPSTREAM }}](https://github.com/${{ env.UPSTREAM }})
+
+          ### Commits
+          ${{ steps.commits.outputs.summary }}
+          "
+
+          if [ "${{ steps.commits.outputs.count }}" != "0" ] && [ "${{ steps.commits.outputs.count }}" != "unknown" ]; then
+            BODY="$BODY
+          \`\`\`
+          ${{ steps.commits.outputs.log }}
+          \`\`\`
+          "
+          fi
+
+          if [ "${{ steps.releases.outputs.new }}" = "true" ]; then
+            BODY="$BODY
+          ### New Release
+          **${{ steps.releases.outputs.tag }}** (published ${{ steps.releases.outputs.date }})
+          https://github.com/${{ env.UPSTREAM }}/releases/tag/${{ steps.releases.outputs.tag }}
+          "
+          fi
+
+          BODY="$BODY
+          ---
+          *Close this issue after syncing. A new one will be created on next detection.*"
+
+          # close any existing open issue with the label, then create fresh
+          EXISTING=$(gh issue list --label "$LABEL" --state open --json number --jq '.[0].number' 2>/dev/null || echo "")
+          if [ -n "$EXISTING" ]; then
+            gh issue close "$EXISTING" --comment "Superseded by new check."
+          fi
+
+          gh issue create --title "$TITLE" --body "$BODY" --label "$LABEL"

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.out
 *.swp
 /*.json
+!.releaserc.json
 
 .DS_Store
 .idea/

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ vendor/
 /.gocache
 
 .vscode/
+.playwright-mcp/
+.sisyphus/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,7 +5,7 @@ release:
   prerelease: auto
   name_template: "v{{.Version}}"
   draft: false
-  mode: "keep-existing"
+  mode: "append"
 
 before:
   hooks:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -4,7 +4,7 @@ project_name: jira
 release:
   prerelease: auto
   name_template: "v{{.Version}}"
-  draft: true
+  draft: false
   mode: "keep-existing"
 
 before:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,7 +3,7 @@ project_name: jira
 
 release:
   prerelease: auto
-  name_template: "v{{.Version}}"
+  name_template: "{{.Version}}"
   draft: false
   mode: "append"
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -13,7 +13,7 @@ before:
 
 builds:
   - <<: &build_defaults
-      binary: bin/jira
+      binary: jira
       main: ./cmd/jira
       ldflags:
         - -s -w
@@ -42,7 +42,7 @@ archives:
     <<: &archive_defaults
       name_template: >-
         {{ .ProjectName }}_{{ .Version }}_{{- if eq .Os "darwin" }}macOS{{- else }}{{ .Os }}{{- end }}_{{- if eq .Arch "amd64" }}x86_64{{- else if eq .Arch "386" }}i386{{- else }}{{ .Arch }}{{- end }}{{- if .Arm }}v{{ .Arm }}{{ end -}}
-    wrap_in_directory: true
+    wrap_in_directory: false
     formats: [tar.gz]
     files:
       - LICENSE

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,4 +1,5 @@
 {
+  "tagFormat": "${version}",
   "branches": ["main"],
   "plugins": [
     ["@semantic-release/commit-analyzer", {

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,52 @@
+{
+  "branches": ["main"],
+  "plugins": [
+    ["@semantic-release/commit-analyzer", {
+      "preset": "conventionalcommits",
+      "releaseRules": [
+        { "breaking": true, "release": "major" },
+        { "type": "break", "release": "major" },
+        { "type": "feat", "release": "minor" },
+        { "type": "fix", "release": "patch" },
+        { "type": "perf", "release": "patch" },
+        { "type": "revert", "release": "patch" },
+        { "type": "deps", "release": "patch" },
+        { "type": "refactor", "release": false },
+        { "type": "style", "release": false },
+        { "type": "docs", "release": false },
+        { "type": "build", "release": false },
+        { "type": "ci", "release": false },
+        { "type": "test", "release": false },
+        { "type": "chore", "release": false }
+      ]
+    }],
+    ["@semantic-release/release-notes-generator", {
+      "preset": "conventionalcommits",
+      "presetConfig": {
+        "types": [
+          { "type": "feat", "section": "Features" },
+          { "type": "fix", "section": "Bug Fixes" },
+          { "type": "perf", "section": "Performance" },
+          { "type": "revert", "section": "Reverts" },
+          { "type": "deps", "section": "Dependencies" },
+          { "type": "break", "section": "Breaking Changes" },
+          { "type": "refactor", "section": "Code Refactoring", "hidden": true },
+          { "type": "style", "section": "Styles", "hidden": true },
+          { "type": "docs", "section": "Documentation", "hidden": true },
+          { "type": "build", "section": "Build System", "hidden": true },
+          { "type": "ci", "section": "CI", "hidden": true },
+          { "type": "test", "section": "Tests", "hidden": true },
+          { "type": "chore", "section": "Miscellaneous", "hidden": true }
+        ]
+      }
+    }],
+    ["@semantic-release/changelog", {
+      "changelogFile": "CHANGELOG.md"
+    }],
+    "@semantic-release/github",
+    ["@semantic-release/git", {
+      "assets": ["CHANGELOG.md"],
+      "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+    }]
+  ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+## [1.6.0](https://github.com/hackerh3/jira-cli/releases/tag/v1.6.0) (2026-05-11)
+
+### Features
+
+* **jira:** add move-project command for moving issues between projects ([e4b8e97](https://github.com/hackerh3/jira-cli/commit/e4b8e97))
+* **jira:** add move-project API via JSP form wizard ([53dd911](https://github.com/hackerh3/jira-cli/commit/53dd911))
+* **jira:** add JSP session client with cookie jar ([70713a3](https://github.com/hackerh3/jira-cli/commit/70713a3))
+* **api:** add GetIssueComment and UpdateIssueComment ([71f6b5a](https://github.com/hackerh3/jira-cli/commit/71f6b5a))
+* **cmd:** add comment edit subcommand ([e27710d](https://github.com/hackerh3/jira-cli/commit/e27710d))
+
+### Bug Fixes
+
+* **jira:** detect broken workflow and suggest move-project workaround ([8b17182](https://github.com/hackerh3/jira-cli/commit/8b17182))
+* **jira:** confirm step needs confirm=true + smart key extraction ([e28a8b8](https://github.com/hackerh3/jira-cli/commit/e28a8b8))
+* resolve golangci-lint failures in move-project code ([0ec114d](https://github.com/hackerh3/jira-cli/commit/0ec114d))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
-## [1.6.0](https://github.com/hackerh3/jira-cli/releases/tag/v1.6.0) (2026-05-11)
+All notable changes to the hackerh3/jira-cli fork are documented here.
+This fork uses versionless tags (e.g. `1.8.0`) to distinguish from upstream `v1.x.0`.
+
+## [1.8.0](https://github.com/hackerh3/jira-cli/releases/tag/1.8.0) (2026-05-12)
+
+First release under the new versioning scheme. Incorporates all upstream
+changes through v1.7.0 plus fork-exclusive features.
 
 ### Features
 
@@ -9,9 +15,17 @@
 * **jira:** add JSP session client with cookie jar ([70713a3](https://github.com/hackerh3/jira-cli/commit/70713a3))
 * **api:** add GetIssueComment and UpdateIssueComment ([71f6b5a](https://github.com/hackerh3/jira-cli/commit/71f6b5a))
 * **cmd:** add comment edit subcommand ([e27710d](https://github.com/hackerh3/jira-cli/commit/e27710d))
+* **jira:** add Deviniti Issue Template support for issue creation ([d1a9bd2](https://github.com/hackerh3/jira-cli/commit/d1a9bd2))
 
 ### Bug Fixes
 
 * **jira:** detect broken workflow and suggest move-project workaround ([8b17182](https://github.com/hackerh3/jira-cli/commit/8b17182))
 * **jira:** confirm step needs confirm=true + smart key extraction ([e28a8b8](https://github.com/hackerh3/jira-cli/commit/e28a8b8))
 * resolve golangci-lint failures in move-project code ([0ec114d](https://github.com/hackerh3/jira-cli/commit/0ec114d))
+* add plain output for project list ([e58dbc4](https://github.com/hackerh3/jira-cli/commit/e58dbc4))
+* preserve raw JQL ordering ([3061f88](https://github.com/hackerh3/jira-cli/commit/3061f88))
+
+### CI/CD
+
+* semantic-release pipeline with goreleaser cross-compilation
+* versionless tag format (`1.x.0`) to avoid upstream collision

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.8.1](https://github.com/hackerh3/jira-cli/compare/1.8.0...1.8.1) (2026-05-12)
+
+### Bug Fixes
+
+* **ci:** flatten archive layout and build all platforms ([5cf0eca](https://github.com/hackerh3/jira-cli/commit/5cf0ecab63fc9b70358ae0f7c99bd4b9d6eac2a2))
+
 # Changelog
 
 All notable changes to the hackerh3/jira-cli fork are documented here.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 <div align="center">
-    <a href="#">
-        <img alt="stargazers over time" src="https://stars.medv.io/ankitpokhrel/jira-cli.svg" />
-    </a>
-    <h1 align="center">JiraCLI</h1>
+    <h1 align="center">JiraCLI (hackerh3 fork)</h1>
 </div>
+
+> **Fork notice** — This is a maintained fork of [ankitpokhrel/jira-cli](https://github.com/ankitpokhrel/jira-cli).
+> It adds move-project, comment editing, Deviniti template support, and broken-workflow detection.
+> Releases use versionless tags (`1.8.0`) to avoid collision with upstream (`v1.8.0`).
+> Install from **this repo's** [releases page](https://github.com/hackerh3/jira-cli/releases).
 
 <div>
     <p align="center">
@@ -69,19 +71,19 @@ nature of the data. Yet, we've attempted to make the experience as similar as po
 | **Jira**  | <a href="#"><img alt="Jira Cloud" src="https://img.shields.io/badge/Jira Cloud-%E2%9C%93-dark--green?logo=jira&style=flat-square" /></a><a href="#"><img alt="Jira Server" src="https://img.shields.io/badge/Jira Server-%E2%9C%93-dark--green?logo=jira&style=flat-square" /></a> |
 
 ## Installation
-`jira-cli` is available as a downloadable packaged binary for Linux, macOS, and Windows from the [releases page](https://github.com/ankitpokhrel/jira-cli/releases).
+`jira-cli` is available as a downloadable binary for Linux, macOS, and Windows from the [releases page](https://github.com/hackerh3/jira-cli/releases).
 
-You can use Docker to quickly try out `jira-cli`.
+> [!WARNING]
+> Do **not** install via `brew install jira-cli` or the upstream releases page — those ship the
+> upstream binary without fork features. Use the link above or `go install` from this repo.
+
+You can also build from source:
 
 ```sh
-docker run -it --rm ghcr.io/ankitpokhrel/jira-cli:latest
+# Build from this fork
+git clone https://github.com/hackerh3/jira-cli.git && cd jira-cli
+make deps install
 ```
-
-Follow the [installation guide](https://github.com/ankitpokhrel/jira-cli/wiki/Installation) for other installation methods like `Homebrew`, `Nix`, etc.
-
-<a href="https://repology.org/project/jira-cli-go/versions">
-    <img src="https://repology.org/badge/vertical-allrepos/jira-cli-go.svg" alt="Packaging status">
-</a>
 
 ## Getting started
 
@@ -807,7 +809,7 @@ Please [open a discussion](https://github.com/ankitpokhrel/jira-cli/discussions/
 ## Development
 1. Clone the repo.
    ```sh
-   git clone git@github.com:ankitpokhrel/jira-cli.git
+   git clone git@github.com:hackerh3/jira-cli.git
    ```
 
 2. Optional: If you want to run a Jira instance locally, you can use the following make recipe.

--- a/internal/cmd/issue/comment/add/add.go
+++ b/internal/cmd/issue/comment/add/add.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ankitpokhrel/jira-cli/internal/cmdutil"
 	"github.com/ankitpokhrel/jira-cli/internal/query"
 	"github.com/ankitpokhrel/jira-cli/pkg/jira"
+	"github.com/ankitpokhrel/jira-cli/pkg/md"
 	"github.com/ankitpokhrel/jira-cli/pkg/surveyext"
 )
 
@@ -57,6 +58,7 @@ func NewCmdCommentAdd() *cobra.Command {
 	cmd.Flags().StringP("template", "T", "", "Path to a file to read comment body from")
 	cmd.Flags().Bool("no-input", false, "Disable prompt for non-required fields")
 	cmd.Flags().Bool("internal", false, "Make comment internal")
+	cmd.Flags().Bool("raw", false, "Pass comment body as raw Jira wiki markup")
 
 	return &cmd
 }
@@ -99,11 +101,16 @@ func add(cmd *cobra.Command, args []string) {
 		}
 	}
 
+	body := params.body
+	if !params.raw {
+		body = md.ToJiraMD(body)
+	}
+
 	err := func() error {
 		s := cmdutil.Info("Adding comment")
 		defer s.Stop()
 
-		return client.AddIssueComment(ac.params.issueKey, ac.params.body, ac.params.internal)
+		return client.AddIssueComment(ac.params.issueKey, body, ac.params.internal)
 	}()
 	cmdutil.ExitIfError(err)
 
@@ -124,6 +131,7 @@ type addParams struct {
 	template string
 	noInput  bool
 	internal bool
+	raw      bool
 	debug    bool
 }
 
@@ -150,12 +158,16 @@ func parseArgsAndFlags(args []string, flags query.FlagParser) *addParams {
 	internal, err := flags.GetBool("internal")
 	cmdutil.ExitIfError(err)
 
+	raw, err := flags.GetBool("raw")
+	cmdutil.ExitIfError(err)
+
 	return &addParams{
 		issueKey: issueKey,
 		body:     body,
 		template: template,
 		noInput:  noInput,
 		internal: internal,
+		raw:      raw,
 		debug:    debug,
 	}
 }

--- a/internal/cmd/issue/comment/add/add_test.go
+++ b/internal/cmd/issue/comment/add/add_test.go
@@ -1,0 +1,52 @@
+package add
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type testFlagParser struct {
+	bools   map[string]bool
+	strings map[string]string
+}
+
+func (tfp *testFlagParser) GetBool(name string) (bool, error) {
+	return tfp.bools[name], nil
+}
+
+func (tfp *testFlagParser) GetString(name string) (string, error) {
+	return tfp.strings[name], nil
+}
+
+func (*testFlagParser) GetStringArray(string) ([]string, error) { return nil, nil }
+func (*testFlagParser) GetStringToString(string) (map[string]string, error) {
+	return nil, nil
+}
+func (*testFlagParser) GetUint(string) (uint, error) { return 0, nil }
+func (*testFlagParser) Set(string, string) error     { return nil }
+
+func TestParseArgsAndFlags(t *testing.T) {
+	params := parseArgsAndFlags(
+		[]string{"ISSUE-1", "comment body"},
+		&testFlagParser{
+			bools: map[string]bool{
+				"debug":    true,
+				"no-input": true,
+				"internal": true,
+				"raw":      true,
+			},
+			strings: map[string]string{
+				"template": "comment.tmpl",
+			},
+		},
+	)
+
+	assert.Equal(t, "ISSUE-1", params.issueKey)
+	assert.Equal(t, "comment body", params.body)
+	assert.Equal(t, "comment.tmpl", params.template)
+	assert.True(t, params.noInput)
+	assert.True(t, params.internal)
+	assert.True(t, params.raw)
+	assert.True(t, params.debug)
+}

--- a/internal/cmd/issue/comment/comment.go
+++ b/internal/cmd/issue/comment/comment.go
@@ -4,6 +4,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/ankitpokhrel/jira-cli/internal/cmd/issue/comment/add"
+	"github.com/ankitpokhrel/jira-cli/internal/cmd/issue/comment/edit"
 )
 
 const helpText = `Comment command helps you manage issue comments. See available commands below.`
@@ -19,6 +20,7 @@ func NewCmdComment() *cobra.Command {
 	}
 
 	cmd.AddCommand(add.NewCmdCommentAdd())
+	cmd.AddCommand(edit.NewCmdCommentEdit())
 
 	return &cmd
 }

--- a/internal/cmd/issue/comment/edit/edit.go
+++ b/internal/cmd/issue/comment/edit/edit.go
@@ -30,9 +30,9 @@ $ jira issue comment edit ISSUE-1 10042 --internal --no-input`
 // NewCmdCommentEdit is a comment edit command.
 func NewCmdCommentEdit() *cobra.Command {
 	cmd := cobra.Command{
-		Use:   "edit ISSUE-KEY COMMENT-ID",
-		Short: "Edit a comment on an issue",
-		Long:  helpText,
+		Use:     "edit ISSUE-KEY COMMENT-ID",
+		Short:   "Edit a comment on an issue",
+		Long:    helpText,
 		Example: examples,
 		Annotations: map[string]string{
 			"help:args": "ISSUE-KEY\tIssue key of the issue, eg: ISSUE-1\n" +

--- a/internal/cmd/issue/comment/edit/edit.go
+++ b/internal/cmd/issue/comment/edit/edit.go
@@ -1,0 +1,207 @@
+package edit
+
+import (
+	"fmt"
+
+	"github.com/AlecAivazis/survey/v2"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/ankitpokhrel/jira-cli/api"
+	"github.com/ankitpokhrel/jira-cli/internal/cmdcommon"
+	"github.com/ankitpokhrel/jira-cli/internal/cmdutil"
+	"github.com/ankitpokhrel/jira-cli/internal/query"
+	"github.com/ankitpokhrel/jira-cli/pkg/jira"
+	"github.com/ankitpokhrel/jira-cli/pkg/md"
+	"github.com/ankitpokhrel/jira-cli/pkg/surveyext"
+)
+
+const (
+	helpText = `Edit an existing comment on an issue.`
+	examples = `$ jira issue comment edit ISSUE-1 10042
+
+# Edit with inline body (non-interactive)
+$ jira issue comment edit ISSUE-1 10042 -b "Updated text" --no-input
+
+# Mark comment as internal
+$ jira issue comment edit ISSUE-1 10042 --internal --no-input`
+)
+
+// NewCmdCommentEdit is a comment edit command.
+func NewCmdCommentEdit() *cobra.Command {
+	cmd := cobra.Command{
+		Use:   "edit ISSUE-KEY COMMENT-ID",
+		Short: "Edit a comment on an issue",
+		Long:  helpText,
+		Example: examples,
+		Annotations: map[string]string{
+			"help:args": "ISSUE-KEY\tIssue key of the issue, eg: ISSUE-1\n" +
+				"COMMENT-ID\tNumeric ID of the comment to edit",
+		},
+		Args: cobra.MinimumNArgs(2),
+		Run:  edit,
+	}
+
+	cmd.Flags().StringP("body", "b", "", "Edit comment body")
+	cmd.Flags().Bool("no-input", false, "Disable prompt for non-required fields")
+	cmd.Flags().Bool("internal", false, "Mark comment as internal")
+
+	return &cmd
+}
+
+func edit(cmd *cobra.Command, args []string) {
+	params := parseArgsAndFlags(args, cmd.Flags())
+	client := api.DefaultClient(params.debug)
+	ec := editCmd{
+		client: client,
+		params: params,
+	}
+
+	if ec.isNonInteractive() {
+		ec.params.noInput = true
+	}
+
+	// Always fetch existing comment: validates the ID and provides pre-fill body.
+	existing, err := func() (*jira.IssueComment, error) {
+		s := cmdutil.Info(fmt.Sprintf("Fetching comment %s...", params.commentID))
+		defer s.Stop()
+
+		return client.GetIssueComment(params.issueKey, params.commentID)
+	}()
+	cmdutil.ExitIfError(err)
+
+	originalBody := md.FromJiraMD(existing.Body)
+
+	// In non-interactive mode without an explicit body, keep the existing body.
+	// This allows changing only the --internal flag without editing text.
+	if params.noInput && params.body == "" {
+		params.body = originalBody
+	}
+
+	qs := ec.getQuestions(originalBody)
+	if len(qs) > 0 {
+		ans := struct{ Body string }{}
+		err := survey.Ask(qs, &ans)
+		cmdutil.ExitIfError(err)
+
+		params.body = ans.Body
+	}
+
+	// In interactive mode, skip the PUT if the body was not changed.
+	if !params.noInput && params.body == originalBody {
+		cmdutil.Warn("No changes detected, comment was not updated")
+		return
+	}
+
+	if !params.noInput {
+		answer := struct{ Action string }{}
+		err := survey.Ask([]*survey.Question{getNextAction()}, &answer)
+		cmdutil.ExitIfError(err)
+
+		if answer.Action == cmdcommon.ActionCancel {
+			cmdutil.Failed("Action aborted")
+		}
+	}
+
+	err = func() error {
+		s := cmdutil.Info("Updating comment")
+		defer s.Stop()
+
+		return client.UpdateIssueComment(ec.params.issueKey, ec.params.commentID, ec.params.body, ec.params.internal)
+	}()
+	cmdutil.ExitIfError(err)
+
+	server := viper.GetString("server")
+
+	cmdutil.Success("Comment updated on issue %q", ec.params.issueKey)
+	fmt.Printf("%s\n", cmdutil.GenerateServerBrowseURL(server, ec.params.issueKey))
+}
+
+type editParams struct {
+	issueKey  string
+	commentID string
+	body      string
+	noInput   bool
+	internal  bool
+	debug     bool
+}
+
+func parseArgsAndFlags(args []string, flags query.FlagParser) *editParams {
+	var issueKey, commentID string
+
+	nargs := len(args)
+	if nargs >= 1 {
+		issueKey = cmdutil.GetJiraIssueKey(viper.GetString("project.key"), args[0])
+	}
+	if nargs >= 2 {
+		commentID = args[1]
+	}
+
+	debug, err := flags.GetBool("debug")
+	cmdutil.ExitIfError(err)
+
+	body, err := flags.GetString("body")
+	cmdutil.ExitIfError(err)
+
+	noInput, err := flags.GetBool("no-input")
+	cmdutil.ExitIfError(err)
+
+	internal, err := flags.GetBool("internal")
+	cmdutil.ExitIfError(err)
+
+	return &editParams{
+		issueKey:  issueKey,
+		commentID: commentID,
+		body:      body,
+		noInput:   noInput,
+		internal:  internal,
+		debug:     debug,
+	}
+}
+
+type editCmd struct {
+	client *jira.Client
+	params *editParams
+}
+
+func (ec *editCmd) getQuestions(originalBody string) []*survey.Question {
+	var qs []*survey.Question
+
+	// Skip editor if noInput is set or body was already provided via flag.
+	if ec.params.noInput || ec.params.body != "" {
+		return qs
+	}
+
+	qs = append(qs, &survey.Question{
+		Name: "body",
+		Prompt: &surveyext.JiraEditor{
+			Editor: &survey.Editor{
+				Message:       "Comment body",
+				Default:       originalBody,
+				HideDefault:   true,
+				AppendDefault: true,
+			},
+			BlankAllowed: false,
+		},
+	})
+
+	return qs
+}
+
+func getNextAction() *survey.Question {
+	return &survey.Question{
+		Name: "action",
+		Prompt: &survey.Select{
+			Message: "What's next?",
+			Options: []string{
+				cmdcommon.ActionSubmit,
+				cmdcommon.ActionCancel,
+			},
+		},
+		Validate: survey.Required,
+	}
+}
+
+func (ec *editCmd) isNonInteractive() bool {
+	return ec.params.noInput
+}

--- a/internal/cmd/issue/comment/edit/edit.go
+++ b/internal/cmd/issue/comment/edit/edit.go
@@ -45,6 +45,7 @@ func NewCmdCommentEdit() *cobra.Command {
 	cmd.Flags().StringP("body", "b", "", "Edit comment body")
 	cmd.Flags().Bool("no-input", false, "Disable prompt for non-required fields")
 	cmd.Flags().Bool("internal", false, "Mark comment as internal")
+	cmd.Flags().Bool("raw", false, "Pass comment body as raw Jira wiki markup")
 
 	return &cmd
 }
@@ -103,11 +104,16 @@ func edit(cmd *cobra.Command, args []string) {
 		}
 	}
 
+	body := ec.params.body
+	if !ec.params.raw {
+		body = md.ToJiraMD(body)
+	}
+
 	err = func() error {
 		s := cmdutil.Info("Updating comment")
 		defer s.Stop()
 
-		return client.UpdateIssueComment(ec.params.issueKey, ec.params.commentID, ec.params.body, ec.params.internal)
+		return client.UpdateIssueComment(ec.params.issueKey, ec.params.commentID, body, ec.params.internal)
 	}()
 	cmdutil.ExitIfError(err)
 
@@ -123,6 +129,7 @@ type editParams struct {
 	body      string
 	noInput   bool
 	internal  bool
+	raw       bool
 	debug     bool
 }
 
@@ -149,12 +156,16 @@ func parseArgsAndFlags(args []string, flags query.FlagParser) *editParams {
 	internal, err := flags.GetBool("internal")
 	cmdutil.ExitIfError(err)
 
+	raw, err := flags.GetBool("raw")
+	cmdutil.ExitIfError(err)
+
 	return &editParams{
 		issueKey:  issueKey,
 		commentID: commentID,
 		body:      body,
 		noInput:   noInput,
 		internal:  internal,
+		raw:       raw,
 		debug:     debug,
 	}
 }

--- a/internal/cmd/issue/comment/edit/edit_test.go
+++ b/internal/cmd/issue/comment/edit/edit_test.go
@@ -1,0 +1,52 @@
+package edit
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type testFlagParser struct {
+	bools   map[string]bool
+	strings map[string]string
+}
+
+func (tfp *testFlagParser) GetBool(name string) (bool, error) {
+	return tfp.bools[name], nil
+}
+
+func (tfp *testFlagParser) GetString(name string) (string, error) {
+	return tfp.strings[name], nil
+}
+
+func (*testFlagParser) GetStringArray(string) ([]string, error) { return nil, nil }
+func (*testFlagParser) GetStringToString(string) (map[string]string, error) {
+	return nil, nil
+}
+func (*testFlagParser) GetUint(string) (uint, error) { return 0, nil }
+func (*testFlagParser) Set(string, string) error     { return nil }
+
+func TestParseArgsAndFlags(t *testing.T) {
+	params := parseArgsAndFlags(
+		[]string{"ISSUE-1", "10042"},
+		&testFlagParser{
+			bools: map[string]bool{
+				"debug":    true,
+				"no-input": true,
+				"internal": true,
+				"raw":      true,
+			},
+			strings: map[string]string{
+				"body": "updated body",
+			},
+		},
+	)
+
+	assert.Equal(t, "ISSUE-1", params.issueKey)
+	assert.Equal(t, "10042", params.commentID)
+	assert.Equal(t, "updated body", params.body)
+	assert.True(t, params.noInput)
+	assert.True(t, params.internal)
+	assert.True(t, params.raw)
+	assert.True(t, params.debug)
+}

--- a/internal/cmd/issue/create/create.go
+++ b/internal/cmd/issue/create/create.go
@@ -3,6 +3,7 @@ package create
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/spf13/cobra"
@@ -36,6 +37,9 @@ $ jira issue create --template /path/to/template.tmpl
 
 # Get description from standard input
 $ jira issue create --template -
+
+	# Create issue from a Deviniti Issue Template
+	$ jira issue create --jira-template 14866 --template-var TITLE="My Task" -tStory --no-input
 
 # Create issue in the configured project with JSON output
 $ jira issue create --raw
@@ -78,6 +82,16 @@ func create(cmd *cobra.Command, _ []string) {
 
 	params := parseFlags(cmd.Flags())
 	client := api.DefaultClient(params.Debug)
+	if params.JiraTemplate != "" {
+		if params.IssueType == "" {
+			cmdutil.Failed("Param `--type` is mandatory when using `--jira-template`")
+		}
+		s := cmdutil.Info("Fetching template...")
+		err := applyIssueTemplate(client, project, params)
+		s.Stop()
+		cmdutil.ExitIfError(err)
+	}
+
 	cc := createCmd{
 		client: client,
 		params: params,
@@ -108,12 +122,17 @@ func create(cmd *cobra.Command, _ []string) {
 		s := cmdutil.Info("Creating an issue...")
 		defer s.Stop()
 
+		var body any = params.Body
+		if params.BodyIsJiraMarkup {
+			body = jira.JiraMarkup(params.Body)
+		}
+
 		cr := jira.CreateRequest{
 			Project:          project,
 			IssueType:        params.IssueType,
 			ParentIssueKey:   params.ParentIssueKey,
 			Summary:          params.Summary,
-			Body:             params.Body,
+			Body:             body,
 			Reporter:         params.Reporter,
 			Assignee:         params.Assignee,
 			Priority:         params.Priority,
@@ -125,6 +144,7 @@ func create(cmd *cobra.Command, _ []string) {
 			CustomFields:     params.CustomFields,
 			EpicField:        viper.GetString("epic.link"),
 		}
+		cr.JiraTemplateID = params.JiraTemplate
 		cr.ForProjectType(projectType)
 		cr.ForInstallationType(installation)
 		if configuredCustomFields, err := cmdcommon.GetConfiguredCustomFields(); err == nil {
@@ -158,6 +178,114 @@ func create(cmd *cobra.Command, _ []string) {
 	}
 }
 
+func applyIssueTemplate(client *jira.Client, project string, params *cmdcommon.CreateParams) error {
+	projectResp, err := client.GetProjectV2(project)
+	if err != nil {
+		return err
+	}
+
+	issueTypeID, err := resolveIssueTypeID(params.IssueType)
+	if err != nil {
+		return err
+	}
+
+	templateResp, err := client.GetIssueTemplate(params.JiraTemplate, projectResp.ID, issueTypeID)
+	if err != nil {
+		return err
+	}
+
+	for _, variable := range templateResp.UserVariables {
+		if !variable.Required {
+			continue
+		}
+		if strings.TrimSpace(params.TemplateVars[variable.Key]) == "" {
+			return fmt.Errorf("required template variable %q is missing", variable.Key)
+		}
+	}
+
+	for _, field := range templateResp.Fields {
+		substituted := jira.SubstituteTemplateVars(field.Text1, params.TemplateVars)
+
+		switch field.FieldType {
+		case jira.TemplateFieldSummary:
+			if params.Summary == "" || field.Overwritable {
+				params.Summary = substituted
+			}
+		case jira.TemplateFieldDescription:
+			if params.Body == "" || field.Overwritable {
+				params.Body = substituted
+				params.BodyIsJiraMarkup = true
+			}
+		case jira.TemplateFieldLabels:
+			labels := strings.FieldsFunc(substituted, func(r rune) bool {
+				return r == ',' || r == '\n'
+			})
+			for i := range labels {
+				labels[i] = strings.TrimSpace(labels[i])
+			}
+			filtered := labels[:0]
+			for _, label := range labels {
+				if label != "" {
+					filtered = append(filtered, label)
+				}
+			}
+			params.Labels = mergeLabels(filtered, params.Labels)
+		}
+	}
+
+	return nil
+}
+
+func resolveIssueTypeID(issueType string) (string, error) {
+	availableTypes, ok := viper.Get("issue.types").([]any)
+	if !ok {
+		return "", fmt.Errorf("invalid issue types in config")
+	}
+
+	for _, availableType := range availableTypes {
+		typeMap, ok := availableType.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		name, _ := typeMap["name"].(string)
+		handle, _ := typeMap["handle"].(string)
+		id, _ := typeMap["id"].(string)
+
+		if strings.EqualFold(issueType, handle) || strings.EqualFold(issueType, name) {
+			return id, nil
+		}
+	}
+
+	return "", fmt.Errorf("issue type %q not found in config", issueType)
+}
+
+func mergeLabels(templateLabels, userLabels []string) []string {
+	if len(templateLabels) == 0 {
+		return userLabels
+	}
+
+	merged := make([]string, 0, len(templateLabels)+len(userLabels))
+	seen := make(map[string]struct{}, len(templateLabels)+len(userLabels))
+
+	for _, label := range templateLabels {
+		if _, ok := seen[label]; ok {
+			continue
+		}
+		seen[label] = struct{}{}
+		merged = append(merged, label)
+	}
+	for _, label := range userLabels {
+		if _, ok := seen[label]; ok {
+			continue
+		}
+		seen[label] = struct{}{}
+		merged = append(merged, label)
+	}
+
+	return merged
+}
+
 type createCmd struct {
 	client     *jira.Client
 	issueTypes []*jira.IssueType
@@ -166,12 +294,12 @@ type createCmd struct {
 
 func (cc *createCmd) setIssueTypes() error {
 	issueTypes := make([]*jira.IssueType, 0)
-	availableTypes, ok := viper.Get("issue.types").([]interface{})
+	availableTypes, ok := viper.Get("issue.types").([]any)
 	if !ok {
 		return fmt.Errorf("invalid issue types in config")
 	}
 	for _, at := range availableTypes {
-		tp := at.(map[string]interface{})
+		tp := at.(map[string]any)
 		name := tp["name"].(string)
 		handle, _ := tp["handle"].(string)
 		if handle == jira.IssueTypeEpic || name == jira.IssueTypeEpic {
@@ -373,6 +501,12 @@ func parseFlags(flags query.FlagParser) *cmdcommon.CreateParams {
 	template, err := flags.GetString("template")
 	cmdutil.ExitIfError(err)
 
+	jiraTemplate, err := flags.GetString("jira-template")
+	cmdutil.ExitIfError(err)
+
+	templateVars, err := flags.GetStringToString("template-var")
+	cmdutil.ExitIfError(err)
+
 	noInput, err := flags.GetBool("no-input")
 	cmdutil.ExitIfError(err)
 
@@ -394,6 +528,8 @@ func parseFlags(flags query.FlagParser) *cmdcommon.CreateParams {
 		OriginalEstimate: originalEstimate,
 		CustomFields:     custom,
 		Template:         template,
+		JiraTemplate:     jiraTemplate,
+		TemplateVars:     templateVars,
 		NoInput:          noInput,
 		Debug:            debug,
 	}

--- a/internal/cmd/issue/issue.go
+++ b/internal/cmd/issue/issue.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ankitpokhrel/jira-cli/internal/cmd/issue/link"
 	"github.com/ankitpokhrel/jira-cli/internal/cmd/issue/list"
 	"github.com/ankitpokhrel/jira-cli/internal/cmd/issue/move"
+	"github.com/ankitpokhrel/jira-cli/internal/cmd/issue/moveproject"
 	"github.com/ankitpokhrel/jira-cli/internal/cmd/issue/unlink"
 	"github.com/ankitpokhrel/jira-cli/internal/cmd/issue/view"
 	"github.com/ankitpokhrel/jira-cli/internal/cmd/issue/watch"
@@ -37,7 +38,7 @@ func NewCmdIssue() *cobra.Command {
 	cmd.AddCommand(
 		lc, cc, edit.NewCmdEdit(), move.NewCmdMove(), view.NewCmdView(), assign.NewCmdAssign(),
 		link.NewCmdLink(), unlink.NewCmdUnlink(), comment.NewCmdComment(), clone.NewCmdClone(),
-		delete.NewCmdDelete(), watch.NewCmdWatch(), worklog.NewCmdWorklog(),
+		delete.NewCmdDelete(), watch.NewCmdWatch(), worklog.NewCmdWorklog(), moveproject.NewCmdMoveProject(),
 	)
 
 	list.SetFlags(lc)

--- a/internal/cmd/issue/list/list.go
+++ b/internal/cmd/issue/list/list.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ankitpokhrel/jira-cli/internal/query"
 	"github.com/ankitpokhrel/jira-cli/internal/view"
 	"github.com/ankitpokhrel/jira-cli/pkg/jira"
+	"github.com/ankitpokhrel/jira-cli/pkg/jql"
 )
 
 const (
@@ -104,7 +105,7 @@ func loadList(cmd *cobra.Command, args []string) {
 		jqlFlag, err := cmd.Flags().GetString("jql")
 		cmdutil.ExitIfError(err)
 		if jqlFlag != "" {
-			searchQuery = fmt.Sprintf(`%s AND %s`, jqlFlag, searchQuery)
+			searchQuery = jql.AppendAnd(jqlFlag, searchQuery)
 		}
 		cmdutil.ExitIfError(cmd.Flags().Set("jql", searchQuery))
 	}

--- a/internal/cmd/issue/move/move.go
+++ b/internal/cmd/issue/move/move.go
@@ -252,7 +252,7 @@ func (mc *moveCmd) verifyTransition(it string) (*jira.Transition, error) {
 		}
 
 		return nil, fmt.Errorf(
-			"Issue %s has 0 available transitions (workflow may be broken).\n\nThis can happen when issues are created via REST API without proper template initialization.\nWorkaround: Move the issue to another project and back to re-initialize the workflow:\n  jira issue move-project %s JIRA\n  jira issue move-project JIRA-NNNN %s",
+			"issue %s has 0 available transitions (workflow may be broken).\n\nThis can happen when issues are created via REST API without proper template initialization.\nWorkaround: Move the issue to another project and back to re-initialize the workflow:\n  jira issue move-project %s JIRA\n  jira issue move-project JIRA-NNNN %s",
 			mc.params.key,
 			mc.params.key,
 			currentProject,

--- a/internal/cmd/issue/move/move.go
+++ b/internal/cmd/issue/move/move.go
@@ -245,6 +245,20 @@ func (mc *moveCmd) setAvailableTransitions() error {
 func (mc *moveCmd) verifyTransition(it string) (*jira.Transition, error) {
 	var tr *jira.Transition
 
+	if len(mc.transitions) == 0 {
+		currentProject := mc.params.key
+		if parts := strings.SplitN(mc.params.key, "-", 2); len(parts) > 0 && parts[0] != "" {
+			currentProject = parts[0]
+		}
+
+		return nil, fmt.Errorf(
+			"Issue %s has 0 available transitions (workflow may be broken).\n\nThis can happen when issues are created via REST API without proper template initialization.\nWorkaround: Move the issue to another project and back to re-initialize the workflow:\n  jira issue move-project %s JIRA\n  jira issue move-project JIRA-NNNN %s",
+			mc.params.key,
+			mc.params.key,
+			currentProject,
+		)
+	}
+
 	st := strings.ToLower(mc.params.state)
 	all := make([]string, 0, len(mc.transitions))
 	for _, t := range mc.transitions {

--- a/internal/cmd/issue/moveproject/moveproject.go
+++ b/internal/cmd/issue/moveproject/moveproject.go
@@ -1,0 +1,110 @@
+package moveproject
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"net/http"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/ankitpokhrel/jira-cli/api"
+	"github.com/ankitpokhrel/jira-cli/internal/cmdutil"
+	"github.com/ankitpokhrel/jira-cli/pkg/jira"
+)
+
+const helpText = `Move issue to a different Jira project.`
+
+func NewCmdMoveProject() *cobra.Command {
+	cmd := cobra.Command{
+		Use:   "move-project ISSUE-KEY TARGET-PROJECT",
+		Short: "Move issue to a different project",
+		Long:  helpText,
+		Args:  cobra.ExactArgs(2),
+		Annotations: map[string]string{
+			"help:args": `ISSUE-KEY\tIssue key, eg: ISSUE-1
+TARGET-PROJECT\tProject key to move the issue to`,
+		},
+		RunE: moveProject,
+	}
+
+	cmd.Flags().String("issue-type", "", "Issue type in the target project")
+	cmd.Flags().Bool("dry-run", false, "Preview the project move without submitting it")
+
+	return &cmd
+}
+
+func moveProject(cmd *cobra.Command, args []string) error {
+	debug, err := cmd.Flags().GetBool("debug")
+	cmdutil.ExitIfError(err)
+
+	issueType, err := cmd.Flags().GetString("issue-type")
+	cmdutil.ExitIfError(err)
+
+	dryRun, err := cmd.Flags().GetBool("dry-run")
+	cmdutil.ExitIfError(err)
+
+	server := viper.GetString("server")
+	login := viper.GetString("login")
+	token := viper.GetString("api_token")
+	authType := jira.AuthType(viper.GetString("auth_type"))
+	insecure := viper.GetBool("insecure")
+
+	restClient := api.DefaultClient(debug)
+
+	var sessionOpts []func(*http.Transport)
+	if insecure {
+		sessionOpts = append(sessionOpts, func(t *http.Transport) {
+			if t.TLSClientConfig == nil {
+				t.TLSClientConfig = &tls.Config{}
+			}
+			t.TLSClientConfig.InsecureSkipVerify = true
+		})
+	}
+	if authType == jira.AuthTypeMTLS {
+		mtlsConfig := jira.MTLSConfig{
+			CaCert:     viper.GetString("mtls.ca_cert"),
+			ClientCert: viper.GetString("mtls.client_cert"),
+			ClientKey:  viper.GetString("mtls.client_key"),
+		}
+		sessionOpts = append(sessionOpts, func(t *http.Transport) {
+			if t.TLSClientConfig == nil {
+				t.TLSClientConfig = &tls.Config{}
+			}
+			if mtlsConfig.CaCert != "" {
+				caCert, readErr := os.ReadFile(mtlsConfig.CaCert)
+				cmdutil.ExitIfError(readErr)
+				pool := x509.NewCertPool()
+				pool.AppendCertsFromPEM(caCert)
+				t.TLSClientConfig.RootCAs = pool
+			}
+			if mtlsConfig.ClientCert != "" || mtlsConfig.ClientKey != "" {
+				cert, loadErr := tls.LoadX509KeyPair(mtlsConfig.ClientCert, mtlsConfig.ClientKey)
+				cmdutil.ExitIfError(loadErr)
+				t.TLSClientConfig.Certificates = []tls.Certificate{cert}
+				t.TLSClientConfig.Renegotiation = tls.RenegotiateFreelyAsClient
+			}
+		})
+	}
+
+	sessionClient, err := jira.NewSessionClient(server, login, token, authType, sessionOpts...)
+	cmdutil.ExitIfError(err)
+
+	result, err := jira.MoveProject(sessionClient, restClient, jira.MoveProjectParams{
+		IssueKey:      cmdutil.GetJiraIssueKey(viper.GetString("project.key"), args[0]),
+		TargetProject: args[1],
+		IssueType:     issueType,
+		DryRun:        dryRun,
+	})
+	cmdutil.ExitIfError(err)
+
+	if dryRun {
+		fmt.Printf("Would move %s from %s to %s as %s\n", result.OldKey, result.OldProject, result.NewProject, result.IssueType)
+		return nil
+	}
+
+	fmt.Printf("Issue moved: %s → %s\n", result.OldKey, result.NewKey)
+	return nil
+}

--- a/internal/cmd/project/list/list.go
+++ b/internal/cmd/project/list/list.go
@@ -11,13 +11,17 @@ import (
 
 // NewCmdList is a list command.
 func NewCmdList() *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:     "list",
 		Short:   "List lists Jira projects",
 		Long:    "List lists Jira projects that a user has access to.",
 		Aliases: []string{"lists", "ls"},
 		Run:     List,
 	}
+
+	SetFlags(cmd)
+
+	return cmd
 }
 
 // List displays a list view.
@@ -42,7 +46,26 @@ func List(cmd *cobra.Command, _ []string) {
 		return
 	}
 
-	v := view.NewProject(projects)
+	plain, err := cmd.Flags().GetBool("plain")
+	cmdutil.ExitIfError(err)
+
+	noHeaders, err := cmd.Flags().GetBool("no-headers")
+	cmdutil.ExitIfError(err)
+
+	delimiter, err := cmd.Flags().GetString("delimiter")
+	cmdutil.ExitIfError(err)
+
+	v := view.NewProject(projects, view.WithProjectDisplay(view.DisplayFormat{
+		Plain:     plain,
+		NoHeaders: noHeaders,
+		Delimiter: delimiter,
+	}))
 
 	cmdutil.ExitIfError(v.Render())
+}
+
+func SetFlags(cmd *cobra.Command) {
+	cmd.Flags().Bool("plain", false, "Display output in plain mode")
+	cmd.Flags().Bool("no-headers", false, "Don't display table headers in plain mode. Works only with --plain")
+	cmd.Flags().String("delimiter", "\t", "Custom delimeter for columns in plain mode. Works only with --plain")
 }

--- a/internal/cmdcommon/create.go
+++ b/internal/cmdcommon/create.go
@@ -28,6 +28,7 @@ type CreateParams struct {
 	ParentIssueKey   string
 	Summary          string
 	Body             string
+	BodyIsJiraMarkup bool
 	Priority         string
 	Reporter         string
 	Assignee         string
@@ -38,6 +39,8 @@ type CreateParams struct {
 	OriginalEstimate string
 	CustomFields     map[string]string
 	Template         string
+	JiraTemplate     string
+	TemplateVars     map[string]string
 	NoInput          bool
 	Debug            bool
 }
@@ -67,6 +70,10 @@ And, this field is mandatory when creating a sub-task.`)
 	cmd.Flags().StringP("original-estimate", "e", "", prefix+" Original estimate")
 	cmd.Flags().StringToString("custom", custom, "Set custom fields")
 	cmd.Flags().StringP("template", "T", "", "Path to a file to read body/description from")
+	if prefix != "Epic" {
+		cmd.Flags().String("jira-template", "", "Deviniti Issue Template ID (e.g. 14866)")
+		cmd.Flags().StringToString("template-var", custom, "Set Deviniti Issue Template variables")
+	}
 	cmd.Flags().Bool("web", false, "Open in web browser after successful creation")
 	cmd.Flags().Bool("no-input", false, "Disable prompt for non-required fields")
 }

--- a/internal/query/issue.go
+++ b/internal/query/issue.go
@@ -105,10 +105,12 @@ func (i *Issue) Get() string {
 		}
 	})
 
-	if i.params.Reverse {
-		q.OrderBy(obf, jql.DirectionAscending)
-	} else {
-		q.OrderBy(obf, jql.DirectionDescending)
+	if !q.HasOrderBy() {
+		if i.params.Reverse {
+			q.OrderBy(obf, jql.DirectionAscending)
+		} else {
+			q.OrderBy(obf, jql.DirectionDescending)
+		}
 	}
 
 	return q.String()

--- a/internal/query/issue_test.go
+++ b/internal/query/issue_test.go
@@ -432,11 +432,20 @@ func TestIssueGet(t *testing.T) {
 				`type="test" AND resolution="test" AND priority="test" AND reporter="test" ` +
 				`AND assignee="test" AND component="test" AND parent="test" ORDER BY lastViewed ASC`,
 		},
+		{
+			name: "query with jql order by parameter",
+			initialize: func() *Issue {
+				i, err := NewIssue("TEST", &issueFlagParser{jql: "assignee = currentUser() ORDER BY updated DESC"})
+				assert.NoError(t, err)
+				return i
+			},
+			expected: `project="TEST" AND assignee = currentUser() AND issue IN issueHistory() AND issue IN watchedIssues() AND ` +
+				`type="test" AND resolution="test" AND priority="test" AND reporter="test" ` +
+				`AND assignee="test" AND component="test" AND parent="test" ORDER BY updated DESC`,
+		},
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/view/project.go
+++ b/internal/view/project.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"os"
 	"text/tabwriter"
 
 	"github.com/ankitpokhrel/jira-cli/pkg/jira"
@@ -15,9 +16,11 @@ type ProjectOption func(*Project)
 
 // Project is a project view.
 type Project struct {
-	data   []*jira.Project
-	writer io.Writer
-	buf    *bytes.Buffer
+	data            []*jira.Project
+	writer          io.Writer
+	buf             *bytes.Buffer
+	hasCustomWriter bool
+	Display         DisplayFormat
 }
 
 // NewProject initializes a project.
@@ -38,24 +41,65 @@ func NewProject(data []*jira.Project, opts ...ProjectOption) *Project {
 func WithProjectWriter(w io.Writer) ProjectOption {
 	return func(p *Project) {
 		p.writer = w
+		p.hasCustomWriter = true
+	}
+}
+
+func WithProjectDisplay(display DisplayFormat) ProjectOption {
+	return func(p *Project) {
+		p.Display = display
 	}
 }
 
 // Render renders the project view.
 func (p Project) Render() error {
-	p.printHeader()
+	if p.Display.Plain || tui.IsDumbTerminal() || tui.IsNotTTY() {
+		delimiter := "\t"
+		if p.Display.Plain && p.Display.Delimiter != "" {
+			delimiter = p.Display.Delimiter
+		}
+		if p.hasCustomWriter {
+			return p.renderPlain(p.writer, delimiter)
+		}
 
-	for _, d := range p.data {
-		_, _ = fmt.Fprintf(p.writer, "%s\t%s\t%s\t%s\n", d.Key, prepareTitle(d.Name), d.Type, d.Lead.Name)
+		w := tabwriter.NewWriter(os.Stdout, 0, tabWidth, 1, '\t', 0)
+		return p.renderPlain(w, delimiter)
 	}
-	if _, ok := p.writer.(*tabwriter.Writer); ok {
-		err := p.writer.(*tabwriter.Writer).Flush()
+
+	if p.hasCustomWriter {
+		w := tabwriter.NewWriter(p.writer, 0, tabWidth, 1, '\t', 0)
+		if err := p.renderTable(w); err != nil {
+			return err
+		}
+		return w.Flush()
+	}
+
+	if err := p.renderTable(p.writer); err != nil {
+		return err
+	}
+	if w, ok := p.writer.(*tabwriter.Writer); ok {
+		err := w.Flush()
 		if err != nil {
 			return err
 		}
 	}
 
 	return tui.PagerOut(p.buf.String())
+}
+
+func (p Project) renderPlain(w io.Writer, delimiter string) error {
+	return renderPlain(w, p.tableData(), delimiter)
+}
+
+func (p Project) renderTable(w io.Writer) error {
+	for _, items := range p.tableData() {
+		_, err := fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", items[0], items[1], items[2], items[3])
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func (p Project) header() []string {
@@ -67,14 +111,15 @@ func (p Project) header() []string {
 	}
 }
 
-func (p Project) printHeader() {
-	headers := p.header()
-	end := len(headers) - 1
-	for i, h := range headers {
-		_, _ = fmt.Fprintf(p.writer, "%s", h)
-		if i != end {
-			_, _ = fmt.Fprintf(p.writer, "\t")
-		}
+func (p Project) tableData() tui.TableData {
+	data := tui.TableData{}
+	if !p.Display.Plain || !p.Display.NoHeaders {
+		data = append(data, p.header())
 	}
-	_, _ = fmt.Fprintln(p.writer)
+
+	for _, d := range p.data {
+		data = append(data, []string{d.Key, prepareTitle(d.Name), d.Type, d.Lead.Name})
+	}
+
+	return data
 }

--- a/internal/view/project_test.go
+++ b/internal/view/project_test.go
@@ -2,6 +2,7 @@ package view
 
 import (
 	"bytes"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -27,8 +28,132 @@ func TestProjectRender(t *testing.T) {
 
 	expected := `KEY	NAME	TYPE	LEAD
 FRST	First	classic	Person A
-SCND	[2[] Second	next-gen	Person B
+SCND	[2] Second	next-gen	Person B
 THIRD	Third	classic	Person C
 `
 	assert.Equal(t, expected, b.String())
+}
+
+func TestProjectRenderPlain(t *testing.T) {
+	var b bytes.Buffer
+
+	//nolint:unused
+	type lead struct {
+		Name string `json:"displayName"`
+	}
+
+	data := []*jira.Project{
+		{Key: "FRST", Name: "First", Lead: lead{Name: "Person A"}, Type: jira.ProjectTypeClassic},
+		{Key: "SCND", Name: "[2] Second", Lead: lead{Name: "Person B"}, Type: jira.ProjectTypeNextGen},
+	}
+	project := NewProject(
+		data,
+		WithProjectWriter(&b),
+		WithProjectDisplay(DisplayFormat{Plain: true}),
+	)
+	assert.NoError(t, project.Render())
+
+	expected := "KEY\tNAME\tTYPE\tLEAD\nFRST\tFirst\tclassic\tPerson A\nSCND\t[2] Second\tnext-gen\tPerson B\n"
+	assert.Equal(t, expected, b.String())
+}
+
+func TestProjectRenderPlainNoHeadersWithDelimiter(t *testing.T) {
+	var b bytes.Buffer
+
+	//nolint:unused
+	type lead struct {
+		Name string `json:"displayName"`
+	}
+
+	data := []*jira.Project{
+		{Key: "FRST", Name: "First", Lead: lead{Name: "Person A"}, Type: jira.ProjectTypeClassic},
+	}
+	project := NewProject(
+		data,
+		WithProjectWriter(&b),
+		WithProjectDisplay(DisplayFormat{Plain: true, NoHeaders: true, Delimiter: "|"}),
+	)
+	assert.NoError(t, project.Render())
+
+	expected := "FRST|First|classic|Person A\n"
+	assert.Equal(t, expected, b.String())
+}
+
+func TestProjectRenderNoHeadersIgnoredWithoutPlain(t *testing.T) {
+	var b bytes.Buffer
+
+	//nolint:unused
+	type lead struct {
+		Name string `json:"displayName"`
+	}
+
+	data := []*jira.Project{
+		{Key: "FRST", Name: "First", Lead: lead{Name: "Person A"}, Type: jira.ProjectTypeClassic},
+	}
+	project := NewProject(
+		data,
+		WithProjectWriter(&b),
+		WithProjectDisplay(DisplayFormat{NoHeaders: true}),
+	)
+	assert.NoError(t, project.Render())
+
+	expected := "KEY\tNAME\tTYPE\tLEAD\nFRST\tFirst\tclassic\tPerson A\n"
+	assert.Equal(t, expected, b.String())
+}
+
+func TestProjectRenderPlainWithDelimiterKeepsHeaders(t *testing.T) {
+	var b bytes.Buffer
+
+	//nolint:unused
+	type lead struct {
+		Name string `json:"displayName"`
+	}
+
+	data := []*jira.Project{
+		{Key: "FRST", Name: "First", Lead: lead{Name: "Person A"}, Type: jira.ProjectTypeClassic},
+	}
+	project := NewProject(
+		data,
+		WithProjectWriter(&b),
+		WithProjectDisplay(DisplayFormat{Plain: true, Delimiter: "|"}),
+	)
+	assert.NoError(t, project.Render())
+
+	expected := "KEY|NAME|TYPE|LEAD\nFRST|First|classic|Person A\n"
+	assert.Equal(t, expected, b.String())
+}
+
+func TestProjectRenderPlainUsesStdoutWithoutCustomWriter(t *testing.T) {
+	t.Cleanup(func() {
+		os.Stdout = os.NewFile(uintptr(1), "/dev/stdout")
+	})
+
+	reader, writer, err := os.Pipe()
+	assert.NoError(t, err)
+
+	originalStdout := os.Stdout
+	os.Stdout = writer
+
+	//nolint:unused
+	type lead struct {
+		Name string `json:"displayName"`
+	}
+
+	data := []*jira.Project{
+		{Key: "SOS", Name: "Service Operations", Lead: lead{Name: "Marks, Philipp"}, Type: jira.ProjectTypeClassic},
+	}
+	project := NewProject(data, WithProjectDisplay(DisplayFormat{Plain: true}))
+	assert.NoError(t, project.Render())
+	assert.NoError(t, writer.Close())
+	os.Stdout = originalStdout
+
+	var b bytes.Buffer
+	_, err = b.ReadFrom(reader)
+	assert.NoError(t, err)
+	assert.NoError(t, reader.Close())
+
+	out := b.String()
+	assert.Contains(t, out, "KEY\tNAME")
+	assert.Contains(t, out, "TYPE\tLEAD")
+	assert.Contains(t, out, "SOS\tService Operations\tclassic\tMarks, Philipp\n")
 }

--- a/pkg/jira/client.go
+++ b/pkg/jira/client.go
@@ -76,17 +76,17 @@ func (e Errors) String() string {
 	if len(e.ErrorMessages) > 0 || len(e.Errors) > 0 {
 		out.WriteString("\nError:\n")
 		for _, v := range e.ErrorMessages {
-			out.WriteString(fmt.Sprintf("  - %s\n", v))
+			_, _ = fmt.Fprintf(&out, "  - %s\n", v)
 		}
 		for k, v := range e.Errors {
-			out.WriteString(fmt.Sprintf("  - %s: %s\n", k, v))
+			_, _ = fmt.Fprintf(&out, "  - %s: %s\n", k, v)
 		}
 	}
 
 	if len(e.WarningMessages) > 0 {
 		out.WriteString("\nWarning:\n")
 		for _, v := range e.WarningMessages {
-			out.WriteString(fmt.Sprintf("  - %s\n", v))
+			_, _ = fmt.Fprintf(&out, "  - %s\n", v)
 		}
 	}
 
@@ -192,6 +192,11 @@ func WithInsecureTLS(ins bool) ClientFunc {
 	return func(c *Client) {
 		c.insecure = ins
 	}
+}
+
+// GetRaw sends GET request to an arbitrary path on the server (no base URL prefix).
+func (c *Client) GetRaw(ctx context.Context, path string, headers Header) (*http.Response, error) {
+	return c.request(ctx, http.MethodGet, c.server+path, nil, headers)
 }
 
 // Get sends GET request to v3 version of the jira api.

--- a/pkg/jira/create.go
+++ b/pkg/jira/create.go
@@ -121,6 +121,7 @@ func (c *Client) create(req *CreateRequest, ver string) (*CreateResponse, error)
 	return &out, err
 }
 
+//nolint:gocyclo
 func (*Client) getRequestData(req *CreateRequest) *createRequest {
 	if req.Labels == nil {
 		req.Labels = []string{}

--- a/pkg/jira/create.go
+++ b/pkg/jira/create.go
@@ -3,6 +3,7 @@ package jira
 import (
 	"context"
 	"encoding/json"
+	"maps"
 	"net/http"
 	"strconv"
 	"strings"
@@ -26,7 +27,7 @@ type CreateRequest struct {
 	// This can also be used to attach epic for next-gen project.
 	ParentIssueKey   string
 	Summary          string
-	Body             interface{} // string in v1/v2 and adf.ADF in v3
+	Body             any // string in v1/v2 and adf.ADF in v3
 	Reporter         string
 	Assignee         string
 	Priority         string
@@ -44,12 +45,15 @@ type CreateRequest struct {
 	SubtaskField string
 	// CustomFields holds all custom fields passed
 	// while creating an issue.
-	CustomFields map[string]string
+	CustomFields   map[string]string
+	JiraTemplateID string
 
 	projectType            string
 	installationType       string
 	configuredCustomFields []IssueTypeField
 }
+
+type JiraMarkup string
 
 // ForProjectType sets jira project type.
 func (cr *CreateRequest) ForProjectType(pt string) {
@@ -138,6 +142,8 @@ func (*Client) getRequestData(req *CreateRequest) *createRequest {
 	switch v := req.Body.(type) {
 	case string:
 		cf.Description = md.ToJiraMD(v)
+	case JiraMarkup:
+		cf.Description = string(v)
 	case *adf.ADF:
 		cf.Description = v
 	}
@@ -223,6 +229,12 @@ func (*Client) getRequestData(req *CreateRequest) *createRequest {
 	}
 
 	constructCustomFields(req.CustomFields, req.configuredCustomFields, &data)
+	if req.JiraTemplateID != "" {
+		if data.Fields.M.customFields == nil {
+			data.Fields.M.customFields = make(customField)
+		}
+		data.Fields.M.customFields["customfield_10203"] = req.JiraTemplateID
+	}
 
 	return &data
 }
@@ -294,7 +306,7 @@ type createFields struct {
 	} `json:"parent,omitempty"`
 	Name        string           `json:"name,omitempty"`
 	Summary     string           `json:"summary"`
-	Description interface{}      `json:"description,omitempty"`
+	Description any              `json:"description,omitempty"`
 	Reporter    *nameOrAccountID `json:"reporter,omitempty"`
 	Assignee    *nameOrAccountID `json:"assignee,omitempty"`
 	Priority    *struct {
@@ -328,11 +340,11 @@ func (cfm *createFieldsMarshaler) MarshalJSON() ([]byte, error) {
 		return m, err
 	}
 
-	var temp interface{}
+	var temp any
 	if err := json.Unmarshal(m, &temp); err != nil {
 		return nil, err
 	}
-	dm := temp.(map[string]interface{})
+	dm := temp.(map[string]any)
 
 	if epic, ok := dm["name"]; ok {
 		if cfm.M.epicField != "" {
@@ -341,9 +353,7 @@ func (cfm *createFieldsMarshaler) MarshalJSON() ([]byte, error) {
 		delete(dm, "name")
 	}
 
-	for key, val := range cfm.M.customFields {
-		dm[key] = val
-	}
+	maps.Copy(dm, cfm.M.customFields)
 
 	return json.Marshal(dm)
 }

--- a/pkg/jira/create_test.go
+++ b/pkg/jira/create_test.go
@@ -178,3 +178,90 @@ func TestCreateEpicNextGen(t *testing.T) {
 	_, err = client.CreateV2(&requestData)
 	assert.Error(t, &ErrUnexpectedResponse{}, err)
 }
+
+func TestCreateWithJiraTemplate(t *testing.T) {
+	expectedBody := `{"update":{},"fields":{"project":{"key":"TEST"},"issuetype":{"name":"Story"},` +
+		`"summary":"SOS - Test","customfield_10203":"14866"}}`
+	testServer := createTestServer{code: 201}
+	server := testServer.serve(t, expectedBody)
+	defer server.Close()
+
+	client := NewClient(Config{Server: server.URL}, WithTimeout(3*time.Second))
+
+	requestData := CreateRequest{
+		Project:        "TEST",
+		IssueType:      "Story",
+		Summary:        "SOS - Test",
+		JiraTemplateID: "14866",
+	}
+	actual, err := client.CreateV2(&requestData)
+	assert.NoError(t, err)
+
+	expected := &CreateResponse{
+		ID:  "10057",
+		Key: "TEST-3",
+	}
+	assert.Equal(t, expected, actual)
+}
+
+func TestCreateWithJiraTemplateAndCustomFields(t *testing.T) {
+	expectedBody := `{"update":{},"fields":{"project":{"key":"TEST"},"issuetype":{"name":"Story"},` +
+		`"summary":"Test","customfield_10203":"14866","customfield_10002":3}}`
+	testServer := createTestServer{code: 201}
+	server := testServer.serve(t, expectedBody)
+	defer server.Close()
+
+	client := NewClient(Config{Server: server.URL}, WithTimeout(3*time.Second))
+
+	requestData := CreateRequest{
+		Project:        "TEST",
+		IssueType:      "Story",
+		Summary:        "Test",
+		JiraTemplateID: "14866",
+		CustomFields:   map[string]string{"story-points": "3"},
+	}
+	requestData.WithCustomFields([]IssueTypeField{
+		{
+			Key:  "customfield_10002",
+			Name: "Story Points",
+			Schema: struct {
+				DataType string `json:"type"`
+				Items    string `json:"items,omitempty"`
+			}{DataType: "number"},
+		},
+	})
+	actual, err := client.CreateV2(&requestData)
+	assert.NoError(t, err)
+
+	expected := &CreateResponse{
+		ID:  "10057",
+		Key: "TEST-3",
+	}
+	assert.Equal(t, expected, actual)
+}
+
+func TestCreateWithJiraMarkupDescription(t *testing.T) {
+	expectedBody := `{"update":{},"fields":{"project":{"key":"TEST"},"issuetype":{"name":"Story"},` +
+		`"summary":"SOS - Test","description":"h2. Checklist\n(x) done\n(/) accepted","customfield_10203":"14866"}}`
+	testServer := createTestServer{code: 201}
+	server := testServer.serve(t, expectedBody)
+	defer server.Close()
+
+	client := NewClient(Config{Server: server.URL}, WithTimeout(3*time.Second))
+
+	requestData := CreateRequest{
+		Project:        "TEST",
+		IssueType:      "Story",
+		Summary:        "SOS - Test",
+		Body:           JiraMarkup("h2. Checklist\n(x) done\n(/) accepted"),
+		JiraTemplateID: "14866",
+	}
+	actual, err := client.CreateV2(&requestData)
+	assert.NoError(t, err)
+
+	expected := &CreateResponse{
+		ID:  "10057",
+		Key: "TEST-3",
+	}
+	assert.Equal(t, expected, actual)
+}

--- a/pkg/jira/issue.go
+++ b/pkg/jira/issue.go
@@ -341,6 +341,66 @@ type issueWorklogRequest struct {
 	Comment   string `json:"comment"`
 }
 
+// IssueComment holds data for a single Jira issue comment (v2 API).
+type IssueComment struct {
+	ID   string `json:"id"`
+	Body string `json:"body"`
+}
+
+// GetIssueComment fetches a single comment using GET /issue/{key}/comment/{commentID}.
+func (c *Client) GetIssueComment(key, commentID string) (*IssueComment, error) {
+	path := fmt.Sprintf("/issue/%s/comment/%s", key, commentID)
+	res, err := c.GetV2(context.Background(), path, Header{
+		"Accept": "application/json",
+	})
+	if err != nil {
+		return nil, err
+	}
+	if res == nil {
+		return nil, ErrEmptyResponse
+	}
+	defer func() { _ = res.Body.Close() }()
+
+	if res.StatusCode != http.StatusOK {
+		return nil, formatUnexpectedResponse(res)
+	}
+
+	var comment IssueComment
+	if err := json.NewDecoder(res.Body).Decode(&comment); err != nil {
+		return nil, err
+	}
+	return &comment, nil
+}
+
+// UpdateIssueComment updates a comment using PUT /issue/{key}/comment/{commentID}.
+func (c *Client) UpdateIssueComment(key, commentID, comment string, internal bool) error {
+	body, err := json.Marshal(&issueCommentRequest{
+		Body:       md.ToJiraMD(comment),
+		Properties: []issueCommentProperty{{Key: "sd.public.comment", Value: issueCommentPropertyValue{Internal: internal}}},
+	})
+	if err != nil {
+		return err
+	}
+
+	path := fmt.Sprintf("/issue/%s/comment/%s", key, commentID)
+	res, err := c.PutV2(context.Background(), path, body, Header{
+		"Accept":       "application/json",
+		"Content-Type": "application/json",
+	})
+	if err != nil {
+		return err
+	}
+	if res == nil {
+		return ErrEmptyResponse
+	}
+	defer func() { _ = res.Body.Close() }()
+
+	if res.StatusCode != http.StatusOK {
+		return formatUnexpectedResponse(res)
+	}
+	return nil
+}
+
 // AddIssueWorklog adds worklog to an issue using POST /issue/{key}/worklog endpoint.
 // Leave param `started` empty to use the server's current datetime as start date.
 func (c *Client) AddIssueWorklog(key, started, timeSpent, comment, newEstimate string) error {

--- a/pkg/jira/issue.go
+++ b/pkg/jira/issue.go
@@ -306,12 +306,16 @@ type issueCommentProperty struct {
 }
 type issueCommentRequest struct {
 	Body       string                 `json:"body"`
-	Properties []issueCommentProperty `json:"properties"`
+	Properties []issueCommentProperty `json:"properties,omitempty"`
 }
 
 // AddIssueComment adds comment to an issue using POST /issue/{key}/comment endpoint.
 func (c *Client) AddIssueComment(key, comment string, internal bool) error {
-	body, err := json.Marshal(&issueCommentRequest{Body: md.ToJiraMD(comment), Properties: []issueCommentProperty{{Key: "sd.public.comment", Value: issueCommentPropertyValue{Internal: internal}}}})
+	req := &issueCommentRequest{Body: comment}
+	if internal {
+		req.Properties = []issueCommentProperty{{Key: "sd.public.comment", Value: issueCommentPropertyValue{Internal: internal}}}
+	}
+	body, err := json.Marshal(req)
 	if err != nil {
 		return err
 	}
@@ -374,10 +378,11 @@ func (c *Client) GetIssueComment(key, commentID string) (*IssueComment, error) {
 
 // UpdateIssueComment updates a comment using PUT /issue/{key}/comment/{commentID}.
 func (c *Client) UpdateIssueComment(key, commentID, comment string, internal bool) error {
-	body, err := json.Marshal(&issueCommentRequest{
-		Body:       md.ToJiraMD(comment),
-		Properties: []issueCommentProperty{{Key: "sd.public.comment", Value: issueCommentPropertyValue{Internal: internal}}},
-	})
+	req := &issueCommentRequest{Body: comment}
+	if internal {
+		req.Properties = []issueCommentProperty{{Key: "sd.public.comment", Value: issueCommentPropertyValue{Internal: internal}}}
+	}
+	body, err := json.Marshal(req)
 	if err != nil {
 		return err
 	}

--- a/pkg/jira/issue_test.go
+++ b/pkg/jira/issue_test.go
@@ -554,6 +554,71 @@ func TestAddIssueComment(t *testing.T) {
 	assert.Error(t, &ErrUnexpectedResponse{}, err)
 }
 
+func TestGetIssueComment(t *testing.T) {
+	var notFound bool
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.Equal(t, "/rest/api/2/issue/TEST-1/comment/10042", r.URL.Path)
+		assert.Equal(t, "application/json", r.Header.Get("Accept"))
+
+		if notFound {
+			w.WriteHeader(404)
+			return
+		}
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{"id":"10042","body":"existing comment text"}`))
+	}))
+	defer server.Close()
+
+	client := NewClient(Config{Server: server.URL}, WithTimeout(3*time.Second))
+
+	comment, err := client.GetIssueComment("TEST-1", "10042")
+	assert.NoError(t, err)
+	assert.Equal(t, "10042", comment.ID)
+	assert.Equal(t, "existing comment text", comment.Body)
+
+	notFound = true
+
+	comment, err = client.GetIssueComment("TEST-1", "10042")
+	assert.Nil(t, comment)
+	assert.Error(t, err)
+}
+
+func TestUpdateIssueComment(t *testing.T) {
+	var unexpectedStatusCode bool
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "PUT", r.Method)
+		assert.Equal(t, "/rest/api/2/issue/TEST-1/comment/10042", r.URL.Path)
+		assert.Equal(t, "application/json", r.Header.Get("Accept"))
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+
+		actualBody := new(strings.Builder)
+		_, _ = io.Copy(actualBody, r.Body)
+
+		expectedBody := `{"body":"updated comment","properties":[{"key":"sd.public.comment","value":{"internal":false}}]}`
+		assert.Equal(t, expectedBody, actualBody.String())
+
+		if unexpectedStatusCode {
+			w.WriteHeader(400)
+		} else {
+			w.WriteHeader(200)
+		}
+	}))
+	defer server.Close()
+
+	client := NewClient(Config{Server: server.URL}, WithTimeout(3*time.Second))
+
+	err := client.UpdateIssueComment("TEST-1", "10042", "updated comment", false)
+	assert.NoError(t, err)
+
+	unexpectedStatusCode = true
+
+	err = client.UpdateIssueComment("TEST-1", "10042", "updated comment", false)
+	assert.Error(t, &ErrUnexpectedResponse{}, err)
+}
+
 func TestAddIssueWorklog(t *testing.T) {
 	var unexpectedStatusCode bool
 

--- a/pkg/jira/issue_test.go
+++ b/pkg/jira/issue_test.go
@@ -531,7 +531,7 @@ func TestAddIssueComment(t *testing.T) {
 		actualBody := new(strings.Builder)
 		_, _ = io.Copy(actualBody, r.Body)
 
-		expectedBody := `{"body":"comment","properties":[{"key":"sd.public.comment","value":{"internal":false}}]}`
+		expectedBody := `{"body":"comment"}`
 
 		assert.Equal(t, expectedBody, actualBody.String())
 
@@ -552,6 +552,23 @@ func TestAddIssueComment(t *testing.T) {
 
 	err = client.AddIssueComment("TEST-1", "comment", false)
 	assert.Error(t, &ErrUnexpectedResponse{}, err)
+}
+
+func TestAddIssueCommentInternal(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		actualBody := new(strings.Builder)
+		_, _ = io.Copy(actualBody, r.Body)
+
+		expectedBody := `{"body":"comment","properties":[{"key":"sd.public.comment","value":{"internal":true}}]}`
+		assert.Equal(t, expectedBody, actualBody.String())
+
+		w.WriteHeader(201)
+	}))
+	defer server.Close()
+
+	client := NewClient(Config{Server: server.URL}, WithTimeout(3*time.Second))
+	err := client.AddIssueComment("TEST-1", "comment", true)
+	assert.NoError(t, err)
 }
 
 func TestGetIssueComment(t *testing.T) {
@@ -597,7 +614,7 @@ func TestUpdateIssueComment(t *testing.T) {
 		actualBody := new(strings.Builder)
 		_, _ = io.Copy(actualBody, r.Body)
 
-		expectedBody := `{"body":"updated comment","properties":[{"key":"sd.public.comment","value":{"internal":false}}]}`
+		expectedBody := `{"body":"updated comment"}`
 		assert.Equal(t, expectedBody, actualBody.String())
 
 		if unexpectedStatusCode {
@@ -617,6 +634,23 @@ func TestUpdateIssueComment(t *testing.T) {
 
 	err = client.UpdateIssueComment("TEST-1", "10042", "updated comment", false)
 	assert.Error(t, &ErrUnexpectedResponse{}, err)
+}
+
+func TestUpdateIssueCommentInternal(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		actualBody := new(strings.Builder)
+		_, _ = io.Copy(actualBody, r.Body)
+
+		expectedBody := `{"body":"updated comment","properties":[{"key":"sd.public.comment","value":{"internal":true}}]}`
+		assert.Equal(t, expectedBody, actualBody.String())
+
+		w.WriteHeader(200)
+	}))
+	defer server.Close()
+
+	client := NewClient(Config{Server: server.URL}, WithTimeout(3*time.Second))
+	err := client.UpdateIssueComment("TEST-1", "10042", "updated comment", true)
+	assert.NoError(t, err)
 }
 
 func TestAddIssueWorklog(t *testing.T) {

--- a/pkg/jira/moveproject.go
+++ b/pkg/jira/moveproject.go
@@ -1,0 +1,184 @@
+package jira
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/url"
+	"regexp"
+	"strings"
+)
+
+var moveProjectBrowsePattern = regexp.MustCompile(`/browse/([A-Z]+-\d+)`)
+
+// MoveProjectParams holds parameters for moving an issue between projects.
+type MoveProjectParams struct {
+	IssueKey      string
+	TargetProject string
+	IssueType     string // empty = keep same
+	DryRun        bool
+}
+
+// MoveProjectResult holds the result of a project move.
+type MoveProjectResult struct {
+	OldKey     string
+	NewKey     string
+	OldProject string
+	NewProject string
+	IssueType  string
+}
+
+// MoveProject moves an issue from one Jira project to another using the legacy JSP workflow.
+func MoveProject(sc *SessionClient, client *Client, params MoveProjectParams) (*MoveProjectResult, error) {
+	if sc == nil {
+		return nil, fmt.Errorf("session client is required")
+	}
+	if client == nil {
+		return nil, fmt.Errorf("client is required")
+	}
+	if strings.TrimSpace(params.IssueKey) == "" {
+		return nil, fmt.Errorf("issue key is required")
+	}
+	if strings.TrimSpace(params.TargetProject) == "" {
+		return nil, fmt.Errorf("target project is required")
+	}
+
+	type issueResponse struct {
+		ID     string `json:"id"`
+		Key    string `json:"key"`
+		Fields struct {
+			Project struct {
+				ID  string `json:"id"`
+				Key string `json:"key"`
+			} `json:"project"`
+			IssueType struct {
+				ID   string `json:"id"`
+				Name string `json:"name"`
+			} `json:"issuetype"`
+		} `json:"fields"`
+	}
+
+	type projectResponse struct {
+		ID         string `json:"id"`
+		Key        string `json:"key"`
+		IssueTypes []struct {
+			ID   string `json:"id"`
+			Name string `json:"name"`
+		} `json:"issueTypes"`
+	}
+
+	issueResp, err := client.GetV2(context.Background(), "/issue/"+params.IssueKey+"?fields=project,issuetype", nil)
+	if err != nil {
+		return nil, err
+	}
+	defer issueResp.Body.Close()
+
+	issueBody, err := io.ReadAll(issueResp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var issueInfo issueResponse
+	if err := json.Unmarshal(issueBody, &issueInfo); err != nil {
+		return nil, fmt.Errorf("parse issue response: %w", err)
+	}
+
+	if strings.TrimSpace(issueInfo.ID) == "" {
+		return nil, fmt.Errorf("issue %q missing id", params.IssueKey)
+	}
+	if strings.TrimSpace(issueInfo.Fields.Project.Key) == "" {
+		return nil, fmt.Errorf("issue %q missing project key", params.IssueKey)
+	}
+	if strings.TrimSpace(issueInfo.Fields.IssueType.Name) == "" {
+		return nil, fmt.Errorf("issue %q missing issue type", params.IssueKey)
+	}
+
+	targetResp, err := client.GetV2(context.Background(), "/project/"+params.TargetProject, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer targetResp.Body.Close()
+
+	targetBody, err := io.ReadAll(targetResp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var targetInfo projectResponse
+	if err := json.Unmarshal(targetBody, &targetInfo); err != nil {
+		return nil, fmt.Errorf("parse target project response: %w", err)
+	}
+
+	if strings.TrimSpace(targetInfo.ID) == "" {
+		return nil, fmt.Errorf("target project %q missing id", params.TargetProject)
+	}
+	if strings.TrimSpace(targetInfo.Key) == "" {
+		return nil, fmt.Errorf("target project %q missing key", params.TargetProject)
+	}
+
+	if strings.EqualFold(issueInfo.Fields.Project.Key, targetInfo.Key) {
+		return nil, fmt.Errorf("issue %q is already in project %q", params.IssueKey, targetInfo.Key)
+	}
+
+	issueTypeName := strings.TrimSpace(params.IssueType)
+	if issueTypeName == "" {
+		issueTypeName = issueInfo.Fields.IssueType.Name
+	}
+
+	issueTypeID := ""
+	for _, targetIssueType := range targetInfo.IssueTypes {
+		if targetIssueType.Name == issueTypeName {
+			issueTypeID = targetIssueType.ID
+			break
+		}
+	}
+	if issueTypeID == "" {
+		return nil, fmt.Errorf("issue type %q is not available in project %q", issueTypeName, targetInfo.Key)
+	}
+
+	result := &MoveProjectResult{
+		OldKey:     issueInfo.Key,
+		OldProject: issueInfo.Fields.Project.Key,
+		NewProject: targetInfo.Key,
+		IssueType:  issueTypeName,
+	}
+
+	if params.DryRun {
+		return result, nil
+	}
+
+	if _, err := sc.Get("/secure/MoveIssue!default.jspa?id=" + issueInfo.ID); err != nil {
+		return nil, err
+	}
+
+	stepTwo := url.Values{}
+	stepTwo.Set("id", issueInfo.ID)
+	stepTwo.Set("pid", targetInfo.ID)
+	stepTwo.Set("issuetype", issueTypeID)
+	if _, _, err := sc.PostForm("/secure/MoveIssue.jspa", stepTwo); err != nil {
+		return nil, err
+	}
+
+	stepThree := url.Values{}
+	stepThree.Set("id", issueInfo.ID)
+	if _, _, err := sc.PostForm("/secure/MoveIssueUpdateFields.jspa", stepThree); err != nil {
+		return nil, err
+	}
+
+	stepFour := url.Values{}
+	stepFour.Set("id", issueInfo.ID)
+	_, finalURL, err := sc.PostForm("/secure/MoveIssueConfirm.jspa", stepFour)
+	if err != nil {
+		return nil, err
+	}
+
+	match := moveProjectBrowsePattern.FindStringSubmatch(finalURL)
+	if len(match) != 2 {
+		return nil, fmt.Errorf("could not extract new issue key from redirect URL %q", finalURL)
+	}
+
+	result.NewKey = match[1]
+
+	return result, nil
+}

--- a/pkg/jira/moveproject.go
+++ b/pkg/jira/moveproject.go
@@ -32,6 +32,126 @@ type MoveProjectResult struct {
 	IssueType  string
 }
 
+type issueInfo struct {
+	ID     string `json:"id"`
+	Key    string `json:"key"`
+	Fields struct {
+		Project struct {
+			ID  string `json:"id"`
+			Key string `json:"key"`
+		} `json:"project"`
+		IssueType struct {
+			ID   string `json:"id"`
+			Name string `json:"name"`
+		} `json:"issuetype"`
+	} `json:"fields"`
+}
+
+type projectInfo struct {
+	ID         string `json:"id"`
+	Key        string `json:"key"`
+	IssueTypes []struct {
+		ID   string `json:"id"`
+		Name string `json:"name"`
+	} `json:"issueTypes"`
+}
+
+func fetchIssueInfo(client *Client, issueKey string) (*issueInfo, error) {
+	issueResp, err := client.GetV2(context.Background(), "/issue/"+issueKey+"?fields=project,issuetype", nil)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = issueResp.Body.Close() }()
+
+	issueBody, err := io.ReadAll(issueResp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var info issueInfo
+	if err := json.Unmarshal(issueBody, &info); err != nil {
+		return nil, fmt.Errorf("parse issue response: %w", err)
+	}
+
+	if strings.TrimSpace(info.ID) == "" {
+		return nil, fmt.Errorf("issue %q missing id", issueKey)
+	}
+	if strings.TrimSpace(info.Fields.Project.Key) == "" {
+		return nil, fmt.Errorf("issue %q missing project key", issueKey)
+	}
+	if strings.TrimSpace(info.Fields.IssueType.Name) == "" {
+		return nil, fmt.Errorf("issue %q missing issue type", issueKey)
+	}
+
+	return &info, nil
+}
+
+func fetchProjectInfo(client *Client, projectKey string) (*projectInfo, error) {
+	targetResp, err := client.GetV2(context.Background(), "/project/"+projectKey, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = targetResp.Body.Close() }()
+
+	targetBody, err := io.ReadAll(targetResp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var info projectInfo
+	if err := json.Unmarshal(targetBody, &info); err != nil {
+		return nil, fmt.Errorf("parse target project response: %w", err)
+	}
+
+	if strings.TrimSpace(info.ID) == "" {
+		return nil, fmt.Errorf("target project %q missing id", projectKey)
+	}
+	if strings.TrimSpace(info.Key) == "" {
+		return nil, fmt.Errorf("target project %q missing key", projectKey)
+	}
+
+	return &info, nil
+}
+
+func resolveTargetIssueType(issue *issueInfo, project *projectInfo, requestedType string) (string, string, error) {
+	issueTypeName := strings.TrimSpace(requestedType)
+	if issueTypeName == "" {
+		issueTypeName = issue.Fields.IssueType.Name
+	}
+
+	for _, targetIssueType := range project.IssueTypes {
+		if targetIssueType.Name == issueTypeName {
+			return issueTypeName, targetIssueType.ID, nil
+		}
+	}
+
+	return "", "", fmt.Errorf("issue type %q is not available in project %q", issueTypeName, project.Key)
+}
+
+func extractMovedIssueKey(result *MoveProjectResult, originalKey, finalURL, body string) bool {
+	match := moveProjectBrowsePattern.FindStringSubmatch(finalURL)
+	if len(match) == 2 && match[1] != originalKey {
+		result.NewKey = match[1]
+		return true
+	}
+
+	for _, m := range moveProjectTitlePattern.FindAllStringSubmatch(body, -1) {
+		if len(m) == 2 && m[1] != originalKey {
+			result.NewKey = m[1]
+			return true
+		}
+	}
+
+	for _, m := range moveProjectBrowsePattern.FindAllStringSubmatch(body, -1) {
+		if len(m) == 2 && m[1] != originalKey {
+			result.NewKey = m[1]
+			return true
+		}
+	}
+
+	return false
+}
+
 // MoveProject moves an issue from one Jira project to another using the legacy JSP workflow.
 func MoveProject(sc *SessionClient, client *Client, params MoveProjectParams) (*MoveProjectResult, error) {
 	if sc == nil {
@@ -47,97 +167,23 @@ func MoveProject(sc *SessionClient, client *Client, params MoveProjectParams) (*
 		return nil, fmt.Errorf("target project is required")
 	}
 
-	type issueResponse struct {
-		ID     string `json:"id"`
-		Key    string `json:"key"`
-		Fields struct {
-			Project struct {
-				ID  string `json:"id"`
-				Key string `json:"key"`
-			} `json:"project"`
-			IssueType struct {
-				ID   string `json:"id"`
-				Name string `json:"name"`
-			} `json:"issuetype"`
-		} `json:"fields"`
-	}
-
-	type projectResponse struct {
-		ID         string `json:"id"`
-		Key        string `json:"key"`
-		IssueTypes []struct {
-			ID   string `json:"id"`
-			Name string `json:"name"`
-		} `json:"issueTypes"`
-	}
-
-	issueResp, err := client.GetV2(context.Background(), "/issue/"+params.IssueKey+"?fields=project,issuetype", nil)
-	if err != nil {
-		return nil, err
-	}
-	defer issueResp.Body.Close()
-
-	issueBody, err := io.ReadAll(issueResp.Body)
+	issueInfo, err := fetchIssueInfo(client, params.IssueKey)
 	if err != nil {
 		return nil, err
 	}
 
-	var issueInfo issueResponse
-	if err := json.Unmarshal(issueBody, &issueInfo); err != nil {
-		return nil, fmt.Errorf("parse issue response: %w", err)
-	}
-
-	if strings.TrimSpace(issueInfo.ID) == "" {
-		return nil, fmt.Errorf("issue %q missing id", params.IssueKey)
-	}
-	if strings.TrimSpace(issueInfo.Fields.Project.Key) == "" {
-		return nil, fmt.Errorf("issue %q missing project key", params.IssueKey)
-	}
-	if strings.TrimSpace(issueInfo.Fields.IssueType.Name) == "" {
-		return nil, fmt.Errorf("issue %q missing issue type", params.IssueKey)
-	}
-
-	targetResp, err := client.GetV2(context.Background(), "/project/"+params.TargetProject, nil)
+	targetInfo, err := fetchProjectInfo(client, params.TargetProject)
 	if err != nil {
 		return nil, err
-	}
-	defer targetResp.Body.Close()
-
-	targetBody, err := io.ReadAll(targetResp.Body)
-	if err != nil {
-		return nil, err
-	}
-
-	var targetInfo projectResponse
-	if err := json.Unmarshal(targetBody, &targetInfo); err != nil {
-		return nil, fmt.Errorf("parse target project response: %w", err)
-	}
-
-	if strings.TrimSpace(targetInfo.ID) == "" {
-		return nil, fmt.Errorf("target project %q missing id", params.TargetProject)
-	}
-	if strings.TrimSpace(targetInfo.Key) == "" {
-		return nil, fmt.Errorf("target project %q missing key", params.TargetProject)
 	}
 
 	if strings.EqualFold(issueInfo.Fields.Project.Key, targetInfo.Key) {
 		return nil, fmt.Errorf("issue %q is already in project %q", params.IssueKey, targetInfo.Key)
 	}
 
-	issueTypeName := strings.TrimSpace(params.IssueType)
-	if issueTypeName == "" {
-		issueTypeName = issueInfo.Fields.IssueType.Name
-	}
-
-	issueTypeID := ""
-	for _, targetIssueType := range targetInfo.IssueTypes {
-		if targetIssueType.Name == issueTypeName {
-			issueTypeID = targetIssueType.ID
-			break
-		}
-	}
-	if issueTypeID == "" {
-		return nil, fmt.Errorf("issue type %q is not available in project %q", issueTypeName, targetInfo.Key)
+	issueTypeName, issueTypeID, err := resolveTargetIssueType(issueInfo, targetInfo, params.IssueType)
+	if err != nil {
+		return nil, err
 	}
 
 	result := &MoveProjectResult{
@@ -178,30 +224,9 @@ func MoveProject(sc *SessionClient, client *Client, params MoveProjectParams) (*
 		return nil, err
 	}
 
-	// Try extracting the new key from the redirect URL first.
-	match := moveProjectBrowsePattern.FindStringSubmatch(finalURL)
-	if len(match) == 2 && match[1] != params.IssueKey {
-		result.NewKey = match[1]
+	if extractMovedIssueKey(result, issueInfo.Key, finalURL, body) {
 		return result, nil
 	}
 
-	// Fallback: find the new key in the page title [KEY-123] that differs from the original key.
-	for _, m := range moveProjectTitlePattern.FindAllStringSubmatch(body, -1) {
-		if len(m) == 2 && m[1] != issueInfo.Key {
-			result.NewKey = m[1]
-			return result, nil
-		}
-	}
-
-	// Last resort: find any /browse/KEY that differs from the original.
-	for _, m := range moveProjectBrowsePattern.FindAllStringSubmatch(body, -1) {
-		if len(m) == 2 && m[1] != issueInfo.Key {
-			result.NewKey = m[1]
-			return result, nil
-		}
-	}
-
 	return nil, fmt.Errorf("could not extract new issue key from response")
-
-	return result, nil
 }

--- a/pkg/jira/moveproject.go
+++ b/pkg/jira/moveproject.go
@@ -10,7 +10,10 @@ import (
 	"strings"
 )
 
-var moveProjectBrowsePattern = regexp.MustCompile(`/browse/([A-Z]+-\d+)`)
+var (
+	moveProjectBrowsePattern = regexp.MustCompile(`/browse/([A-Z]+-\d+)`)
+	moveProjectTitlePattern  = regexp.MustCompile(`\[([A-Z]+-\d+)\]`)
+)
 
 // MoveProjectParams holds parameters for moving an issue between projects.
 type MoveProjectParams struct {
@@ -168,17 +171,37 @@ func MoveProject(sc *SessionClient, client *Client, params MoveProjectParams) (*
 
 	stepFour := url.Values{}
 	stepFour.Set("id", issueInfo.ID)
-	_, finalURL, err := sc.PostForm("/secure/MoveIssueConfirm.jspa", stepFour)
+	stepFour.Set("confirm", "true")
+	stepFour.Set("Move", "Move")
+	body, finalURL, err := sc.PostForm("/secure/MoveIssueConfirm.jspa", stepFour)
 	if err != nil {
 		return nil, err
 	}
 
+	// Try extracting the new key from the redirect URL first.
 	match := moveProjectBrowsePattern.FindStringSubmatch(finalURL)
-	if len(match) != 2 {
-		return nil, fmt.Errorf("could not extract new issue key from redirect URL %q", finalURL)
+	if len(match) == 2 && match[1] != params.IssueKey {
+		result.NewKey = match[1]
+		return result, nil
 	}
 
-	result.NewKey = match[1]
+	// Fallback: find the new key in the page title [KEY-123] that differs from the original key.
+	for _, m := range moveProjectTitlePattern.FindAllStringSubmatch(body, -1) {
+		if len(m) == 2 && m[1] != issueInfo.Key {
+			result.NewKey = m[1]
+			return result, nil
+		}
+	}
+
+	// Last resort: find any /browse/KEY that differs from the original.
+	for _, m := range moveProjectBrowsePattern.FindAllStringSubmatch(body, -1) {
+		if len(m) == 2 && m[1] != issueInfo.Key {
+			result.NewKey = m[1]
+			return result, nil
+		}
+	}
+
+	return nil, fmt.Errorf("could not extract new issue key from response")
 
 	return result, nil
 }

--- a/pkg/jira/session.go
+++ b/pkg/jira/session.go
@@ -1,0 +1,155 @@
+package jira
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/cookiejar"
+	"net/url"
+	"regexp"
+	"strings"
+)
+
+var atlTokenPattern = regexp.MustCompile(`name="atl_token"\s+value="([^"]+)"`)
+
+type SessionClient struct {
+	client    *http.Client
+	server    string
+	login     string
+	token     string
+	authType  AuthType
+	xsrfToken string
+}
+
+func NewSessionClient(server, login, token string, authType AuthType, opts ...func(*http.Transport)) (*SessionClient, error) {
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		return nil, err
+	}
+
+	transport := &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+	}
+
+	for _, opt := range opts {
+		opt(transport)
+	}
+
+	return &SessionClient{
+		client: &http.Client{
+			Jar:       jar,
+			Transport: transport,
+		},
+		server:   strings.TrimSuffix(server, "/"),
+		login:    login,
+		token:    token,
+		authType: authType,
+	}, nil
+}
+
+func (s *SessionClient) Get(path string) (string, error) {
+	req, err := http.NewRequest(http.MethodGet, s.server+path, nil)
+	if err != nil {
+		return "", err
+	}
+
+	s.setAuth(req)
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	bodyText := string(body)
+	s.extractXSRFToken(resp, bodyText)
+
+	return bodyText, nil
+}
+
+func (s *SessionClient) PostForm(path string, data url.Values) (string, string, error) {
+	form := url.Values{}
+	for key, values := range data {
+		copied := make([]string, len(values))
+		copy(copied, values)
+		form[key] = copied
+	}
+
+	if s.xsrfToken != "" && form.Get("atl_token") == "" {
+		form.Set("atl_token", s.xsrfToken)
+	}
+
+	req, err := http.NewRequest(http.MethodPost, s.server+path, strings.NewReader(form.Encode()))
+	if err != nil {
+		return "", "", err
+	}
+
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	s.setAuth(req)
+
+	finalURL := req.URL.String()
+	client := *s.client
+	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		finalURL = req.URL.String()
+		if len(via) >= 10 {
+			return fmt.Errorf("stopped after 10 redirects")
+		}
+		return nil
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", finalURL, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", finalURL, err
+	}
+
+	if resp.Request != nil && resp.Request.URL != nil {
+		finalURL = resp.Request.URL.String()
+	}
+
+	bodyText := string(body)
+	s.extractXSRFToken(resp, bodyText)
+
+	return bodyText, finalURL, nil
+}
+
+func (s *SessionClient) GetXSRFToken() string {
+	return s.xsrfToken
+}
+
+func (s *SessionClient) extractXSRFToken(resp *http.Response, body string) {
+	for _, cookie := range resp.Cookies() {
+		if cookie.Name == "atlassian.xsrf.token" && cookie.Value != "" {
+			s.xsrfToken = cookie.Value
+			return
+		}
+	}
+
+	match := atlTokenPattern.FindStringSubmatch(body)
+	if len(match) == 2 {
+		s.xsrfToken = match[1]
+	}
+}
+
+func (s *SessionClient) setAuth(req *http.Request) {
+	switch s.authType.String() {
+	case string(AuthTypeMTLS):
+		if s.token != "" {
+			req.Header.Add("Authorization", "Bearer "+s.token)
+		}
+	case string(AuthTypeBearer):
+		req.Header.Add("Authorization", "Bearer "+s.token)
+	case string(AuthTypeBasic):
+		req.SetBasicAuth(s.login, s.token)
+	}
+}

--- a/pkg/jira/session.go
+++ b/pkg/jira/session.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 )
 
+const maxRedirects = 10
+
 var atlTokenPattern = regexp.MustCompile(`name="atl_token"\s+value="([^"]+)"`)
 
 type SessionClient struct {
@@ -59,7 +61,7 @@ func (s *SessionClient) Get(path string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
@@ -96,8 +98,8 @@ func (s *SessionClient) PostForm(path string, data url.Values) (string, string, 
 	client := *s.client
 	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
 		finalURL = req.URL.String()
-		if len(via) >= 10 {
-			return fmt.Errorf("stopped after 10 redirects")
+		if len(via) >= maxRedirects {
+			return fmt.Errorf("stopped after %d redirects", maxRedirects)
 		}
 		return nil
 	}
@@ -106,7 +108,7 @@ func (s *SessionClient) PostForm(path string, data url.Values) (string, string, 
 	if err != nil {
 		return "", finalURL, err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {

--- a/pkg/jira/template.go
+++ b/pkg/jira/template.go
@@ -1,0 +1,104 @@
+package jira
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+const (
+	TemplateFieldSummary     = 1
+	TemplateFieldDescription = 2
+	TemplateFieldLabels      = 4
+)
+
+type TemplateField struct {
+	FieldType             int    `json:"fieldType"`
+	Text1                 string `json:"text1"`
+	JiraField             bool   `json:"jiraField"`
+	ReadOnly              bool   `json:"readOnly"`
+	Overwritable          bool   `json:"overwritable"`
+	AtlassianWikiRenderer bool   `json:"atlassianWikiRenderer"`
+}
+
+type TemplateVariable struct {
+	ID               int      `json:"id"`
+	Key              string   `json:"key"`
+	FieldType        string   `json:"fieldType"`
+	Required         bool     `json:"required"`
+	Options          []string `json:"options"`
+	Order            int      `json:"order"`
+	IsUsedInTemplate bool     `json:"isUsedInTemplate"`
+}
+
+type TemplateResponse struct {
+	Fields              []TemplateField    `json:"fields"`
+	TemplateID          string             `json:"templateID"`
+	TemplateName        string             `json:"templateName"`
+	PatternFields       []string           `json:"patternFields"`
+	UserVariables       []TemplateVariable `json:"userVariables"`
+	TemplateDescription string             `json:"templateDescription"`
+}
+
+func (c *Client) GetIssueTemplate(templateID, projectID, issueTypeID string) (*TemplateResponse, error) {
+	path := fmt.Sprintf(
+		"/rest/it/1.0/template/autocomplete?templateId=%s&projectId=%s&issueTypeId=%s",
+		templateID,
+		projectID,
+		issueTypeID,
+	)
+
+	res, err := c.GetRaw(context.Background(), path, nil)
+	if err != nil {
+		return nil, err
+	}
+	if res == nil {
+		return nil, ErrEmptyResponse
+	}
+	defer func() { _ = res.Body.Close() }()
+
+	if res.StatusCode != http.StatusOK {
+		return nil, formatUnexpectedResponse(res)
+	}
+
+	var out TemplateResponse
+
+	err = json.NewDecoder(res.Body).Decode(&out)
+
+	return &out, err
+}
+
+func (c *Client) GetProjectV2(key string) (*Project, error) {
+	res, err := c.GetV2(context.Background(), "/project/"+key, nil)
+	if err != nil {
+		return nil, err
+	}
+	if res == nil {
+		return nil, ErrEmptyResponse
+	}
+	defer func() { _ = res.Body.Close() }()
+
+	if res.StatusCode != http.StatusOK {
+		return nil, formatUnexpectedResponse(res)
+	}
+
+	var out Project
+
+	err = json.NewDecoder(res.Body).Decode(&out)
+
+	return &out, err
+}
+
+func SubstituteTemplateVars(text string, vars map[string]string) string {
+	if len(vars) == 0 || text == "" {
+		return text
+	}
+
+	for key, val := range vars {
+		text = strings.ReplaceAll(text, "["+key+"]", val)
+	}
+
+	return text
+}

--- a/pkg/jira/template_test.go
+++ b/pkg/jira/template_test.go
@@ -1,0 +1,29 @@
+package jira
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSubstituteTemplateVars(t *testing.T) {
+	tests := []struct {
+		name     string
+		text     string
+		vars     map[string]string
+		expected string
+	}{
+		{"basic substitution", "SOS - [TITLE]", map[string]string{"TITLE": "My Task"}, "SOS - My Task"},
+		{"multiple vars", "[A] and [B]", map[string]string{"A": "X", "B": "Y"}, "X and Y"},
+		{"nil vars", "SOS - [TITLE]", nil, "SOS - [TITLE]"},
+		{"empty vars", "SOS - [TITLE]", map[string]string{}, "SOS - [TITLE]"},
+		{"no match", "plain text", map[string]string{"X": "Y"}, "plain text"},
+		{"repeated var", "[X] [X]", map[string]string{"X": "Z"}, "Z Z"},
+		{"empty value", "SOS - [TITLE]", map[string]string{"TITLE": ""}, "SOS - "},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, SubstituteTemplateVars(tt.text, tt.vars))
+		})
+	}
+}

--- a/pkg/jira/types.go
+++ b/pkg/jira/types.go
@@ -28,6 +28,7 @@ func (at AuthType) String() string {
 
 // Project holds project info.
 type Project struct {
+	ID   string `json:"id"`
 	Key  string `json:"key"`
 	Name string `json:"name"`
 	Lead struct {
@@ -38,12 +39,12 @@ type Project struct {
 
 // ProjectVersion holds project version info.
 type ProjectVersion struct {
-	Archived    bool        `json:"archived"`
-	Description interface{} `json:"description"`
-	ID          string      `json:"id"`
-	Name        string      `json:"name"`
-	ProjectID   int         `json:"projectId"`
-	Released    bool        `json:"released"`
+	Archived    bool   `json:"archived"`
+	Description any    `json:"description"`
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	ProjectID   int    `json:"projectId"`
+	Released    bool   `json:"released"`
 }
 
 // Board holds board info.
@@ -61,15 +62,16 @@ type Epic struct {
 
 // Issue holds issue info.
 type Issue struct {
+	ID     string      `json:"id"`
 	Key    string      `json:"key"`
 	Fields IssueFields `json:"fields"`
 }
 
 // IssueFields holds issue fields.
 type IssueFields struct {
-	Summary     string      `json:"summary"`
-	Description interface{} `json:"description"` // string in v1/v2, adf.ADF in v3
-	Labels      []string    `json:"labels"`
+	Summary     string   `json:"summary"`
+	Description any      `json:"description"` // string in v1/v2, adf.ADF in v3
+	Labels      []string `json:"labels"`
 	Resolution  struct {
 		Name string `json:"name"`
 	} `json:"resolution"`
@@ -104,10 +106,10 @@ type IssueFields struct {
 	} `json:"versions"`
 	Comment struct {
 		Comments []struct {
-			ID      string      `json:"id"`
-			Author  User        `json:"author"`
-			Body    interface{} `json:"body"` // string in v1/v2, adf.ADF in v3
-			Created string      `json:"created"`
+			ID      string `json:"id"`
+			Author  User   `json:"author"`
+			Body    any    `json:"body"` // string in v1/v2, adf.ADF in v3
+			Created string `json:"created"`
 		} `json:"comments"`
 		Total int `json:"total"`
 	} `json:"comment"`

--- a/pkg/jql/jql.go
+++ b/pkg/jql/jql.go
@@ -23,6 +23,8 @@ type JQL struct {
 	orderBy string
 }
 
+var orderByRegex = regexp.MustCompile(`(?i)\sORDER\s+BY\s`)
+
 // NewJQL initializes jql query builder.
 func NewJQL(project string) *JQL {
 	return &JQL{
@@ -123,9 +125,9 @@ func (j *JQL) In(field string, value ...string) *JQL {
 	if field != "" && n > 0 {
 		var q strings.Builder
 
-		q.WriteString(fmt.Sprintf("%s IN (", field))
+		_, _ = fmt.Fprintf(&q, "%s IN (", field)
 		for i, v := range value {
-			q.WriteString(fmt.Sprintf("%q", v))
+			_, _ = fmt.Fprintf(&q, "%q", v)
 			if i != n-1 {
 				q.WriteString(", ")
 			}
@@ -143,9 +145,9 @@ func (j *JQL) NotIn(field string, value ...string) *JQL {
 	if field != "" && n > 0 {
 		var q strings.Builder
 
-		q.WriteString(fmt.Sprintf("%s NOT IN (", field))
+		_, _ = fmt.Fprintf(&q, "%s NOT IN (", field)
 		for i, v := range value {
-			q.WriteString(fmt.Sprintf("%q", v))
+			_, _ = fmt.Fprintf(&q, "%q", v)
 			if i != n-1 {
 				q.WriteString(", ")
 			}
@@ -161,6 +163,11 @@ func (j *JQL) NotIn(field string, value ...string) *JQL {
 func (j *JQL) OrderBy(field, dir string) *JQL {
 	j.orderBy = fmt.Sprintf("ORDER BY %s %s", field, dir)
 	return j
+}
+
+// HasOrderBy reports whether the query already contains an ORDER BY clause.
+func (j *JQL) HasOrderBy() bool {
+	return j.orderBy != ""
 }
 
 // And combines filter with AND operator.
@@ -179,15 +186,70 @@ func (j *JQL) Or(fn GroupFunc) *JQL {
 
 // Raw sets the passed JQL query along with project context.
 func (j *JQL) Raw(q string) *JQL {
-	q = strings.TrimSpace(q)
-	if q == "" {
+	filters, orderBy := SplitOrderByClause(q)
+	if filters == "" && orderBy == "" {
 		return j
 	}
-	if hasProjectFilter(q) {
+	if hasProjectFilter(filters) {
 		j.filters = j.filters[1:]
 	}
-	j.filters = append(j.filters, q)
+	if filters != "" {
+		j.filters = append(j.filters, filters)
+	}
+	if orderBy != "" {
+		j.orderBy = orderBy
+	}
 	return j
+}
+
+// SplitOrderByClause separates a trailing ORDER BY clause from a JQL query.
+func SplitOrderByClause(q string) (string, string) {
+	q = strings.TrimSpace(q)
+	if q == "" {
+		return "", ""
+	}
+
+	matches := orderByRegex.FindAllStringIndex(q, -1)
+	if len(matches) == 0 {
+		return q, ""
+	}
+
+	idx := matches[len(matches)-1][0]
+	filters := strings.TrimSpace(q[:idx])
+	orderBy := strings.TrimSpace(q[idx:])
+
+	if filters == "" {
+		return q, ""
+	}
+
+	return filters, orderBy
+}
+
+// AppendAnd appends clauses before a trailing ORDER BY clause, if present.
+func AppendAnd(q string, clauses ...string) string {
+	filters, orderBy := SplitOrderByClause(q)
+	parts := make([]string, 0, len(clauses)+1)
+
+	if filters != "" {
+		parts = append(parts, filters)
+	}
+
+	for _, clause := range clauses {
+		clause = strings.TrimSpace(clause)
+		if clause != "" {
+			parts = append(parts, clause)
+		}
+	}
+
+	joined := strings.Join(parts, " AND ")
+	if joined == "" {
+		return orderBy
+	}
+	if orderBy != "" {
+		return joined + " " + orderBy
+	}
+
+	return joined
 }
 
 // String returns the constructed query.
@@ -204,7 +266,7 @@ func (j *JQL) mergeFilters(separator string) {
 		qs.WriteString(filter)
 
 		if i != fLen-1 {
-			qs.WriteString(fmt.Sprintf(" %s ", separator))
+			_, _ = fmt.Fprintf(&qs, " %s ", separator)
 		}
 	}
 

--- a/pkg/jql/jql_test.go
+++ b/pkg/jql/jql_test.go
@@ -299,11 +299,45 @@ func TestJQL(t *testing.T) {
 			},
 			expected: "type=\"Story\" OR summary ~ cli AND project IN (TEST1,TEST2)",
 		},
+		{
+			name: "it keeps raw order by at the end of the query",
+			initialize: func() *JQL {
+				jql := NewJQL("TEST")
+				jql.And(func() {
+					jql.FilterBy("type", "Story").
+						Raw("summary ~ cli ORDER BY updated DESC")
+				})
+				return jql
+			},
+			expected: "project=\"TEST\" AND type=\"Story\" AND summary ~ cli ORDER BY updated DESC",
+		},
+		{
+			name: "it preserves raw order by with project override",
+			initialize: func() *JQL {
+				jql := NewJQL("TEST")
+				jql.And(func() {
+					jql.FilterBy("type", "Story").
+						Raw("project = TEST1 AND summary ~ cli ORDER BY updated DESC")
+				})
+				return jql
+			},
+			expected: "type=\"Story\" AND project = TEST1 AND summary ~ cli ORDER BY updated DESC",
+		},
+		{
+			name: "it keeps raw multi-column order by at the end of the query",
+			initialize: func() *JQL {
+				jql := NewJQL("TEST")
+				jql.And(func() {
+					jql.FilterBy("type", "Story").
+						Raw("summary ~ cli ORDER BY updated DESC, created DESC")
+				})
+				return jql
+			},
+			expected: "project=\"TEST\" AND type=\"Story\" AND summary ~ cli ORDER BY updated DESC, created DESC",
+		},
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -311,6 +345,38 @@ func TestJQL(t *testing.T) {
 			assert.Equal(t, tc.expected, jql.String())
 		})
 	}
+}
+
+func TestSplitOrderByClause(t *testing.T) {
+	t.Parallel()
+
+	filters, orderBy := SplitOrderByClause("summary ~ cli ORDER BY updated DESC")
+	assert.Equal(t, "summary ~ cli", filters)
+	assert.Equal(t, "ORDER BY updated DESC", orderBy)
+
+	filters, orderBy = SplitOrderByClause("summary ~ cli ORDER BY updated DESC, created DESC")
+	assert.Equal(t, "summary ~ cli", filters)
+	assert.Equal(t, "ORDER BY updated DESC, created DESC", orderBy)
+
+	filters, orderBy = SplitOrderByClause("summary ~ cli")
+	assert.Equal(t, "summary ~ cli", filters)
+	assert.Equal(t, "", orderBy)
+}
+
+func TestAppendAnd(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(
+		t,
+		`assignee = currentUser() AND text ~ "bug" ORDER BY updated DESC`,
+		AppendAnd(`assignee = currentUser() ORDER BY updated DESC`, `text ~ "bug"`),
+	)
+
+	assert.Equal(
+		t,
+		`assignee = currentUser() AND text ~ "bug" ORDER BY updated DESC, created DESC`,
+		AppendAnd(`assignee = currentUser() ORDER BY updated DESC, created DESC`, `text ~ "bug"`),
+	)
 }
 
 func TestHasProject(t *testing.T) {
@@ -373,8 +439,6 @@ func TestHasProject(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run("", func(t *testing.T) {
 			t.Parallel()
 


### PR DESCRIPTION
## Summary
- Moves `md.ToJiraMD()` conversion from the Jira client layer (`pkg/jira/issue.go`) up to the command layer (`add`/`edit` commands), fixing the bug where comments created via API were double-converted
- Adds `--raw` flag to `jira issue comment add` and `jira issue comment edit` to skip markdown-to-Jira conversion entirely (useful for pre-formatted or programmatic input)
- Adds `omitempty` to the `Properties` field in `CommentBody` so empty properties are not sent to the API
- Only sets `properties` when `internal=true`, preventing spurious empty objects in API requests

## Testing
- Added unit tests for both `add` and `edit` commands verifying `--raw` flag behavior
- Existing `pkg/jira/issue_test.go` updated to reflect moved conversion logic

Closes #13