### PR TITLE
fix: convert Markdown when editing server issues

### DIFF
--- a/internal/cmd/issue/edit/edit.go
+++ b/internal/cmd/issue/edit/edit.go
@@ -107,11 +107,6 @@ func edit(cmd *cobra.Command, args []string) {
 		}
 		params.body = string(b)
 	}
-	// Keep body as is if there were no changes.
-	if params.body != "" && params.body == originalBody {
-		params.body = ""
-	}
-
 	labels := params.labels
 	labels = append(labels, issue.Fields.Labels...)
 
@@ -137,10 +132,7 @@ func edit(cmd *cobra.Command, args []string) {
 		s := cmdutil.Info("Updating an issue...")
 		defer s.Stop()
 
-		body := params.body
-		if isADF {
-			body = md.ToJiraMD(body)
-		}
+		body := bodyForEdit(params.body, originalBody, isADF)
 
 		parent := cmdutil.GetJiraIssueKey(project, params.parentIssueKey)
 		if parent == "" && issue.Fields.Parent != nil {
@@ -176,6 +168,56 @@ func edit(cmd *cobra.Command, args []string) {
 		err := cmdutil.Navigate(server, params.issueKey)
 		cmdutil.ExitIfError(err)
 	}
+}
+
+func bodyForEdit(body, originalBody string, isADF bool) string {
+	if body == "" || body == originalBody {
+		return ""
+	}
+	if !isADF && hasJiraWikiMarkup(body) {
+		return body
+	}
+	return md.ToJiraMD(body)
+}
+
+func hasJiraWikiMarkup(body string) bool {
+	inFencedCode := false
+	for line := range strings.SplitSeq(body, "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "```") {
+			inFencedCode = !inFencedCode
+			continue
+		}
+		if !inFencedCode && (isJiraWikiBlock(line) || hasJiraWikiLink(line)) {
+			return true
+		}
+	}
+	return false
+}
+
+func isJiraWikiBlock(line string) bool {
+	if len(line) >= 3 && line[0] == 'h' && line[1] >= '1' && line[1] <= '6' && line[2] == '.' {
+		return true
+	}
+	if strings.HasPrefix(line, "bq.") || strings.HasPrefix(line, "||") {
+		return true
+	}
+	for _, macro := range []string{"{code", "{noformat", "{panel", "{quote"} {
+		if strings.HasPrefix(line, macro+"}") || strings.HasPrefix(line, macro+":") {
+			return true
+		}
+	}
+	return false
+}
+
+func hasJiraWikiLink(line string) bool {
+	open := strings.IndexByte(line, '[')
+	if open == -1 {
+		return false
+	}
+	pipe := strings.IndexByte(line[open+1:], '|')
+	close := strings.IndexByte(line[open+1:], ']')
+	return pipe >= 0 && close > pipe
 }
 
 func getAnswers(params *editParams, issue *jira.Issue) {

--- a/internal/cmd/issue/edit/edit_test.go
+++ b/internal/cmd/issue/edit/edit_test.go
@@ -1,0 +1,59 @@
+package edit
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBodyForEdit(t *testing.T) {
+	t.Parallel()
+
+	markdown := "## Objective\n\n- item\n- [ ] criterion\n"
+	jiraWiki := "h2. Objective\n\n* item\n* [ ] criterion\n"
+	jiraWikiInline := "*important* [documentation|https://example.com]"
+	converted := "h2. Objective\n* item\n* \\[ \\] criterion\n\n"
+
+	tests := []struct {
+		name         string
+		body         string
+		originalBody string
+		isADF        bool
+		expected     string
+	}{
+		{
+			name:     "converts Markdown for Jira Server",
+			body:     markdown,
+			expected: converted,
+		},
+		{
+			name:     "continues converting Markdown for Jira Cloud",
+			body:     markdown,
+			isADF:    true,
+			expected: converted,
+		},
+		{
+			name:     "preserves Jira Wiki Markup for Jira Server",
+			body:     jiraWiki,
+			expected: jiraWiki,
+		},
+		{
+			name:     "preserves inline Jira Wiki Markup for Jira Server",
+			body:     jiraWikiInline,
+			expected: jiraWikiInline,
+		},
+		{
+			name:         "omits an unchanged Jira Server description",
+			body:         jiraWiki,
+			originalBody: jiraWiki,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tt.expected, bodyForEdit(tt.body, tt.originalBody, tt.isADF))
+		})
+	}
+}


### PR DESCRIPTION
**What does this PR solve?**

Jira Server returns issue descriptions as strings. During `jira issue edit`, Markdown conversion was only applied when the existing description was ADF, so CommonMark submitted through `--body`, stdin, or the editor was sent unchanged to Jira Server. Constructs such as `## Objective`, bullet lists, and textual checkboxes were consequently interpreted incorrectly as Jira Wiki Markup.

This change converts edited CommonMark descriptions to Jira Wiki Markup for Jira Server as well. It keeps the existing Jira Cloud/ADF behavior, omits unchanged descriptions from the update, and preserves input that is already recognizable Jira Wiki Markup to avoid double conversion.

**How to test?**

```sh
go test ./internal/cmd/issue/edit
PATH="$(go env GOPATH)/bin:$PATH" make lint
make test
```

The new tests cover:

- headings, bullet lists, and textual checkboxes on Jira Server;
- the existing Jira Cloud/ADF conversion path;
- Jira Wiki Markup preservation;
- unchanged Jira Server descriptions.

**Checklist**

- [x] I have added/updated enough tests related to my changes.
- [ ] I have also manually checked and verified that my changes fix the issue and doesn't break any other functionalities.
- [x] My changes are backwards compatible.
