### PR TITLE
feat: globalId for remote links

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,6 +450,9 @@ $ jira issue link remote
 
 # Pass required parameters to skip prompt
 $ jira issue link remote ISSUE-1 https://example.com "Example text"
+
+# Provide global ID to update an existing remote link when matched
+$ jira issue link remote ISSUE-1 https://example.com "Example text" --global-id "system=https://example.com&id=123"
 ```
 
 #### Unlink
@@ -667,7 +670,7 @@ $ jira sprint add SPRINT_ID ISSUE-1 ISSUE-2
 
 ### Releases
 
-Interact with releases (project versions).  
+Interact with releases (project versions).
 Ensure the [feature is enabled](https://support.atlassian.com/jira-software-cloud/docs/enable-releases-and-versions/) on your instance.
 
 #### List

--- a/internal/cmd/issue/link/remote/remote.go
+++ b/internal/cmd/issue/link/remote/remote.go
@@ -34,6 +34,8 @@ func NewCmdRemoteLink() *cobra.Command {
 		Run: remotelink,
 	}
 
+	cmd.Flags().String("global-id", "", "Global ID for create-or-update remote links")
+
 	return &cmd
 }
 
@@ -54,7 +56,7 @@ func remotelink(cmd *cobra.Command, args []string) {
 		s := cmdutil.Info("Creating remote web link for issue")
 		defer s.Stop()
 
-		return client.RemoteLinkIssue(lc.params.issueKey, lc.params.title, lc.params.url)
+		return client.RemoteLinkIssue(lc.params.issueKey, lc.params.title, lc.params.url, lc.params.globalID)
 	}()
 	cmdutil.ExitIfError(err)
 
@@ -73,6 +75,7 @@ type linkParams struct {
 	issueKey string
 	url      string
 	title    string
+	globalID string
 	debug    bool
 }
 
@@ -92,10 +95,14 @@ func parseArgsAndFlags(flags query.FlagParser, args []string, project string) *l
 	debug, err := flags.GetBool("debug")
 	cmdutil.ExitIfError(err)
 
+	globalID, err := flags.GetString("global-id")
+	cmdutil.ExitIfError(err)
+
 	return &linkParams{
 		issueKey: issueKey,
 		url:      url,
 		title:    title,
+		globalID: globalID,
 		debug:    debug,
 	}
 }

--- a/pkg/jira/issue.go
+++ b/pkg/jira/issue.go
@@ -422,6 +422,7 @@ func ifaceToADF(v interface{}) *adf.ADF {
 }
 
 type remotelinkRequest struct {
+	GlobalID     string `json:"globalId,omitempty"`
 	RemoteObject struct {
 		URL   string `json:"url"`
 		Title string `json:"title"`
@@ -429,8 +430,9 @@ type remotelinkRequest struct {
 }
 
 // RemoteLinkIssue adds a remote link to an issue using POST /issue/{issueId}/remotelink endpoint.
-func (c *Client) RemoteLinkIssue(issueID, title, url string) error {
+func (c *Client) RemoteLinkIssue(issueID, title, url, globalID string) error {
 	body, err := json.Marshal(remotelinkRequest{
+		GlobalID: globalID,
 		RemoteObject: struct {
 			URL   string `json:"url"`
 			Title string `json:"title"`

--- a/pkg/jira/issue_test.go
+++ b/pkg/jira/issue_test.go
@@ -1,6 +1,7 @@
 package jira
 
 import (
+	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -682,12 +683,18 @@ func TestGetField(t *testing.T) {
 
 func TestRemoteLinkIssue(t *testing.T) {
 	var unexpectedStatusCode bool
+	var body map[string]interface{}
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "/rest/api/2/issue/TEST-1/remotelink", r.URL.Path)
 		assert.Equal(t, http.MethodPost, r.Method)
 		assert.Equal(t, "application/json", r.Header.Get("Accept"))
 		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+
+		var reqBody map[string]interface{}
+		err := json.NewDecoder(r.Body).Decode(&reqBody)
+		assert.NoError(t, err)
+		body = reqBody
 
 		if unexpectedStatusCode {
 			w.WriteHeader(400)
@@ -699,13 +706,17 @@ func TestRemoteLinkIssue(t *testing.T) {
 
 	client := NewClient(Config{Server: server.URL}, WithTimeout(3*time.Second))
 
-	err := client.RemoteLinkIssue("TEST-1", "weblink title", "http://weblink.com")
+	err := client.RemoteLinkIssue("TEST-1", "weblink title", "http://weblink.com", "system=http://www.mycompany.com/support&id=1")
 	assert.NoError(t, err)
+	assert.Equal(t, "system=http://www.mycompany.com/support&id=1", body["globalId"])
+	assert.Equal(t, map[string]interface{}{"title": "weblink title", "url": "http://weblink.com"}, body["object"])
 
 	unexpectedStatusCode = true
 
-	err = client.RemoteLinkIssue("TEST-1", "weblink title", "https://weblink.com")
+	err = client.RemoteLinkIssue("TEST-1", "weblink title", "https://weblink.com", "")
 	assert.Error(t, &ErrUnexpectedResponse{}, err)
+	_, hasGlobalID := body["globalId"]
+	assert.False(t, hasGlobalID)
 }
 
 func TestWatchIssue(t *testing.T) {


### PR DESCRIPTION
The issue remote link API supports a globalID parameter that allows for updating an existing remote link: https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-remote-links/#api-rest-api-3-issue-issueidorkey-remotelink-post

This also makes requests idempotent, which is critical when using the CLI in a CI environment where you want to avoid creating duplicate issue links.