### PR TITLE
fix: Preserve multibyte UTF-8 text in jirawiki parser (#1003)

### DIFF
--- a/pkg/md/jirawiki/parser.go
+++ b/pkg/md/jirawiki/parser.go
@@ -184,7 +184,7 @@ func secondPass(lines []string) string {
 					end = token.endIdx
 				}
 			} else {
-				out.WriteRune(rune(line[beg]))
+				out.WriteByte(line[beg])
 			}
 
 			end++

--- a/pkg/md/jirawiki/parser_test.go
+++ b/pkg/md/jirawiki/parser_test.go
@@ -615,3 +615,49 @@ func TestTables(t *testing.T) {
 		})
 	}
 }
+
+func TestParseNonASCIIText(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "greek with bold",
+			input:    "Λέξη με *bold* κείμενο.",
+			expected: "Λέξη με **bold** κείμενο.\n",
+		},
+		{
+			name:     "cyrillic with bold",
+			input:    "Текст с *bold* словом.",
+			expected: "Текст с **bold** словом.\n",
+		},
+		{
+			name:     "cjk with bold",
+			input:    "これは *bold* です。",
+			expected: "これは **bold** です。\n",
+		},
+		{
+			name:     "accented latin with reference link",
+			input:    "Café [link|https://ankit.pl] señor.",
+			expected: "Café [link](https://ankit.pl) señor.\n",
+		},
+		{
+			name:     "emoji with bold",
+			input:    "Status 🚀 *done* ✅",
+			expected: "Status 🚀 **done** ✅\n",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tc.expected, Parse(tc.input))
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #1003.

The parser was writing out one raw byte as if it were a whole character, which breaks characters that use more than one byte. This only happened on lines containing a Jira-wiki token (e.g. `*bold*`); other lines were copied as-is and looked fine.

## Implementation

One-line fix in `pkg/md/jirawiki/parsre.go`.
Write the raw byte instead of converting to rune first.

## Testing

- Added test cases for parsing Greek, Cyrillic, CJK, accented Latin and emoji combined with wiki markup.
- `go test ./pkg/md/jirawiki/` and `go test ./...` — all green.