### PR TITLE
(RFC) feat: make the default project optional

### DIFF
--- a/internal/cmd/epic/add/add.go
+++ b/internal/cmd/epic/add/add.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/ankitpokhrel/jira-cli/api"
+	"github.com/ankitpokhrel/jira-cli/internal/cmdcommon"
 	"github.com/ankitpokhrel/jira-cli/internal/cmdutil"
 	"github.com/ankitpokhrel/jira-cli/internal/query"
 	"github.com/ankitpokhrel/jira-cli/pkg/jira"
@@ -39,8 +40,13 @@ func add(cmd *cobra.Command, args []string) {
 	server := viper.GetString("server")
 	project := viper.GetString("project.key")
 	projectType := viper.GetString("project.type")
+
+	cmdcommon.EnsureProject(project)
+
 	params := parseFlags(cmd.Flags(), args, project)
 	client := api.DefaultClient(params.debug)
+	projectType, err := cmdcommon.ResolveProjectType(client, project, projectType, viper.GetString("installation"), cmd.Flags().Changed("project"))
+	cmdutil.ExitIfError(err)
 
 	qs := getQuestions(params)
 	if len(qs) > 0 {
@@ -69,7 +75,7 @@ func add(cmd *cobra.Command, args []string) {
 		passed bool
 	)
 
-	err := func() error {
+	err = func() error {
 		s := cmdutil.Info("Adding issues to the epic...")
 		defer s.Stop()
 

--- a/internal/cmd/epic/create/create.go
+++ b/internal/cmd/epic/create/create.go
@@ -51,8 +51,12 @@ func create(cmd *cobra.Command, _ []string) {
 	projectType := viper.GetString("project.type")
 	installation := viper.GetString("installation")
 
+	cmdcommon.EnsureProject(project)
+
 	params := parseFlags(cmd.Flags())
 	client := api.DefaultClient(params.Debug)
+	projectType, err := cmdcommon.ResolveProjectType(client, project, projectType, installation, cmd.Flags().Changed("project"))
+	cmdutil.ExitIfError(err)
 	cc := createCmd{
 		client: client,
 		params: params,

--- a/internal/cmd/epic/list/list.go
+++ b/internal/cmd/epic/list/list.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/ankitpokhrel/jira-cli/api"
 	"github.com/ankitpokhrel/jira-cli/internal/cmd/issue/list"
+	"github.com/ankitpokhrel/jira-cli/internal/cmdcommon"
 	"github.com/ankitpokhrel/jira-cli/internal/cmdutil"
 	"github.com/ankitpokhrel/jira-cli/internal/query"
 	"github.com/ankitpokhrel/jira-cli/internal/view"
@@ -78,10 +79,14 @@ func epicList(cmd *cobra.Command, args []string) {
 	cmdutil.ExitIfError(err)
 
 	client := api.DefaultClient(debug)
+	projectType, err = cmdcommon.ResolveProjectType(client, project, projectType, viper.GetString("installation"), cmd.Flags().Changed("project"))
+	cmdutil.ExitIfError(err)
 
 	if len(args) == 0 {
 		epicExplorerView(cmd, cmd.Flags(), project, projectType, server, client)
 	} else {
+		cmdcommon.EnsureProject(project)
+
 		key := cmdutil.GetJiraIssueKey(project, args[0])
 		singleEpicView(cmd.Flags(), key, project, projectType, server, client)
 	}
@@ -120,7 +125,7 @@ func singleEpicView(flags query.FlagParser, key, project, projectType, server st
 
 	if len(issues) == 0 {
 		fmt.Println()
-		cmdutil.Failed("No result found for given query in project %q", project)
+		cmdutil.Failed("%s", cmdutil.NoResultMessage(project))
 		return
 	}
 
@@ -191,7 +196,7 @@ func epicExplorerView(cmd *cobra.Command, flags query.FlagParser, project, proje
 
 	if len(epics) == 0 {
 		fmt.Println()
-		cmdutil.Failed("No result found for given query in project %q", project)
+		cmdutil.Failed("%s", cmdutil.NoResultMessage(project))
 		return
 	}
 

--- a/internal/cmd/epic/remove/remove.go
+++ b/internal/cmd/epic/remove/remove.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/ankitpokhrel/jira-cli/api"
+	"github.com/ankitpokhrel/jira-cli/internal/cmdcommon"
 	"github.com/ankitpokhrel/jira-cli/internal/cmdutil"
 	"github.com/ankitpokhrel/jira-cli/internal/query"
 	"github.com/ankitpokhrel/jira-cli/pkg/jira"
@@ -37,8 +38,13 @@ func NewCmdRemove() *cobra.Command {
 func remove(cmd *cobra.Command, args []string) {
 	project := viper.GetString("project.key")
 	projectType := viper.GetString("project.type")
+
+	cmdcommon.EnsureProject(project)
+
 	params := parseFlags(cmd.Flags(), args, project)
 	client := api.DefaultClient(params.debug)
+	projectType, err := cmdcommon.ResolveProjectType(client, project, projectType, viper.GetString("installation"), cmd.Flags().Changed("project"))
+	cmdutil.ExitIfError(err)
 
 	qs := getQuestions(params)
 	if len(qs) > 0 {
@@ -63,7 +69,7 @@ func remove(cmd *cobra.Command, args []string) {
 		passed bool
 	)
 
-	err := func() error {
+	err = func() error {
 		s := cmdutil.Info("Removing assigned epic from issues...")
 		defer s.Stop()
 

--- a/internal/cmd/init/init.go
+++ b/internal/cmd/init/init.go
@@ -20,7 +20,9 @@ type initParams struct {
 	login        string
 	authType     string
 	project      string
+	noProject    bool
 	board        string
+	noBoard      bool
 	force        bool
 	insecure     bool
 }
@@ -42,7 +44,9 @@ func NewCmdInit() *cobra.Command {
 	cmd.Flags().String("login", "", "Jira login username or email based on your setup")
 	cmd.Flags().String("auth-type", "", "Authentication type can be basic, bearer or mtls")
 	cmd.Flags().String("project", "", "Your default project key")
+	cmd.Flags().Bool("no-project", false, "Configure without a default project (work across multiple projects and pass -p/--project per command)")
 	cmd.Flags().String("board", "", "Name of your default board in the project")
+	cmd.Flags().Bool("no-board", false, "Configure without a default board")
 	cmd.Flags().Bool("force", false, "Forcefully override existing config if it exists")
 	cmd.Flags().Bool("insecure", false, `If set, the tool will skip TLS certificate verification.
 This can be useful if your server is using self-signed certificates.`)
@@ -72,7 +76,13 @@ func parseFlags(flags query.FlagParser) *initParams {
 	project, err := flags.GetString("project")
 	cmdutil.ExitIfError(err)
 
+	noProject, err := flags.GetBool("no-project")
+	cmdutil.ExitIfError(err)
+
 	board, err := flags.GetString("board")
+	cmdutil.ExitIfError(err)
+
+	noBoard, err := flags.GetBool("no-board")
 	cmdutil.ExitIfError(err)
 
 	force, err := flags.GetBool("force")
@@ -87,7 +97,9 @@ func parseFlags(flags query.FlagParser) *initParams {
 		login:        login,
 		authType:     authType,
 		project:      project,
+		noProject:    noProject,
 		board:        board,
+		noBoard:      noBoard,
 		force:        force,
 		insecure:     insecure,
 	}
@@ -103,7 +115,9 @@ func initialize(cmd *cobra.Command, _ []string) {
 			Login:        params.login,
 			AuthType:     params.authType,
 			Project:      params.project,
+			NoProject:    params.noProject,
 			Board:        params.board,
+			NoBoard:      params.noBoard,
 			Force:        params.force,
 			Insecure:     params.insecure,
 		},

--- a/internal/cmd/issue/clone/clone.go
+++ b/internal/cmd/issue/clone/clone.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/ankitpokhrel/jira-cli/api"
+	"github.com/ankitpokhrel/jira-cli/internal/cmdcommon"
 	"github.com/ankitpokhrel/jira-cli/internal/cmdutil"
 	"github.com/ankitpokhrel/jira-cli/internal/query"
 	"github.com/ankitpokhrel/jira-cli/pkg/adf"
@@ -50,8 +51,12 @@ func clone(cmd *cobra.Command, args []string) {
 	project := viper.GetString("project.key")
 	projectType := viper.GetString("project.type")
 
+	cmdcommon.EnsureProject(project)
+
 	params := parseFlags(cmd.Flags())
 	client := api.DefaultClient(params.debug)
+	projectType, err := cmdcommon.ResolveProjectType(client, project, projectType, viper.GetString("installation"), cmd.Flags().Changed("project"))
+	cmdutil.ExitIfError(err)
 	cc := cloneCmd{
 		client: client,
 		params: params,

--- a/internal/cmd/issue/create/create.go
+++ b/internal/cmd/issue/create/create.go
@@ -76,12 +76,21 @@ func create(cmd *cobra.Command, _ []string) {
 	projectType := viper.GetString("project.type")
 	installation := viper.GetString("installation")
 
+	cmdcommon.EnsureProject(project)
+
+	projectOverridden := cmd.Flags().Changed("project")
+
 	params := parseFlags(cmd.Flags())
 	client := api.DefaultClient(params.Debug)
 	cc := createCmd{
-		client: client,
-		params: params,
+		client:            client,
+		params:            params,
+		project:           project,
+		projectOverridden: projectOverridden,
 	}
+
+	projectType, err := cmdcommon.ResolveProjectType(client, project, projectType, installation, projectOverridden)
+	cmdutil.ExitIfError(err)
 
 	if cc.isNonInteractive() || cc.params.NoInput || tui.IsDumbTerminal() {
 		cc.params.NoInput = true
@@ -159,34 +168,80 @@ func create(cmd *cobra.Command, _ []string) {
 }
 
 type createCmd struct {
-	client     *jira.Client
-	issueTypes []*jira.IssueType
-	params     *cmdcommon.CreateParams
+	client            *jira.Client
+	issueTypes        []*jira.IssueType
+	params            *cmdcommon.CreateParams
+	project           string
+	projectOverridden bool
 }
 
 func (cc *createCmd) setIssueTypes() error {
-	issueTypes := make([]*jira.IssueType, 0)
-	availableTypes, ok := viper.Get("issue.types").([]interface{})
-	if !ok {
-		return fmt.Errorf("invalid issue types in config")
-	}
-	for _, at := range availableTypes {
-		tp := at.(map[string]interface{})
-		name := tp["name"].(string)
-		handle, _ := tp["handle"].(string)
-		if handle == jira.IssueTypeEpic || name == jira.IssueTypeEpic {
-			continue
+	if !cc.projectOverridden {
+		if availableTypes, ok := viper.Get("issue.types").([]interface{}); ok && len(availableTypes) > 0 {
+			if configured := parseConfiguredIssueTypes(availableTypes); len(configured) > 0 {
+				cc.issueTypes = configured
+				return nil
+			}
 		}
-		issueTypes = append(issueTypes, &jira.IssueType{
-			ID:      tp["id"].(string),
-			Name:    name,
-			Handle:  handle,
-			Subtask: tp["subtask"].(bool),
-		})
+	}
+
+	issueTypes, err := fetchIssueTypes(cc.client, cc.project)
+	if err != nil {
+		return err
 	}
 	cc.issueTypes = issueTypes
 
 	return nil
+}
+
+func parseConfiguredIssueTypes(availableTypes []interface{}) []*jira.IssueType {
+	issueTypes := make([]*jira.IssueType, 0, len(availableTypes))
+	for _, at := range availableTypes {
+		tp, ok := at.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		id, _ := tp["id"].(string)
+		name, _ := tp["name"].(string)
+		handle, _ := tp["handle"].(string)
+		subtask, _ := tp["subtask"].(bool)
+		issueTypes = append(issueTypes, &jira.IssueType{
+			ID:      id,
+			Name:    name,
+			Handle:  handle,
+			Subtask: subtask,
+		})
+	}
+	return filterOutEpics(issueTypes)
+}
+
+func fetchIssueTypes(client *jira.Client, project string) ([]*jira.IssueType, error) {
+	serverV9 := jira.SupportsV9CreateMeta(
+		viper.GetString("installation"),
+		viper.GetInt("version.major"),
+		viper.GetInt("version.minor"),
+	)
+	issueTypes, err := client.ProjectIssueTypes(project, serverV9)
+	if err != nil {
+		return nil, err
+	}
+
+	filtered := filterOutEpics(issueTypes)
+	if len(filtered) == 0 {
+		return nil, fmt.Errorf("no issue types found for project %q", project)
+	}
+	return filtered, nil
+}
+
+func filterOutEpics(issueTypes []*jira.IssueType) []*jira.IssueType {
+	filtered := make([]*jira.IssueType, 0, len(issueTypes))
+	for _, it := range issueTypes {
+		if it.Handle == jira.IssueTypeEpic || it.Name == jira.IssueTypeEpic {
+			continue
+		}
+		filtered = append(filtered, it)
+	}
+	return filtered
 }
 
 func (cc *createCmd) getIssueType() *survey.Question {

--- a/internal/cmd/issue/list/list.go
+++ b/internal/cmd/issue/list/list.go
@@ -129,7 +129,7 @@ func loadList(cmd *cobra.Command, args []string) {
 
 	if len(issues) == 0 {
 		fmt.Println()
-		cmdutil.Failed("No result found for given query in project %q", project)
+		cmdutil.Failed("%s", cmdutil.NoResultMessage(project))
 		return
 	}
 

--- a/internal/cmd/sprint/list/list.go
+++ b/internal/cmd/sprint/list/list.go
@@ -114,7 +114,7 @@ func singleSprintView(sprintQuery *query.Sprint, flags query.FlagParser, boardID
 
 	if len(issues) == 0 {
 		fmt.Println()
-		cmdutil.Failed("No result found for given query in project %q", project)
+		cmdutil.Failed("%s", cmdutil.NoResultMessage(project))
 		return
 	}
 
@@ -199,7 +199,7 @@ func sprintExplorerView(sprintQuery *query.Sprint, flags query.FlagParser, board
 	}()
 	if len(sprints) == 0 {
 		fmt.Println()
-		cmdutil.Failed("No result found for given query in project %q", project)
+		cmdutil.Failed("%s", cmdutil.NoResultMessage(project))
 		return
 	}
 

--- a/internal/cmdcommon/project.go
+++ b/internal/cmdcommon/project.go
@@ -1,0 +1,39 @@
+package cmdcommon
+
+import (
+	"fmt"
+
+	"github.com/ankitpokhrel/jira-cli/internal/cmdutil"
+	"github.com/ankitpokhrel/jira-cli/pkg/jira"
+)
+
+// EnsureProject terminates the command with a helpful message when no project
+// is configured or supplied via -p/--project.
+func EnsureProject(project string) {
+	if project == "" {
+		cmdutil.Failed(
+			"No project provided.\n" +
+				"Set a default project by running 'jira init', or pass one with the -p/--project flag.",
+		)
+	}
+}
+
+// ResolveProjectType returns the Jira "style" (classic vs next-gen) for the
+// effective project.
+func ResolveProjectType(client *jira.Client, project, cachedType, installation string, overridden bool) (string, error) {
+	if installation != jira.InstallationTypeCloud || project == "" {
+		return cachedType, nil
+	}
+	if !overridden && cachedType != "" {
+		return cachedType, nil
+	}
+
+	p, err := client.ProjectByKey(project)
+	if err != nil {
+		if overridden {
+			return "", fmt.Errorf("unable to resolve type for project %q: %w", project, err)
+		}
+		return cachedType, nil
+	}
+	return p.Type, nil
+}

--- a/internal/cmdcommon/project_test.go
+++ b/internal/cmdcommon/project_test.go
@@ -1,0 +1,84 @@
+package cmdcommon
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/ankitpokhrel/jira-cli/pkg/jira"
+)
+
+func TestResolveProjectType(t *testing.T) {
+	newClient := func(handler http.HandlerFunc) (*jira.Client, func()) {
+		server := httptest.NewServer(handler)
+		client := jira.NewClient(jira.Config{Server: server.URL}, jira.WithTimeout(3*time.Second))
+		return client, server.Close
+	}
+
+	apiType := func(style string) http.HandlerFunc {
+		return func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/rest/api/2/project/PRJ", r.URL.Path)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"key":"PRJ","style":"` + style + `"}`))
+		}
+	}
+	apiError := func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusInternalServerError) }
+
+	t.Run("non-cloud returns cached value without calling the API", func(t *testing.T) {
+		got, err := ResolveProjectType(nil, "PRJ", "classic", jira.InstallationTypeLocal, true)
+		assert.NoError(t, err)
+		assert.Equal(t, "classic", got)
+	})
+
+	t.Run("default project uses cached value without calling the API", func(t *testing.T) {
+		got, err := ResolveProjectType(nil, "PRJ", "next-gen", jira.InstallationTypeCloud, false)
+		assert.NoError(t, err)
+		assert.Equal(t, "next-gen", got)
+	})
+
+	t.Run("empty project returns cached value without calling the API", func(t *testing.T) {
+		got, err := ResolveProjectType(nil, "", "", jira.InstallationTypeCloud, false)
+		assert.NoError(t, err)
+		assert.Equal(t, "", got)
+	})
+
+	t.Run("overridden project resolves from the API", func(t *testing.T) {
+		client, closeFn := newClient(apiType("next-gen"))
+		defer closeFn()
+
+		got, err := ResolveProjectType(client, "PRJ", "classic", jira.InstallationTypeCloud, true)
+		assert.NoError(t, err)
+		assert.Equal(t, "next-gen", got)
+	})
+
+	t.Run("missing cached value resolves from the API even without override", func(t *testing.T) {
+		client, closeFn := newClient(apiType("classic"))
+		defer closeFn()
+
+		got, err := ResolveProjectType(client, "PRJ", "", jira.InstallationTypeCloud, false)
+		assert.NoError(t, err)
+		assert.Equal(t, "classic", got)
+	})
+
+	t.Run("overridden project errors on API failure instead of returning the wrong cached type", func(t *testing.T) {
+		client, closeFn := newClient(apiError)
+		defer closeFn()
+
+		got, err := ResolveProjectType(client, "PRJ", "next-gen", jira.InstallationTypeCloud, true)
+		assert.Error(t, err)
+		assert.Equal(t, "", got)
+	})
+
+	t.Run("missing cached value falls back to cached on API failure without override", func(t *testing.T) {
+		client, closeFn := newClient(apiError)
+		defer closeFn()
+
+		got, err := ResolveProjectType(client, "PRJ", "", jira.InstallationTypeCloud, false)
+		assert.NoError(t, err)
+		assert.Equal(t, "", got)
+	})
+}

--- a/internal/cmdutil/utils.go
+++ b/internal/cmdutil/utils.go
@@ -90,6 +90,13 @@ func Failed(msg string, args ...interface{}) {
 	os.Exit(1)
 }
 
+func NoResultMessage(project string) string {
+	if project == "" {
+		return "No result found for the given query"
+	}
+	return fmt.Sprintf("No result found for given query in project %q", project)
+}
+
 // Navigate navigates to jira issue.
 func Navigate(server, path string) error {
 	url := GenerateServerBrowseURL(server, path)

--- a/internal/config/generator.go
+++ b/internal/config/generator.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 
 	"github.com/AlecAivazis/survey/v2"
@@ -27,7 +28,6 @@ const (
 
 	optionSearch = "[Search...]"
 	optionBack   = "Go-back"
-	optionNone   = "None"
 	lineBreak    = "----------"
 )
 
@@ -68,7 +68,9 @@ type JiraCLIConfig struct {
 	AuthType     string
 	Login        string
 	Project      string
+	NoProject    bool
 	Board        string
+	NoBoard      bool
 	Force        bool
 	Insecure     bool
 	MTLS         JiraCLIMTLSConfig
@@ -485,20 +487,45 @@ func (c *JiraCLIConfigGenerator) configureProjectAndBoardDetails() error {
 		return err
 	}
 
-	if c.usrCfg.Project == "" {
+	if !c.usrCfg.NoProject && c.usrCfg.Project == "" {
+		setDefault := true
+		confirm := &survey.Confirm{
+			Message: "Set a default project?",
+			Help:    "Choose No to work across multiple projects and pass -p/--project on each command.",
+			Default: true,
+		}
+		if err := survey.AskOne(confirm, &setDefault); err != nil {
+			return err
+		}
+		if !setDefault {
+			c.value.project = nil
+			return nil
+		}
+
 		projectPrompt := survey.Select{
 			Message: "Default project:",
-			Help:    "This is your project key that you want to access by default when using the cli.",
+			Help:    "Project key to access by default when using the cli.",
 			Options: c.projectSuggestions,
 		}
 		if err := survey.AskOne(&projectPrompt, &project, survey.WithValidator(survey.Required)); err != nil {
 			return err
 		}
 	}
+
+	if c.usrCfg.NoProject {
+		c.value.project = nil
+		return nil
+	}
+
 	c.value.project = c.projectsMap[strings.ToLower(project)]
 
 	if c.value.project == nil {
 		return fmt.Errorf("project not found\n  Please check the project key and try again")
+	}
+
+	if c.usrCfg.NoBoard {
+		c.value.board = nil
+		return nil
 	}
 
 	if err := c.getBoardSuggestions(project); err != nil {
@@ -507,6 +534,25 @@ func (c *JiraCLIConfigGenerator) configureProjectAndBoardDetails() error {
 	defaultBoardSuggestions := c.boardSuggestions
 
 	if c.usrCfg.Board == "" {
+		if len(c.boardsMap) == 0 {
+			c.value.board = nil
+			return nil
+		}
+
+		setDefault := true
+		confirm := &survey.Confirm{
+			Message: "Set a default board?",
+			Help:    "Choose No to use the CLI without a default board.",
+			Default: true,
+		}
+		if err := survey.AskOne(confirm, &setDefault); err != nil {
+			return err
+		}
+		if !setDefault {
+			c.value.board = nil
+			return nil
+		}
+
 		for {
 			boardPrompt := &survey.Question{
 				Name: "",
@@ -552,17 +598,19 @@ func (c *JiraCLIConfigGenerator) configureProjectAndBoardDetails() error {
 	}
 	c.value.board = c.boardsMap[strings.ToLower(board)]
 
-	if c.value.board == nil && !strings.EqualFold(board, optionNone) {
-		var suggest string
-		if len(defaultBoardSuggestions) > 2 {
-			suggest = strings.Join(defaultBoardSuggestions[2:], ", ")
-		} else {
-			suggest = strings.Join(defaultBoardSuggestions, ", ")
+	if c.value.board == nil {
+		names := make([]string, 0, len(c.boardsMap))
+		for _, b := range c.boardsMap {
+			names = append(names, b.Name)
+		}
+		sort.Strings(names)
+
+		if len(names) == 0 {
+			return fmt.Errorf("board %q not found\n  No boards are available for project %q", board, c.value.project.Key)
 		}
 		return fmt.Errorf(
-			"board not found\n  Boards available for the project '%s' are '%s'",
-			c.value.project.Key,
-			suggest,
+			"board %q not found\n  Boards available for project %q are: %s",
+			board, c.value.project.Key, strings.Join(names, ", "),
 		)
 	}
 	return nil
@@ -614,17 +662,10 @@ func (c *JiraCLIConfigGenerator) searchAndAssignBoard(project, keyword string) e
 }
 
 func (c *JiraCLIConfigGenerator) configureMetadata() error {
-	var err error
-
-	//nolint:mnd
-	isV9Compatible := c.value.version.major >= 9 || (c.value.version.major == 8 && c.value.version.minor > 4)
-	if c.value.installation == jira.InstallationTypeLocal && isV9Compatible {
-		err = c.configureIssueTypesForJiraServerV9()
-	} else {
-		err = c.configureIssueTypes()
-	}
-	if err != nil {
-		return err
+	if c.value.project != nil {
+		if err := c.configureIssueTypes(); err != nil {
+			return err
+		}
 	}
 
 	return c.configureFields()
@@ -634,60 +675,14 @@ func (c *JiraCLIConfigGenerator) configureIssueTypes() error {
 	s := cmdutil.Info("Configuring metadata. Please wait...")
 	defer s.Stop()
 
-	meta, err := c.jiraClient.GetCreateMeta(&jira.CreateMetaRequest{
-		Projects: c.value.project.Key,
-		Expand:   "projects.issuetypes.fields",
-	})
+	serverV9 := jira.SupportsV9CreateMeta(c.value.installation, c.value.version.major, c.value.version.minor)
+	issueTypes, err := c.jiraClient.ProjectIssueTypes(c.value.project.Key, serverV9)
 	if err != nil {
 		return err
 	}
-	if len(meta.Projects) == 0 || len(meta.Projects[0].IssueTypes) == 0 {
+	if len(issueTypes) == 0 {
 		return ErrUnexpectedResponseFormat
 	}
-
-	issueTypes := make([]*jira.IssueType, 0, len(meta.Projects[0].IssueTypes))
-
-	for _, it := range meta.Projects[0].IssueTypes {
-		issueType := jira.IssueType{
-			ID:      it.ID,
-			Name:    it.Name,
-			Handle:  it.Handle,
-			Subtask: it.Subtask,
-		}
-		issueTypes = append(issueTypes, &issueType)
-	}
-
-	c.value.issueTypes = issueTypes
-
-	return nil
-}
-
-func (c *JiraCLIConfigGenerator) configureIssueTypesForJiraServerV9() error {
-	s := cmdutil.Info("Configuring metadata. Please wait...")
-	defer s.Stop()
-
-	meta, err := c.jiraClient.GetCreateMetaForJiraServerV9(&jira.CreateMetaRequest{
-		Projects: c.value.project.Key,
-		Expand:   "projects.issuetypes.fields",
-	})
-	if err != nil {
-		return err
-	}
-	if len(meta.Values) == 0 {
-		return ErrUnexpectedResponseFormat
-	}
-
-	issueTypes := make([]*jira.IssueType, 0, len(meta.Values))
-
-	for _, it := range meta.Values {
-		issueType := jira.IssueType{
-			ID:      it.ID,
-			Name:    it.Name,
-			Subtask: it.Subtask,
-		}
-		issueTypes = append(issueTypes, &issueType)
-	}
-
 	c.value.issueTypes = issueTypes
 
 	return nil
@@ -754,9 +749,7 @@ func (c *JiraCLIConfigGenerator) write(path string) (string, error) {
 	config.Set("installation", c.value.installation)
 	config.Set("server", c.value.server)
 	config.Set("login", c.value.login)
-	config.Set("project", c.value.project)
 	config.Set("epic", c.value.epic)
-	config.Set("issue.types", c.value.issueTypes)
 	config.Set("issue.fields.custom", c.value.customFields)
 	config.Set("auth_type", c.value.authType.String())
 	config.Set("timezone", c.value.timezone)
@@ -773,6 +766,19 @@ func (c *JiraCLIConfigGenerator) write(path string) (string, error) {
 		config.Set("version.major", c.value.version.major)
 		config.Set("version.minor", c.value.version.minor)
 		config.Set("version.patch", c.value.version.patch)
+	}
+
+	// Project.
+	if c.value.project != nil {
+		config.Set("project", c.value.project)
+	} else {
+		config.Set("project", "")
+	}
+
+	if c.value.issueTypes != nil {
+		config.Set("issue.types", c.value.issueTypes)
+	} else {
+		config.Set("issue.types", []*jira.IssueType{})
 	}
 
 	if c.value.board != nil {
@@ -815,9 +821,9 @@ func (c *JiraCLIConfigGenerator) getBoardSuggestions(project string) error {
 		if c.value.installation == jira.InstallationTypeCloud {
 			return err
 		}
-		// We don't care about the error in the local instance since board API may not exist if agile-addon is not installed.
-		// The only option available for board selection, in this case, is "None" if not passed directly from the flag.
-		c.boardSuggestions = append(c.boardSuggestions, optionNone)
+		// We don't care about the error in the local instance since the board
+		// API may not exist if the agile add-on is not installed. In that case
+		// there are simply no boards to choose from.
 		return nil
 	}
 	c.boardSuggestions = append(c.boardSuggestions, optionSearch, lineBreak)
@@ -825,7 +831,6 @@ func (c *JiraCLIConfigGenerator) getBoardSuggestions(project string) error {
 		c.boardsMap[strings.ToLower(board.Name)] = board
 		c.boardSuggestions = append(c.boardSuggestions, board.Name)
 	}
-	c.boardSuggestions = append(c.boardSuggestions, optionNone)
 
 	return nil
 }

--- a/pkg/jira/createmeta.go
+++ b/pkg/jira/createmeta.go
@@ -98,3 +98,52 @@ func (c *Client) GetCreateMetaForJiraServerV9(req *CreateMetaRequest) (*CreateMe
 
 	return &out, err
 }
+
+// ProjectIssueTypes returns the issue types available for creating issues
+// in the given project.
+func (c *Client) ProjectIssueTypes(project string, serverV9 bool) ([]*IssueType, error) {
+	req := &CreateMetaRequest{
+		Projects: project,
+		Expand:   "projects.issuetypes.fields",
+	}
+
+	if serverV9 {
+		meta, err := c.GetCreateMetaForJiraServerV9(req)
+		if err != nil {
+			return nil, err
+		}
+
+		issueTypes := make([]*IssueType, 0, len(meta.Values))
+
+		for _, it := range meta.Values {
+			issueTypes = append(issueTypes, &IssueType{
+				ID:      it.ID,
+				Name:    it.Name,
+				Subtask: it.Subtask,
+			})
+		}
+
+		return issueTypes, nil
+	}
+
+	meta, err := c.GetCreateMeta(req)
+	if err != nil {
+		return nil, err
+	}
+	if len(meta.Projects) == 0 {
+		return []*IssueType{}, nil
+	}
+
+	issueTypes := make([]*IssueType, 0, len(meta.Projects[0].IssueTypes))
+
+	for _, it := range meta.Projects[0].IssueTypes {
+		issueTypes = append(issueTypes, &IssueType{
+			ID:      it.ID,
+			Name:    it.Name,
+			Handle:  it.Handle,
+			Subtask: it.Subtask,
+		})
+	}
+
+	return issueTypes, nil
+}

--- a/pkg/jira/project.go
+++ b/pkg/jira/project.go
@@ -34,3 +34,25 @@ func (c *Client) Project() ([]*Project, error) {
 
 	return out, err
 }
+
+// ProjectByKey fetches a single project from the /project/{key} endpoint.
+func (c *Client) ProjectByKey(key string) (*Project, error) {
+	res, err := c.GetV2(context.Background(), "/project/"+key, nil)
+	if err != nil {
+		return nil, err
+	}
+	if res == nil {
+		return nil, ErrEmptyResponse
+	}
+	defer func() { _ = res.Body.Close() }()
+
+	if res.StatusCode != http.StatusOK {
+		return nil, formatUnexpectedResponse(res)
+	}
+
+	var out Project
+
+	err = json.NewDecoder(res.Body).Decode(&out)
+
+	return &out, err
+}

--- a/pkg/jira/project_test.go
+++ b/pkg/jira/project_test.go
@@ -71,3 +71,43 @@ func TestProjects(t *testing.T) {
 	_, err = client.Project()
 	assert.Error(t, &ErrUnexpectedResponse{}, err)
 }
+
+func TestProjectByKey(t *testing.T) {
+	var unexpectedStatusCode bool
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/rest/api/2/project/PRJ1", r.URL.Path)
+
+		if unexpectedStatusCode {
+			w.WriteHeader(400)
+		} else {
+			resp, err := os.ReadFile("./testdata/project.json")
+			assert.NoError(t, err)
+
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(200)
+			_, _ = w.Write(resp)
+		}
+	}))
+	defer server.Close()
+
+	client := NewClient(Config{Server: server.URL}, WithTimeout(3*time.Second))
+
+	actual, err := client.ProjectByKey("PRJ1")
+	assert.NoError(t, err)
+
+	expected := &Project{
+		Key:  "PRJ1",
+		Name: "Project 1",
+		Lead: struct {
+			Name string `json:"displayName"`
+		}{Name: "Person A"},
+		Type: "next-gen",
+	}
+	assert.Equal(t, expected, actual)
+
+	unexpectedStatusCode = true
+
+	_, err = client.ProjectByKey("PRJ1")
+	assert.Error(t, &ErrUnexpectedResponse{}, err)
+}

--- a/pkg/jira/serverinfo.go
+++ b/pkg/jira/serverinfo.go
@@ -36,3 +36,13 @@ func (c *Client) ServerInfo() (*ServerInfo, error) {
 
 	return &info, err
 }
+
+// SupportsV9CreateMeta reports whether the installation should use the Jira
+// Server v9 createmeta endpoint.
+func SupportsV9CreateMeta(installation string, major, minor int) bool {
+	if installation != InstallationTypeLocal {
+		return false
+	}
+	//nolint:mnd
+	return major >= 9 || (major == 8 && minor > 4)
+}

--- a/pkg/jira/testdata/project.json
+++ b/pkg/jira/testdata/project.json
@@ -1,0 +1,8 @@
+{
+  "key": "PRJ1",
+  "lead": {
+    "displayName": "Person A"
+  },
+  "name": "Project 1",
+  "style": "next-gen"
+}

--- a/pkg/jql/jql.go
+++ b/pkg/jql/jql.go
@@ -2,8 +2,8 @@ package jql
 
 import (
 	"fmt"
-	"regexp"
 	"strings"
+	"unicode"
 )
 
 const (
@@ -25,10 +25,11 @@ type JQL struct {
 
 // NewJQL initializes jql query builder.
 func NewJQL(project string) *JQL {
-	return &JQL{
-		project: project,
-		filters: []string{fmt.Sprintf("project=%q", project)},
+	j := &JQL{project: project}
+	if project != "" {
+		j.filters = append(j.filters, fmt.Sprintf("project=%q", project))
 	}
+	return j
 }
 
 // History search through user issue history.
@@ -183,7 +184,7 @@ func (j *JQL) Raw(q string) *JQL {
 	if q == "" {
 		return j
 	}
-	if hasProjectFilter(q) {
+	if j.project != "" && hasProjectFilter(q) {
 		j.filters = j.filters[1:]
 	}
 	j.filters = append(j.filters, q)
@@ -219,14 +220,131 @@ func (j *JQL) mergeFilters(separator string) {
 func (j *JQL) compile() string {
 	q := strings.Join(j.filters, " ")
 	if j.orderBy != "" {
-		q += " " + j.orderBy
+		if q != "" {
+			q += " "
+		}
+		q += j.orderBy
 	}
 
 	return q
 }
 
+type tokenKind int
+
+const (
+	tokenWord   tokenKind = iota // an identifier or keyword, e.g. project, IN, EMPTY
+	tokenString                  // a quoted string literal
+	tokenOp                      // an operator, e.g. =, !=, ~, <=
+	tokenPunct                   // any other single character, e.g. ( ) ,
+)
+
+type token struct {
+	kind  tokenKind
+	value string
+}
+
+// hasProjectFilter reports whether the query already contains a `project` field
+// clause, e.g. `project = X`, `project IN (...)` or `project IS NOT EMPTY`.
 func hasProjectFilter(str string) bool {
-	regx := "(?i)((project)[\\s]*?={0,1}\\b)[^'.']"
-	m, _ := regexp.MatchString(regx, str)
-	return m
+	tokens := tokenize(str)
+	for i, t := range tokens {
+		if t.kind == tokenWord && strings.EqualFold(t.value, "project") && isProjectOperator(tokens[i+1:]) {
+			return true
+		}
+	}
+	return false
+}
+
+// isProjectOperator reports whether the tokens immediately following a `project`
+// field form a supported project operator: =, !=, IN, NOT IN or IS [NOT] EMPTY.
+func isProjectOperator(tokens []token) bool {
+	if len(tokens) == 0 {
+		return false
+	}
+	first := tokens[0]
+
+	if first.kind == tokenOp {
+		return first.value == "=" || first.value == "!="
+	}
+	if first.kind != tokenWord {
+		return false
+	}
+
+	switch {
+	case strings.EqualFold(first.value, "in"):
+		return true
+	case strings.EqualFold(first.value, "not"):
+		return len(tokens) > 1 && tokens[1].kind == tokenWord && strings.EqualFold(tokens[1].value, "in")
+	case strings.EqualFold(first.value, "is"):
+		rest := tokens[1:]
+		if len(rest) > 0 && rest[0].kind == tokenWord && strings.EqualFold(rest[0].value, "not") {
+			rest = rest[1:]
+		}
+		return len(rest) > 0 && rest[0].kind == tokenWord && strings.EqualFold(rest[0].value, "empty")
+	}
+	return false
+}
+
+// tokenize splits a JQL string into tokens, consuming quoted string literals.
+func tokenize(str string) []token {
+	var tokens []token
+
+	runes := []rune(str)
+	n := len(runes)
+
+	for i := 0; i < n; {
+		c := runes[i]
+
+		switch {
+		case unicode.IsSpace(c):
+			i++
+		case c == '"' || c == '\'':
+			var sb strings.Builder
+			i++ // opening quote
+			for i < n {
+				if runes[i] == '\\' && i+1 < n {
+					sb.WriteRune(runes[i+1])
+					i += 2
+					continue
+				}
+				if runes[i] == c {
+					i++ // closing quote
+					break
+				}
+				sb.WriteRune(runes[i])
+				i++
+			}
+			tokens = append(tokens, token{kind: tokenString, value: sb.String()})
+		case isWordRune(c):
+			start := i
+			for i < n && isWordRune(runes[i]) {
+				i++
+			}
+			tokens = append(tokens, token{kind: tokenWord, value: string(runes[start:i])})
+		case isOperatorRune(c):
+			start := i
+			for i < n && isOperatorRune(runes[i]) {
+				i++
+			}
+			tokens = append(tokens, token{kind: tokenOp, value: string(runes[start:i])})
+		default:
+			tokens = append(tokens, token{kind: tokenPunct, value: string(c)})
+			i++
+		}
+	}
+
+	return tokens
+}
+
+func isWordRune(r rune) bool {
+	return unicode.IsLetter(r) || unicode.IsDigit(r) || r == '_' || r == '.'
+}
+
+func isOperatorRune(r rune) bool {
+	switch r {
+	case '=', '!', '~', '<', '>':
+		return true
+	default:
+		return false
+	}
 }

--- a/pkg/jql/jql_test.go
+++ b/pkg/jql/jql_test.go
@@ -299,6 +299,68 @@ func TestJQL(t *testing.T) {
 			},
 			expected: "type=\"Story\" OR summary ~ cli AND project IN (TEST1,TEST2)",
 		},
+		{
+			name: "it omits the project clause when project is empty",
+			initialize: func() *JQL {
+				return NewJQL("")
+			},
+			expected: "",
+		},
+		{
+			name: "it sets order by without a project clause",
+			initialize: func() *JQL {
+				jql := NewJQL("")
+				jql.OrderBy("updated", "DESC")
+				return jql
+			},
+			expected: "ORDER BY updated DESC",
+		},
+		{
+			name: "it filters without a project clause",
+			initialize: func() *JQL {
+				jql := NewJQL("")
+				jql.And(func() {
+					jql.FilterBy("type", "Story").
+						FilterBy("resolution", "Done")
+				})
+				return jql
+			},
+			expected: "type=\"Story\" AND resolution=\"Done\"",
+		},
+		{
+			name: "it keeps raw project filter when project is empty",
+			initialize: func() *JQL {
+				jql := NewJQL("")
+				jql.And(func() {
+					jql.FilterBy("type", "Story").
+						Raw("project = TEST1")
+				})
+				return jql
+			},
+			expected: "type=\"Story\" AND project = TEST1",
+		},
+		{
+			name: "it keeps the default project scope when a quoted value mentions project",
+			initialize: func() *JQL {
+				jql := NewJQL("TEST")
+				jql.And(func() {
+					jql.Raw(`summary ~ "project in progress"`)
+				})
+				return jql
+			},
+			expected: `project="TEST" AND summary ~ "project in progress"`,
+		},
+		{
+			name: "it replaces the default project scope when raw has a real project filter",
+			initialize: func() *JQL {
+				jql := NewJQL("TEST")
+				jql.And(func() {
+					jql.Raw("project = OTHER")
+				})
+				return jql
+			},
+			expected: "project = OTHER",
+		},
 	}
 
 	for _, tc := range cases {
@@ -355,6 +417,10 @@ func TestHasProject(t *testing.T) {
 			expected: true,
 		},
 		{
+			input:    "project IS EMPTY",
+			expected: true,
+		},
+		{
 			input:    "project",
 			expected: false,
 		},
@@ -369,6 +435,62 @@ func TestHasProject(t *testing.T) {
 		{
 			input:    "projectType=\"classic\" AND type=\"Story\" AND assignee IS EMPTY",
 			expected: false,
+		},
+		{
+			input:    "myproject = TEST",
+			expected: false,
+		},
+		{
+			input:    "summary ~ \"my project\"",
+			expected: false,
+		},
+		{
+			input:    "summary ~ \"the project is late\" AND type=\"Bug\"",
+			expected: false,
+		},
+		{
+			input:    "summary ~ \"project in progress\"",
+			expected: false,
+		},
+		{
+			input:    "summary ~ \"project = done\"",
+			expected: false,
+		},
+		{
+			input:    "summary ~ \"project is empty by now\"",
+			expected: false,
+		},
+		{
+			input:    "summary ~ \"blocked on project\" AND project = TEST",
+			expected: true,
+		},
+		{
+			input:    "project=TEST",
+			expected: true,
+		},
+		{
+			input:    "project!=TEST",
+			expected: true,
+		},
+		{
+			input:    "project IS NOT EMPTY",
+			expected: true,
+		},
+		{
+			input:    "project = \"quoted = value\"",
+			expected: true,
+		},
+		{
+			input:    "project.property IS EMPTY",
+			expected: false,
+		},
+		{
+			input:    "summary ~ \"escaped \\\" project = x\"",
+			expected: false,
+		},
+		{
+			input:    "project\n=\nTEST",
+			expected: true,
 		},
 	}
 


### PR DESCRIPTION
POC for making the default project optional (#942, #611, #760, probably others). 

Not asking to merge immediately, just want to know if this direction is acceptable before cleaning up.

Today project is required and the answer is raw JQL (#420). This PR makes the following changes:

- `init --no-project` / `--no-board`, and init now asks instead of forcing it (backwards incompatible)
- no default project -> `issue list`/`epic list` span all projects
- create/clone/epic commands still require a project (prompt for -p)
- `issue create -p OTHER` resolves issue types live, so any project works per-command

Builds on the existing hasProjectFilter/Raw() code from #395 (rewrote the regex
as a tokenizer so `project` inside quotes isn't matched).
