### PR TITLE
fix: Epic add/remove shouldn't require admin permission

### DIFF
--- a/internal/cmd/epic/add/add.go
+++ b/internal/cmd/epic/add/add.go
@@ -21,7 +21,7 @@ const (
 
 // NewCmdAdd is an add command.
 func NewCmdAdd() *cobra.Command {
-	return &cobra.Command{
+	cmd := cobra.Command{
 		Use:     "add EPIC-KEY ISSUE-1 [...ISSUE-N]",
 		Short:   "Add issues to an epic",
 		Long:    helpText,
@@ -33,6 +33,14 @@ func NewCmdAdd() *cobra.Command {
 		},
 		Run: add,
 	}
+
+	setFlags(&cmd)
+
+	return &cmd
+}
+
+func setFlags(cmd *cobra.Command) {
+	cmd.Flags().Bool("skip-notify", false, "Do not notify watchers when adding issues to the epic")
 }
 
 func add(cmd *cobra.Command, args []string) {
@@ -81,7 +89,7 @@ func add(cmd *cobra.Command, args []string) {
 		// There is no way to send bulk update requests as of now, so we need to send these requests
 		// in a loop. We will print failed requests with exit code 1 at the end if there are any.
 		for _, iss := range params.issues {
-			if err := client.Edit(iss, &jira.EditRequest{ParentIssueKey: params.epicKey, SkipNotify: true}); err != nil {
+			if err := client.Edit(iss, &jira.EditRequest{ParentIssueKey: params.epicKey, SkipNotify: params.skipNotify}); err != nil {
 				msg := fmt.Sprintf("\n  - %s: %s", iss, cmdutil.NormalizeJiraError(err.Error()))
 				failed.WriteString(msg)
 			} else {
@@ -127,13 +135,17 @@ func parseFlags(flags query.FlagParser, args []string, project string) *addParam
 		}
 	}
 
+	skipNotify, err := flags.GetBool("skip-notify")
+	cmdutil.ExitIfError(err)
+
 	debug, err := flags.GetBool("debug")
 	cmdutil.ExitIfError(err)
 
 	return &addParams{
-		epicKey: epicKey,
-		issues:  issues,
-		debug:   debug,
+		epicKey:    epicKey,
+		issues:     issues,
+		skipNotify: skipNotify,
+		debug:      debug,
 	}
 }
 
@@ -162,7 +174,8 @@ func getQuestions(params *addParams) []*survey.Question {
 }
 
 type addParams struct {
-	epicKey string
-	issues  []string
-	debug   bool
+	epicKey    string
+	issues     []string
+	skipNotify bool
+	debug      bool
 }

--- a/internal/cmd/epic/remove/remove.go
+++ b/internal/cmd/epic/remove/remove.go
@@ -21,7 +21,7 @@ const (
 
 // NewCmdRemove is a remove command.
 func NewCmdRemove() *cobra.Command {
-	return &cobra.Command{
+	cmd := cobra.Command{
 		Use:     "remove ISSUE-1 [...ISSUE-N]",
 		Short:   "Remove/unassign epic from issues",
 		Long:    helpText,
@@ -32,6 +32,14 @@ func NewCmdRemove() *cobra.Command {
 		},
 		Run: remove,
 	}
+
+	setFlags(&cmd)
+
+	return &cmd
+}
+
+func setFlags(cmd *cobra.Command) {
+	cmd.Flags().Bool("skip-notify", false, "Do not notify watchers when removing epic from issues")
 }
 
 func remove(cmd *cobra.Command, args []string) {
@@ -72,7 +80,7 @@ func remove(cmd *cobra.Command, args []string) {
 		}
 
 		for _, iss := range params.issues {
-			if err := client.Edit(iss, &jira.EditRequest{ParentIssueKey: jira.AssigneeNone, SkipNotify: true}); err != nil {
+			if err := client.Edit(iss, &jira.EditRequest{ParentIssueKey: jira.AssigneeNone, SkipNotify: params.skipNotify}); err != nil {
 				msg := fmt.Sprintf("\n  - %s: %s", iss, cmdutil.NormalizeJiraError(err.Error()))
 				failed.WriteString(msg)
 			} else {
@@ -107,12 +115,16 @@ func parseFlags(flags query.FlagParser, args []string, project string) *removePa
 		issues = append(issues, cmdutil.GetJiraIssueKey(project, iss))
 	}
 
+	skipNotify, err := flags.GetBool("skip-notify")
+	cmdutil.ExitIfError(err)
+
 	debug, err := flags.GetBool("debug")
 	cmdutil.ExitIfError(err)
 
 	return &removeParams{
-		issues: issues,
-		debug:  debug,
+		issues:     issues,
+		skipNotify: skipNotify,
+		debug:      debug,
 	}
 }
 
@@ -134,6 +146,7 @@ func getQuestions(params *removeParams) []*survey.Question {
 }
 
 type removeParams struct {
-	issues []string
-	debug  bool
+	issues     []string
+	skipNotify bool
+	debug      bool
 }

--- a/pkg/jira/edit_test.go
+++ b/pkg/jira/edit_test.go
@@ -1,0 +1,32 @@
+package jira
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEdit(t *testing.T) {
+	var expectedQueryParams string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "PUT", r.Method)
+		assert.Equal(t, "/rest/api/2/issue/TEST-1", r.URL.Path)
+		assert.Equal(t, expectedQueryParams, r.URL.RawQuery)
+
+		w.WriteHeader(204)
+	}))
+	defer server.Close()
+
+	client := NewClient(Config{Server: server.URL}, WithTimeout(3*time.Second))
+
+	err := client.Edit("TEST-1", &EditRequest{ParentIssueKey: "EPIC-1"})
+	assert.NoError(t, err)
+
+	expectedQueryParams = "notifyUsers=false"
+	err = client.Edit("TEST-1", &EditRequest{ParentIssueKey: "EPIC-1", SkipNotify: true})
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
Fixes #959 

This PR makes `--skip-notify` an opt-in flag for epic add and remove instead of always suppressing notifications.

- epic add / epic remove now register a `--skip-notify` flag (default false), matching the existing opt-in pattern already used by issue edit.
- The flag only affects next-gen projects, where the Edit call path is used; the classic project path (EpicIssuesAdd/EpicIssuesRemove) is unchanged.

This is a slight behavior change: previously epic add/epic remove on next-gen projects never notified watchers by default. Now watchers will be notified unless `--skip-notify` is passed. This is the required trade-off as it doesn't make sense to require admin permission for epic operations.