### PR TITLE
fix(epic): migrate tree search to /search/jql (cloud 410 Gone)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,5 @@
 on:
+  workflow_dispatch:
   pull_request:
     types: [opened, synchronize, reopened]
   release:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,7 +2,6 @@ name: Publish a Docker image
 run-name: Docker image for ${{ github.ref_name }}
 
 on:
-  workflow_dispatch:
   release:
     types: [published, prereleased]
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,65 @@
+name: Release
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  release:
+    name: Semantic Release
+    runs-on: ubuntu-latest
+    outputs:
+      new_release_published: ${{ steps.semantic.outputs.new_release_published }}
+      new_release_version: ${{ steps.semantic.outputs.new_release_version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Semantic Release
+        id: semantic
+        uses: cycjimmy/semantic-release-action@v4
+        with:
+          extra_plugins: |
+            @semantic-release/changelog
+            @semantic-release/git
+            conventional-changelog-conventionalcommits
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  goreleaser:
+    name: Build & Upload Binaries
+    needs: release
+    if: needs.release.outputs.new_release_published == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: v${{ needs.release.outputs.new_release_version }}
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '^1.25.6'
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          version: '~> v2'
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: v${{ needs.release.outputs.new_release_version }}
+          ref: ${{ needs.release.outputs.new_release_version }}
 
       - name: Setup Go
         uses: actions/setup-go@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,11 @@ name: Release
 on:
   push:
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Existing tag to build and upload binaries for (repairs a release missing assets)'
+        required: true
 
 permissions:
   contents: write
@@ -12,6 +17,7 @@ permissions:
 jobs:
   release:
     name: Semantic Release
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     outputs:
       new_release_published: ${{ steps.semantic.outputs.new_release_published }}
@@ -42,19 +48,23 @@ jobs:
   goreleaser:
     name: Build & Upload Binaries
     needs: release
-    if: needs.release.outputs.new_release_published == 'true'
+    if: |
+      always() && (
+        github.event_name == 'workflow_dispatch' ||
+        (needs.release.result == 'success' && needs.release.outputs.new_release_published == 'true')
+      )
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ needs.release.outputs.new_release_version }}
+          ref: ${{ inputs.tag || needs.release.outputs.new_release_version }}
 
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '^1.25.6'
+          go-version: '^1.26.5'
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6

--- a/.github/workflows/upstream-watch.yml
+++ b/.github/workflows/upstream-watch.yml
@@ -1,0 +1,126 @@
+name: Upstream Watch
+
+on:
+  schedule:
+    - cron: '0 7 * * *'  # daily at 07:00 UTC
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  issues: write
+
+env:
+  UPSTREAM: ankitpokhrel/jira-cli
+
+jobs:
+  check:
+    name: Check upstream activity
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Add upstream remote
+        run: |
+          git remote add upstream "https://github.com/${{ env.UPSTREAM }}.git"
+          git fetch upstream main --tags --quiet
+
+      - name: Detect new commits
+        id: commits
+        run: |
+          BASE=$(git merge-base HEAD upstream/main 2>/dev/null || echo "")
+          UPSTREAM_HEAD=$(git rev-parse upstream/main)
+
+          if [ -z "$BASE" ]; then
+            echo "count=unknown" >> "$GITHUB_OUTPUT"
+            echo "summary=Could not determine merge-base" >> "$GITHUB_OUTPUT"
+          elif [ "$BASE" = "$UPSTREAM_HEAD" ]; then
+            echo "count=0" >> "$GITHUB_OUTPUT"
+            echo "summary=Up to date with upstream" >> "$GITHUB_OUTPUT"
+          else
+            COUNT=$(git rev-list --count "$BASE".."$UPSTREAM_HEAD")
+            LOG=$(git log --oneline "$BASE".."$UPSTREAM_HEAD" | head -20)
+            echo "count=$COUNT" >> "$GITHUB_OUTPUT"
+
+            # write multi-line log to output
+            {
+              echo "log<<LOGEOF"
+              echo "$LOG"
+              echo "LOGEOF"
+            } >> "$GITHUB_OUTPUT"
+            echo "summary=$COUNT new commit(s) on upstream main" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Detect new releases
+        id: releases
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # get latest upstream release tag
+          LATEST=$(gh api "repos/${{ env.UPSTREAM }}/releases/latest" --jq '.tag_name' 2>/dev/null || echo "")
+
+          if [ -z "$LATEST" ]; then
+            echo "new=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # check if we have this tag as an ancestor
+          if git merge-base --is-ancestor "$LATEST" HEAD 2>/dev/null; then
+            echo "new=false" >> "$GITHUB_OUTPUT"
+          else
+            RELEASE_DATE=$(gh api "repos/${{ env.UPSTREAM }}/releases/latest" --jq '.published_at')
+            echo "new=true" >> "$GITHUB_OUTPUT"
+            echo "tag=$LATEST" >> "$GITHUB_OUTPUT"
+            echo "date=$RELEASE_DATE" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create or update tracking issue
+        if: steps.commits.outputs.count != '0' || steps.releases.outputs.new == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TITLE="upstream: new activity detected"
+          LABEL="upstream-watch"
+
+          # ensure label exists
+          gh label create "$LABEL" --description "Automated upstream tracking" --color "0E8A16" 2>/dev/null || true
+
+          # build issue body
+          BODY="## Upstream Activity Report
+
+          **Checked**: $(date -u '+%Y-%m-%d %H:%M UTC')
+          **Upstream**: [${{ env.UPSTREAM }}](https://github.com/${{ env.UPSTREAM }})
+
+          ### Commits
+          ${{ steps.commits.outputs.summary }}
+          "
+
+          if [ "${{ steps.commits.outputs.count }}" != "0" ] && [ "${{ steps.commits.outputs.count }}" != "unknown" ]; then
+            BODY="$BODY
+          \`\`\`
+          ${{ steps.commits.outputs.log }}
+          \`\`\`
+          "
+          fi
+
+          if [ "${{ steps.releases.outputs.new }}" = "true" ]; then
+            BODY="$BODY
+          ### New Release
+          **${{ steps.releases.outputs.tag }}** (published ${{ steps.releases.outputs.date }})
+          https://github.com/${{ env.UPSTREAM }}/releases/tag/${{ steps.releases.outputs.tag }}
+          "
+          fi
+
+          BODY="$BODY
+          ---
+          *Close this issue after syncing. A new one will be created on next detection.*"
+
+          # close any existing open issue with the label, then create fresh
+          EXISTING=$(gh issue list --label "$LABEL" --state open --json number --jq '.[0].number' 2>/dev/null || echo "")
+          if [ -n "$EXISTING" ]; then
+            gh issue close "$EXISTING" --comment "Superseded by new check."
+          fi
+
+          gh issue create --title "$TITLE" --body "$BODY" --label "$LABEL"

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.out
 *.swp
 /*.json
+!.releaserc.json
 
 .DS_Store
 .idea/

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ vendor/
 /.gocache
 
 .vscode/
+.playwright-mcp/
+.sisyphus/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,7 +5,7 @@ release:
   prerelease: auto
   name_template: "v{{.Version}}"
   draft: false
-  mode: "keep-existing"
+  mode: "append"
 
 before:
   hooks:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -4,7 +4,7 @@ project_name: jira
 release:
   prerelease: auto
   name_template: "v{{.Version}}"
-  draft: true
+  draft: false
   mode: "keep-existing"
 
 before:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,7 +3,7 @@ project_name: jira
 
 release:
   prerelease: auto
-  name_template: "v{{.Version}}"
+  name_template: "{{.Version}}"
   draft: false
   mode: "append"
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -13,7 +13,7 @@ before:
 
 builds:
   - <<: &build_defaults
-      binary: bin/jira
+      binary: jira
       main: ./cmd/jira
       ldflags:
         - -s -w
@@ -42,7 +42,7 @@ archives:
     <<: &archive_defaults
       name_template: >-
         {{ .ProjectName }}_{{ .Version }}_{{- if eq .Os "darwin" }}macOS{{- else }}{{ .Os }}{{- end }}_{{- if eq .Arch "amd64" }}x86_64{{- else if eq .Arch "386" }}i386{{- else }}{{ .Arch }}{{- end }}{{- if .Arm }}v{{ .Arm }}{{ end -}}
-    wrap_in_directory: true
+    wrap_in_directory: false
     formats: [tar.gz]
     files:
       - LICENSE

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,4 +1,5 @@
 {
+  "tagFormat": "${version}",
   "branches": ["main"],
   "plugins": [
     ["@semantic-release/commit-analyzer", {

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,52 @@
+{
+  "branches": ["main"],
+  "plugins": [
+    ["@semantic-release/commit-analyzer", {
+      "preset": "conventionalcommits",
+      "releaseRules": [
+        { "breaking": true, "release": "major" },
+        { "type": "break", "release": "major" },
+        { "type": "feat", "release": "minor" },
+        { "type": "fix", "release": "patch" },
+        { "type": "perf", "release": "patch" },
+        { "type": "revert", "release": "patch" },
+        { "type": "deps", "release": "patch" },
+        { "type": "refactor", "release": false },
+        { "type": "style", "release": false },
+        { "type": "docs", "release": false },
+        { "type": "build", "release": false },
+        { "type": "ci", "release": false },
+        { "type": "test", "release": false },
+        { "type": "chore", "release": false }
+      ]
+    }],
+    ["@semantic-release/release-notes-generator", {
+      "preset": "conventionalcommits",
+      "presetConfig": {
+        "types": [
+          { "type": "feat", "section": "Features" },
+          { "type": "fix", "section": "Bug Fixes" },
+          { "type": "perf", "section": "Performance" },
+          { "type": "revert", "section": "Reverts" },
+          { "type": "deps", "section": "Dependencies" },
+          { "type": "break", "section": "Breaking Changes" },
+          { "type": "refactor", "section": "Code Refactoring", "hidden": true },
+          { "type": "style", "section": "Styles", "hidden": true },
+          { "type": "docs", "section": "Documentation", "hidden": true },
+          { "type": "build", "section": "Build System", "hidden": true },
+          { "type": "ci", "section": "CI", "hidden": true },
+          { "type": "test", "section": "Tests", "hidden": true },
+          { "type": "chore", "section": "Miscellaneous", "hidden": true }
+        ]
+      }
+    }],
+    ["@semantic-release/changelog", {
+      "changelogFile": "CHANGELOG.md"
+    }],
+    "@semantic-release/github",
+    ["@semantic-release/git", {
+      "assets": ["CHANGELOG.md"],
+      "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+    }]
+  ]
+}

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -44,7 +44,12 @@
     ["@semantic-release/changelog", {
       "changelogFile": "CHANGELOG.md"
     }],
-    "@semantic-release/github",
+    ["@semantic-release/github", {
+      "successComment": false,
+      "failComment": false,
+      "failTitle": false,
+      "releasedLabels": false
+    }],
     ["@semantic-release/git", {
       "assets": ["CHANGELOG.md"],
       "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.9.0](https://github.com/hackerh3/jira-cli/compare/1.8.1...1.9.0) (2026-05-13)
+
+### Features
+
+* **cmd:** add epic tree command ([#11](https://github.com/hackerh3/jira-cli/issues/11)) ([a589007](https://github.com/hackerh3/jira-cli/commit/a589007d085b9962af41d4849fc24ce81fe39648))
+
 ## [1.8.1](https://github.com/hackerh3/jira-cli/compare/1.8.0...1.8.1) (2026-05-12)
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.10.0](https://github.com/hackerh3/jira-cli/compare/1.9.0...1.10.0) (2026-05-13)
+
+### Features
+
+* **view:** add --compact flag for LLM-friendly output ([#15](https://github.com/hackerh3/jira-cli/issues/15)) ([7cb397f](https://github.com/hackerh3/jira-cli/commit/7cb397f1efc100bd935e502e5baf2e37fc5e2e9a)), closes [#6](https://github.com/hackerh3/jira-cli/issues/6)
+
 ## [1.9.0](https://github.com/hackerh3/jira-cli/compare/1.8.1...1.9.0) (2026-05-13)
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## [1.11.0](https://github.com/hackerh3/jira-cli/compare/1.10.0...1.11.0) (2026-05-13)
+
+### Features
+
+* **cmd:** warn on duplicate subtask type during issue creation ([#12](https://github.com/hackerh3/jira-cli/issues/12)) ([79a0dc2](https://github.com/hackerh3/jira-cli/commit/79a0dc251ee512bcb150367ddfc028cdbe8ef633))
+
+### Bug Fixes
+
+* **comment:** move markdown conversion to command layer, add --raw flag ([#14](https://github.com/hackerh3/jira-cli/issues/14)) ([e34a03e](https://github.com/hackerh3/jira-cli/commit/e34a03ec0b17dfca882cfe3fcbc619508de9f51f)), closes [#13](https://github.com/hackerh3/jira-cli/issues/13)
+
 ## [1.10.0](https://github.com/hackerh3/jira-cli/compare/1.9.0...1.10.0) (2026-05-13)
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+## [1.6.0](https://github.com/hackerh3/jira-cli/releases/tag/v1.6.0) (2026-05-11)
+
+### Features
+
+* **jira:** add move-project command for moving issues between projects ([e4b8e97](https://github.com/hackerh3/jira-cli/commit/e4b8e97))
+* **jira:** add move-project API via JSP form wizard ([53dd911](https://github.com/hackerh3/jira-cli/commit/53dd911))
+* **jira:** add JSP session client with cookie jar ([70713a3](https://github.com/hackerh3/jira-cli/commit/70713a3))
+* **api:** add GetIssueComment and UpdateIssueComment ([71f6b5a](https://github.com/hackerh3/jira-cli/commit/71f6b5a))
+* **cmd:** add comment edit subcommand ([e27710d](https://github.com/hackerh3/jira-cli/commit/e27710d))
+
+### Bug Fixes
+
+* **jira:** detect broken workflow and suggest move-project workaround ([8b17182](https://github.com/hackerh3/jira-cli/commit/8b17182))
+* **jira:** confirm step needs confirm=true + smart key extraction ([e28a8b8](https://github.com/hackerh3/jira-cli/commit/e28a8b8))
+* resolve golangci-lint failures in move-project code ([0ec114d](https://github.com/hackerh3/jira-cli/commit/0ec114d))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
-## [1.6.0](https://github.com/hackerh3/jira-cli/releases/tag/v1.6.0) (2026-05-11)
+All notable changes to the hackerh3/jira-cli fork are documented here.
+This fork uses versionless tags (e.g. `1.8.0`) to distinguish from upstream `v1.x.0`.
+
+## [1.8.0](https://github.com/hackerh3/jira-cli/releases/tag/1.8.0) (2026-05-12)
+
+First release under the new versioning scheme. Incorporates all upstream
+changes through v1.7.0 plus fork-exclusive features.
 
 ### Features
 
@@ -9,9 +15,17 @@
 * **jira:** add JSP session client with cookie jar ([70713a3](https://github.com/hackerh3/jira-cli/commit/70713a3))
 * **api:** add GetIssueComment and UpdateIssueComment ([71f6b5a](https://github.com/hackerh3/jira-cli/commit/71f6b5a))
 * **cmd:** add comment edit subcommand ([e27710d](https://github.com/hackerh3/jira-cli/commit/e27710d))
+* **jira:** add Deviniti Issue Template support for issue creation ([d1a9bd2](https://github.com/hackerh3/jira-cli/commit/d1a9bd2))
 
 ### Bug Fixes
 
 * **jira:** detect broken workflow and suggest move-project workaround ([8b17182](https://github.com/hackerh3/jira-cli/commit/8b17182))
 * **jira:** confirm step needs confirm=true + smart key extraction ([e28a8b8](https://github.com/hackerh3/jira-cli/commit/e28a8b8))
 * resolve golangci-lint failures in move-project code ([0ec114d](https://github.com/hackerh3/jira-cli/commit/0ec114d))
+* add plain output for project list ([e58dbc4](https://github.com/hackerh3/jira-cli/commit/e58dbc4))
+* preserve raw JQL ordering ([3061f88](https://github.com/hackerh3/jira-cli/commit/3061f88))
+
+### CI/CD
+
+* semantic-release pipeline with goreleaser cross-compilation
+* versionless tag format (`1.x.0`) to avoid upstream collision

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.8.1](https://github.com/hackerh3/jira-cli/compare/1.8.0...1.8.1) (2026-05-12)
+
+### Bug Fixes
+
+* **ci:** flatten archive layout and build all platforms ([5cf0eca](https://github.com/hackerh3/jira-cli/commit/5cf0ecab63fc9b70358ae0f7c99bd4b9d6eac2a2))
+
 # Changelog
 
 All notable changes to the hackerh3/jira-cli fork are documented here.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## [1.11.1](https://github.com/hackerh3/jira-cli/compare/1.11.0...1.11.1) (2026-08-05)
+
 ## [1.11.0](https://github.com/hackerh3/jira-cli/compare/1.10.0...1.11.0) (2026-05-13)
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 <div align="center">
-    <a href="#">
-        <img alt="stargazers over time" src="https://stars.medv.io/ankitpokhrel/jira-cli.svg" />
-    </a>
-    <h1 align="center">JiraCLI</h1>
+    <h1 align="center">JiraCLI (hackerh3 fork)</h1>
 </div>
+
+> **Fork notice** — This is a maintained fork of [ankitpokhrel/jira-cli](https://github.com/ankitpokhrel/jira-cli).
+> It adds move-project, comment editing, Deviniti template support, and broken-workflow detection.
+> Releases use versionless tags (`1.8.0`) to avoid collision with upstream (`v1.8.0`).
+> Install from **this repo's** [releases page](https://github.com/hackerh3/jira-cli/releases).
 
 <div>
     <p align="center">
@@ -69,19 +71,19 @@ nature of the data. Yet, we've attempted to make the experience as similar as po
 | **Jira**  | <a href="#"><img alt="Jira Cloud" src="https://img.shields.io/badge/Jira Cloud-%E2%9C%93-dark--green?logo=jira&style=flat-square" /></a><a href="#"><img alt="Jira Server" src="https://img.shields.io/badge/Jira Server-%E2%9C%93-dark--green?logo=jira&style=flat-square" /></a> |
 
 ## Installation
-`jira-cli` is available as a downloadable packaged binary for Linux, macOS, and Windows from the [releases page](https://github.com/ankitpokhrel/jira-cli/releases).
+`jira-cli` is available as a downloadable binary for Linux, macOS, and Windows from the [releases page](https://github.com/hackerh3/jira-cli/releases).
 
-You can use Docker to quickly try out `jira-cli`.
+> [!WARNING]
+> Do **not** install via `brew install jira-cli` or the upstream releases page — those ship the
+> upstream binary without fork features. Use the link above or `go install` from this repo.
+
+You can also build from source:
 
 ```sh
-docker run -it --rm ghcr.io/ankitpokhrel/jira-cli:latest
+# Build from this fork
+git clone https://github.com/hackerh3/jira-cli.git && cd jira-cli
+make deps install
 ```
-
-Follow the [installation guide](https://github.com/ankitpokhrel/jira-cli/wiki/Installation) for other installation methods like `Homebrew`, `Nix`, etc.
-
-<a href="https://repology.org/project/jira-cli-go/versions">
-    <img src="https://repology.org/badge/vertical-allrepos/jira-cli-go.svg" alt="Packaging status">
-</a>
 
 ## Getting started
 
@@ -807,7 +809,7 @@ Please [open a discussion](https://github.com/ankitpokhrel/jira-cli/discussions/
 ## Development
 1. Clone the repo.
    ```sh
-   git clone git@github.com:ankitpokhrel/jira-cli.git
+   git clone git@github.com:hackerh3/jira-cli.git
    ```
 
 2. Optional: If you want to run a Jira instance locally, you can use the following make recipe.

--- a/UPSTREAM.md
+++ b/UPSTREAM.md
@@ -1,0 +1,48 @@
+# Upstream Sync Tracking
+
+Which fork release contains which state of [ankitpokhrel/jira-cli](https://github.com/ankitpokhrel/jira-cli).
+
+Tag namespaces are deliberately distinct: fork releases are **versionless** (`1.11.0`), upstream
+releases carry the `v` prefix (`v1.7.0`). They never collide.
+
+Upstream has not cut a release since **v1.7.0 (2025-08-30)**, so upstream state is expressed as
+`v1.7.0+N`, where N counts upstream commits merged past that tag.
+
+## Matrix
+
+| Fork release | Date | Upstream base commit | Upstream state | Notes |
+|---|---|---|---|---|
+| unreleased (`main`) | 2026-08-03 | `1f3b2ef` | v1.7.0+15 | UTF-8 wiki parser fix, JQL preserved with `--show-all-issues`, epic add/remove without admin, `--plain` implies table, Go 1.26, golangci-lint 2.12 |
+| 1.11.0 | 2026-05-13 | `396933d` | v1.7.0+6 | |
+| 1.10.0 | 2026-05-13 | `396933d` | v1.7.0+6 | |
+| 1.9.0 | 2026-05-13 | `396933d` | v1.7.0+6 | |
+| 1.8.1 | 2026-05-12 | `396933d` | v1.7.0+6 | |
+| 1.8.0 | 2026-05-12 | `396933d` | v1.7.0+6 | first tracked fork release |
+
+`396933d` = `fix: Autocomplete should work regardless of token (#939)`
+`1f3b2ef` = `fix: Preserve jql filter when using --show-all-issues (#1014)`
+
+## Regenerating
+
+```sh
+git remote add upstream https://github.com/ankitpokhrel/jira-cli.git   # once
+git fetch upstream --tags
+
+for t in $(git tag --list --sort=creatordate | grep -vE '^v') main; do
+  mb=$(git merge-base "$t" upstream/main)
+  printf "%-8s %s  v1.7.0+%s  %s\n" \
+    "$t" "$(git rev-parse --short "$mb")" \
+    "$(git rev-list --count v1.7.0.."$mb")" \
+    "$(git log -1 --format=%ad --date=short "$t")"
+done
+```
+
+## Checking drift
+
+```sh
+git fetch upstream
+git rev-list --left-right --count upstream/main...main   # left = commits we are behind
+git log --oneline main..upstream/main
+```
+
+`.github/workflows/upstream-watch.yml` runs this daily and opens a tracking issue.

--- a/internal/cmd/epic/epic.go
+++ b/internal/cmd/epic/epic.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ankitpokhrel/jira-cli/internal/cmd/epic/create"
 	"github.com/ankitpokhrel/jira-cli/internal/cmd/epic/list"
 	"github.com/ankitpokhrel/jira-cli/internal/cmd/epic/remove"
+	"github.com/ankitpokhrel/jira-cli/internal/cmd/epic/tree"
 )
 
 const helpText = `Epic manage epics in a given project. See available commands below.`
@@ -26,11 +27,13 @@ func NewCmdEpic() *cobra.Command {
 	cc := create.NewCmdCreate()
 	ac := add.NewCmdAdd()
 	rc := remove.NewCmdRemove()
+	tc := tree.NewCmdTree()
 
-	cmd.AddCommand(lc, cc, ac, rc)
+	cmd.AddCommand(lc, cc, ac, rc, tc)
 
 	list.SetFlags(lc)
 	create.SetFlags(cc)
+	tree.SetFlags(tc)
 
 	return &cmd
 }

--- a/internal/cmd/epic/tree/tree.go
+++ b/internal/cmd/epic/tree/tree.go
@@ -1,0 +1,209 @@
+package tree
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/fatih/color"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/ankitpokhrel/jira-cli/api"
+	"github.com/ankitpokhrel/jira-cli/internal/cmdutil"
+	"github.com/ankitpokhrel/jira-cli/pkg/jira"
+)
+
+var (
+	connector    = color.New(color.Faint).SprintFunc()
+	keyStyle     = color.New(color.FgCyan, color.Bold).SprintFunc()
+	epicKeyStyle = color.New(color.FgCyan, color.Bold, color.Underline).SprintFunc()
+	doneStyle    = color.New(color.FgGreen).SprintFunc()
+	activeStyle  = color.New(color.FgYellow).SprintFunc()
+	blockedStyle = color.New(color.FgRed).SprintFunc()
+	dimStyle     = color.New(color.Faint).SprintFunc()
+)
+
+const (
+	helpText = `Tree displays the full issue hierarchy under an epic.
+
+Shows the epic at root level, its child issues on the first level,
+and their subtasks on the second level.`
+
+	examples = `# Display epic hierarchy as a tree
+$ jira epic tree EPIC-1
+
+# Display as a flat table
+$ jira epic tree EPIC-1 --plain
+
+# Display as raw JSON
+$ jira epic tree EPIC-1 --raw
+
+# Display as a flat table without headers
+$ jira epic tree EPIC-1 --plain --no-headers`
+)
+
+// NewCmdTree is a tree command.
+func NewCmdTree() *cobra.Command {
+	return &cobra.Command{
+		Use:     "tree EPIC-KEY",
+		Short:   "Display full issue hierarchy under an epic",
+		Long:    helpText,
+		Example: examples,
+		Annotations: map[string]string{
+			"help:args": "EPIC-KEY\tKey for the issue of type epic, eg: ISSUE-1",
+		},
+		Args: cobra.ExactArgs(1),
+		Run:  run,
+	}
+}
+
+// SetFlags sets flags supported by the tree command.
+func SetFlags(cmd *cobra.Command) {
+	cmd.Flags().Bool("plain", false, "Display output in plain mode")
+	cmd.Flags().Bool("no-headers", false, "Don't display table headers in plain mode. Works only with --plain")
+	cmd.Flags().Bool("raw", false, "Print raw JSON output")
+}
+
+func run(cmd *cobra.Command, args []string) {
+	project := viper.GetString("project.key")
+
+	debug, err := cmd.Flags().GetBool("debug")
+	cmdutil.ExitIfError(err)
+
+	client := api.DefaultClient(debug)
+	key := cmdutil.GetJiraIssueKey(project, args[0])
+
+	tree, err := func() (*jira.EpicTree, error) {
+		s := cmdutil.Info("Fetching epic hierarchy...")
+		defer s.Stop()
+
+		return client.EpicTree(key)
+	}()
+	cmdutil.ExitIfError(err)
+
+	raw, err := cmd.Flags().GetBool("raw")
+	cmdutil.ExitIfError(err)
+	if raw {
+		outputRawJSON(tree)
+		return
+	}
+
+	plain, err := cmd.Flags().GetBool("plain")
+	cmdutil.ExitIfError(err)
+
+	noHeaders, err := cmd.Flags().GetBool("no-headers")
+	cmdutil.ExitIfError(err)
+
+	if plain {
+		renderPlain(tree, noHeaders)
+		return
+	}
+
+	renderTree(tree)
+}
+
+func outputRawJSON(tree *jira.EpicTree) {
+	data, err := json.MarshalIndent(tree, "", "  ")
+	if err != nil {
+		cmdutil.Failed("Failed to marshal epic tree to JSON: %s", err)
+		return
+	}
+
+	fmt.Println(string(data))
+}
+
+func statusColor(status string) string {
+	s := strings.ToLower(status)
+
+	switch {
+	case s == "done" || s == "closed" || s == "resolved" || strings.Contains(s, "complete"):
+		return doneStyle(status)
+	case s == "blocked" || strings.Contains(s, "block"):
+		return blockedStyle(status)
+	case s == "in progress" || s == "in review" || s == "active" || strings.Contains(s, "progress"):
+		return activeStyle(status)
+	default:
+		return dimStyle(status)
+	}
+}
+
+func renderTree(tree *jira.EpicTree) {
+	if tree == nil || tree.Epic == nil {
+		return
+	}
+
+	fmt.Printf("%s [%s] %s\n", epicKeyStyle(tree.Epic.Key), statusColor(tree.Epic.Fields.Status.Name), tree.Epic.Fields.Summary)
+
+	for i, child := range tree.Children {
+		branch := "├── "
+		nextIndent := "│   "
+		if i == len(tree.Children)-1 {
+			branch = "└── "
+			nextIndent = "    "
+		}
+
+		fmt.Printf("%s%s [%s] %s\n",
+			connector(branch),
+			keyStyle(child.Issue.Key),
+			statusColor(child.Issue.Fields.Status.Name),
+			child.Issue.Fields.Summary,
+		)
+
+		for j, subtask := range child.Subtasks {
+			subBranch := "├── "
+			if j == len(child.Subtasks)-1 {
+				subBranch = "└── "
+			}
+
+			fmt.Printf("%s%s%s [%s] %s\n",
+				connector(nextIndent),
+				connector(subBranch),
+				keyStyle(subtask.Key),
+				statusColor(subtask.Fields.Status.Name),
+				subtask.Fields.Summary,
+			)
+		}
+	}
+}
+
+func renderPlain(tree *jira.EpicTree, noHeaders bool) {
+	if tree == nil || tree.Epic == nil {
+		return
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 8, 1, '\t', 0)
+
+	if !noHeaders {
+		_, _ = fmt.Fprintln(w, strings.Join([]string{"KEY", "TYPE", "STATUS", "SUMMARY", "PARENT"}, "\t"))
+	}
+
+	writePlainRow(w, tree.Epic, "")
+
+	for _, child := range tree.Children {
+		writePlainRow(w, child.Issue, tree.Epic.Key)
+		for _, subtask := range child.Subtasks {
+			writePlainRow(w, subtask, child.Issue.Key)
+		}
+	}
+
+	_ = w.Flush()
+}
+
+func writePlainRow(w *tabwriter.Writer, issue *jira.Issue, parent string) {
+	if issue == nil {
+		return
+	}
+
+	_, _ = fmt.Fprintf(
+		w,
+		"%s\t%s\t%s\t%s\t%s\n",
+		issue.Key,
+		issue.Fields.IssueType.Name,
+		issue.Fields.Status.Name,
+		issue.Fields.Summary,
+		parent,
+	)
+}

--- a/internal/cmd/epic/tree/tree.go
+++ b/internal/cmd/epic/tree/tree.go
@@ -43,6 +43,8 @@ $ jira epic tree EPIC-1 --raw
 
 # Display as a flat table without headers
 $ jira epic tree EPIC-1 --plain --no-headers`
+
+	tabMinWidth = 8
 )
 
 // NewCmdTree is a tree command.
@@ -174,7 +176,7 @@ func renderPlain(tree *jira.EpicTree, noHeaders bool) {
 		return
 	}
 
-	w := tabwriter.NewWriter(os.Stdout, 0, 8, 1, '\t', 0)
+	w := tabwriter.NewWriter(os.Stdout, 0, tabMinWidth, 1, '\t', 0)
 
 	if !noHeaders {
 		_, _ = fmt.Fprintln(w, strings.Join([]string{"KEY", "TYPE", "STATUS", "SUMMARY", "PARENT"}, "\t"))

--- a/internal/cmd/issue/comment/add/add.go
+++ b/internal/cmd/issue/comment/add/add.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ankitpokhrel/jira-cli/internal/cmdutil"
 	"github.com/ankitpokhrel/jira-cli/internal/query"
 	"github.com/ankitpokhrel/jira-cli/pkg/jira"
+	"github.com/ankitpokhrel/jira-cli/pkg/md"
 	"github.com/ankitpokhrel/jira-cli/pkg/surveyext"
 )
 
@@ -57,6 +58,7 @@ func NewCmdCommentAdd() *cobra.Command {
 	cmd.Flags().StringP("template", "T", "", "Path to a file to read comment body from")
 	cmd.Flags().Bool("no-input", false, "Disable prompt for non-required fields")
 	cmd.Flags().Bool("internal", false, "Make comment internal")
+	cmd.Flags().Bool("raw", false, "Pass comment body as raw Jira wiki markup")
 
 	return &cmd
 }
@@ -99,11 +101,16 @@ func add(cmd *cobra.Command, args []string) {
 		}
 	}
 
+	body := params.body
+	if !params.raw {
+		body = md.ToJiraMD(body)
+	}
+
 	err := func() error {
 		s := cmdutil.Info("Adding comment")
 		defer s.Stop()
 
-		return client.AddIssueComment(ac.params.issueKey, ac.params.body, ac.params.internal)
+		return client.AddIssueComment(ac.params.issueKey, body, ac.params.internal)
 	}()
 	cmdutil.ExitIfError(err)
 
@@ -124,6 +131,7 @@ type addParams struct {
 	template string
 	noInput  bool
 	internal bool
+	raw      bool
 	debug    bool
 }
 
@@ -150,12 +158,16 @@ func parseArgsAndFlags(args []string, flags query.FlagParser) *addParams {
 	internal, err := flags.GetBool("internal")
 	cmdutil.ExitIfError(err)
 
+	raw, err := flags.GetBool("raw")
+	cmdutil.ExitIfError(err)
+
 	return &addParams{
 		issueKey: issueKey,
 		body:     body,
 		template: template,
 		noInput:  noInput,
 		internal: internal,
+		raw:      raw,
 		debug:    debug,
 	}
 }

--- a/internal/cmd/issue/comment/add/add_test.go
+++ b/internal/cmd/issue/comment/add/add_test.go
@@ -1,0 +1,52 @@
+package add
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type testFlagParser struct {
+	bools   map[string]bool
+	strings map[string]string
+}
+
+func (tfp *testFlagParser) GetBool(name string) (bool, error) {
+	return tfp.bools[name], nil
+}
+
+func (tfp *testFlagParser) GetString(name string) (string, error) {
+	return tfp.strings[name], nil
+}
+
+func (*testFlagParser) GetStringArray(string) ([]string, error) { return nil, nil }
+func (*testFlagParser) GetStringToString(string) (map[string]string, error) {
+	return nil, nil
+}
+func (*testFlagParser) GetUint(string) (uint, error) { return 0, nil }
+func (*testFlagParser) Set(string, string) error     { return nil }
+
+func TestParseArgsAndFlags(t *testing.T) {
+	params := parseArgsAndFlags(
+		[]string{"ISSUE-1", "comment body"},
+		&testFlagParser{
+			bools: map[string]bool{
+				"debug":    true,
+				"no-input": true,
+				"internal": true,
+				"raw":      true,
+			},
+			strings: map[string]string{
+				"template": "comment.tmpl",
+			},
+		},
+	)
+
+	assert.Equal(t, "ISSUE-1", params.issueKey)
+	assert.Equal(t, "comment body", params.body)
+	assert.Equal(t, "comment.tmpl", params.template)
+	assert.True(t, params.noInput)
+	assert.True(t, params.internal)
+	assert.True(t, params.raw)
+	assert.True(t, params.debug)
+}

--- a/internal/cmd/issue/comment/comment.go
+++ b/internal/cmd/issue/comment/comment.go
@@ -4,6 +4,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/ankitpokhrel/jira-cli/internal/cmd/issue/comment/add"
+	"github.com/ankitpokhrel/jira-cli/internal/cmd/issue/comment/edit"
 )
 
 const helpText = `Comment command helps you manage issue comments. See available commands below.`
@@ -19,6 +20,7 @@ func NewCmdComment() *cobra.Command {
 	}
 
 	cmd.AddCommand(add.NewCmdCommentAdd())
+	cmd.AddCommand(edit.NewCmdCommentEdit())
 
 	return &cmd
 }

--- a/internal/cmd/issue/comment/edit/edit.go
+++ b/internal/cmd/issue/comment/edit/edit.go
@@ -30,9 +30,9 @@ $ jira issue comment edit ISSUE-1 10042 --internal --no-input`
 // NewCmdCommentEdit is a comment edit command.
 func NewCmdCommentEdit() *cobra.Command {
 	cmd := cobra.Command{
-		Use:   "edit ISSUE-KEY COMMENT-ID",
-		Short: "Edit a comment on an issue",
-		Long:  helpText,
+		Use:     "edit ISSUE-KEY COMMENT-ID",
+		Short:   "Edit a comment on an issue",
+		Long:    helpText,
 		Example: examples,
 		Annotations: map[string]string{
 			"help:args": "ISSUE-KEY\tIssue key of the issue, eg: ISSUE-1\n" +

--- a/internal/cmd/issue/comment/edit/edit.go
+++ b/internal/cmd/issue/comment/edit/edit.go
@@ -1,0 +1,207 @@
+package edit
+
+import (
+	"fmt"
+
+	"github.com/AlecAivazis/survey/v2"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/ankitpokhrel/jira-cli/api"
+	"github.com/ankitpokhrel/jira-cli/internal/cmdcommon"
+	"github.com/ankitpokhrel/jira-cli/internal/cmdutil"
+	"github.com/ankitpokhrel/jira-cli/internal/query"
+	"github.com/ankitpokhrel/jira-cli/pkg/jira"
+	"github.com/ankitpokhrel/jira-cli/pkg/md"
+	"github.com/ankitpokhrel/jira-cli/pkg/surveyext"
+)
+
+const (
+	helpText = `Edit an existing comment on an issue.`
+	examples = `$ jira issue comment edit ISSUE-1 10042
+
+# Edit with inline body (non-interactive)
+$ jira issue comment edit ISSUE-1 10042 -b "Updated text" --no-input
+
+# Mark comment as internal
+$ jira issue comment edit ISSUE-1 10042 --internal --no-input`
+)
+
+// NewCmdCommentEdit is a comment edit command.
+func NewCmdCommentEdit() *cobra.Command {
+	cmd := cobra.Command{
+		Use:   "edit ISSUE-KEY COMMENT-ID",
+		Short: "Edit a comment on an issue",
+		Long:  helpText,
+		Example: examples,
+		Annotations: map[string]string{
+			"help:args": "ISSUE-KEY\tIssue key of the issue, eg: ISSUE-1\n" +
+				"COMMENT-ID\tNumeric ID of the comment to edit",
+		},
+		Args: cobra.MinimumNArgs(2),
+		Run:  edit,
+	}
+
+	cmd.Flags().StringP("body", "b", "", "Edit comment body")
+	cmd.Flags().Bool("no-input", false, "Disable prompt for non-required fields")
+	cmd.Flags().Bool("internal", false, "Mark comment as internal")
+
+	return &cmd
+}
+
+func edit(cmd *cobra.Command, args []string) {
+	params := parseArgsAndFlags(args, cmd.Flags())
+	client := api.DefaultClient(params.debug)
+	ec := editCmd{
+		client: client,
+		params: params,
+	}
+
+	if ec.isNonInteractive() {
+		ec.params.noInput = true
+	}
+
+	// Always fetch existing comment: validates the ID and provides pre-fill body.
+	existing, err := func() (*jira.IssueComment, error) {
+		s := cmdutil.Info(fmt.Sprintf("Fetching comment %s...", params.commentID))
+		defer s.Stop()
+
+		return client.GetIssueComment(params.issueKey, params.commentID)
+	}()
+	cmdutil.ExitIfError(err)
+
+	originalBody := md.FromJiraMD(existing.Body)
+
+	// In non-interactive mode without an explicit body, keep the existing body.
+	// This allows changing only the --internal flag without editing text.
+	if params.noInput && params.body == "" {
+		params.body = originalBody
+	}
+
+	qs := ec.getQuestions(originalBody)
+	if len(qs) > 0 {
+		ans := struct{ Body string }{}
+		err := survey.Ask(qs, &ans)
+		cmdutil.ExitIfError(err)
+
+		params.body = ans.Body
+	}
+
+	// In interactive mode, skip the PUT if the body was not changed.
+	if !params.noInput && params.body == originalBody {
+		cmdutil.Warn("No changes detected, comment was not updated")
+		return
+	}
+
+	if !params.noInput {
+		answer := struct{ Action string }{}
+		err := survey.Ask([]*survey.Question{getNextAction()}, &answer)
+		cmdutil.ExitIfError(err)
+
+		if answer.Action == cmdcommon.ActionCancel {
+			cmdutil.Failed("Action aborted")
+		}
+	}
+
+	err = func() error {
+		s := cmdutil.Info("Updating comment")
+		defer s.Stop()
+
+		return client.UpdateIssueComment(ec.params.issueKey, ec.params.commentID, ec.params.body, ec.params.internal)
+	}()
+	cmdutil.ExitIfError(err)
+
+	server := viper.GetString("server")
+
+	cmdutil.Success("Comment updated on issue %q", ec.params.issueKey)
+	fmt.Printf("%s\n", cmdutil.GenerateServerBrowseURL(server, ec.params.issueKey))
+}
+
+type editParams struct {
+	issueKey  string
+	commentID string
+	body      string
+	noInput   bool
+	internal  bool
+	debug     bool
+}
+
+func parseArgsAndFlags(args []string, flags query.FlagParser) *editParams {
+	var issueKey, commentID string
+
+	nargs := len(args)
+	if nargs >= 1 {
+		issueKey = cmdutil.GetJiraIssueKey(viper.GetString("project.key"), args[0])
+	}
+	if nargs >= 2 {
+		commentID = args[1]
+	}
+
+	debug, err := flags.GetBool("debug")
+	cmdutil.ExitIfError(err)
+
+	body, err := flags.GetString("body")
+	cmdutil.ExitIfError(err)
+
+	noInput, err := flags.GetBool("no-input")
+	cmdutil.ExitIfError(err)
+
+	internal, err := flags.GetBool("internal")
+	cmdutil.ExitIfError(err)
+
+	return &editParams{
+		issueKey:  issueKey,
+		commentID: commentID,
+		body:      body,
+		noInput:   noInput,
+		internal:  internal,
+		debug:     debug,
+	}
+}
+
+type editCmd struct {
+	client *jira.Client
+	params *editParams
+}
+
+func (ec *editCmd) getQuestions(originalBody string) []*survey.Question {
+	var qs []*survey.Question
+
+	// Skip editor if noInput is set or body was already provided via flag.
+	if ec.params.noInput || ec.params.body != "" {
+		return qs
+	}
+
+	qs = append(qs, &survey.Question{
+		Name: "body",
+		Prompt: &surveyext.JiraEditor{
+			Editor: &survey.Editor{
+				Message:       "Comment body",
+				Default:       originalBody,
+				HideDefault:   true,
+				AppendDefault: true,
+			},
+			BlankAllowed: false,
+		},
+	})
+
+	return qs
+}
+
+func getNextAction() *survey.Question {
+	return &survey.Question{
+		Name: "action",
+		Prompt: &survey.Select{
+			Message: "What's next?",
+			Options: []string{
+				cmdcommon.ActionSubmit,
+				cmdcommon.ActionCancel,
+			},
+		},
+		Validate: survey.Required,
+	}
+}
+
+func (ec *editCmd) isNonInteractive() bool {
+	return ec.params.noInput
+}

--- a/internal/cmd/issue/comment/edit/edit.go
+++ b/internal/cmd/issue/comment/edit/edit.go
@@ -45,6 +45,7 @@ func NewCmdCommentEdit() *cobra.Command {
 	cmd.Flags().StringP("body", "b", "", "Edit comment body")
 	cmd.Flags().Bool("no-input", false, "Disable prompt for non-required fields")
 	cmd.Flags().Bool("internal", false, "Mark comment as internal")
+	cmd.Flags().Bool("raw", false, "Pass comment body as raw Jira wiki markup")
 
 	return &cmd
 }
@@ -103,11 +104,16 @@ func edit(cmd *cobra.Command, args []string) {
 		}
 	}
 
+	body := ec.params.body
+	if !ec.params.raw {
+		body = md.ToJiraMD(body)
+	}
+
 	err = func() error {
 		s := cmdutil.Info("Updating comment")
 		defer s.Stop()
 
-		return client.UpdateIssueComment(ec.params.issueKey, ec.params.commentID, ec.params.body, ec.params.internal)
+		return client.UpdateIssueComment(ec.params.issueKey, ec.params.commentID, body, ec.params.internal)
 	}()
 	cmdutil.ExitIfError(err)
 
@@ -123,6 +129,7 @@ type editParams struct {
 	body      string
 	noInput   bool
 	internal  bool
+	raw       bool
 	debug     bool
 }
 
@@ -149,12 +156,16 @@ func parseArgsAndFlags(args []string, flags query.FlagParser) *editParams {
 	internal, err := flags.GetBool("internal")
 	cmdutil.ExitIfError(err)
 
+	raw, err := flags.GetBool("raw")
+	cmdutil.ExitIfError(err)
+
 	return &editParams{
 		issueKey:  issueKey,
 		commentID: commentID,
 		body:      body,
 		noInput:   noInput,
 		internal:  internal,
+		raw:       raw,
 		debug:     debug,
 	}
 }

--- a/internal/cmd/issue/comment/edit/edit.go
+++ b/internal/cmd/issue/comment/edit/edit.go
@@ -176,27 +176,25 @@ type editCmd struct {
 }
 
 func (ec *editCmd) getQuestions(originalBody string) []*survey.Question {
-	var qs []*survey.Question
-
 	// Skip editor if noInput is set or body was already provided via flag.
 	if ec.params.noInput || ec.params.body != "" {
-		return qs
+		return nil
 	}
 
-	qs = append(qs, &survey.Question{
-		Name: "body",
-		Prompt: &surveyext.JiraEditor{
-			Editor: &survey.Editor{
-				Message:       "Comment body",
-				Default:       originalBody,
-				HideDefault:   true,
-				AppendDefault: true,
+	return []*survey.Question{
+		{
+			Name: "body",
+			Prompt: &surveyext.JiraEditor{
+				Editor: &survey.Editor{
+					Message:       "Comment body",
+					Default:       originalBody,
+					HideDefault:   true,
+					AppendDefault: true,
+				},
+				BlankAllowed: false,
 			},
-			BlankAllowed: false,
 		},
-	})
-
-	return qs
+	}
 }
 
 func getNextAction() *survey.Question {

--- a/internal/cmd/issue/comment/edit/edit_test.go
+++ b/internal/cmd/issue/comment/edit/edit_test.go
@@ -1,0 +1,52 @@
+package edit
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type testFlagParser struct {
+	bools   map[string]bool
+	strings map[string]string
+}
+
+func (tfp *testFlagParser) GetBool(name string) (bool, error) {
+	return tfp.bools[name], nil
+}
+
+func (tfp *testFlagParser) GetString(name string) (string, error) {
+	return tfp.strings[name], nil
+}
+
+func (*testFlagParser) GetStringArray(string) ([]string, error) { return nil, nil }
+func (*testFlagParser) GetStringToString(string) (map[string]string, error) {
+	return nil, nil
+}
+func (*testFlagParser) GetUint(string) (uint, error) { return 0, nil }
+func (*testFlagParser) Set(string, string) error     { return nil }
+
+func TestParseArgsAndFlags(t *testing.T) {
+	params := parseArgsAndFlags(
+		[]string{"ISSUE-1", "10042"},
+		&testFlagParser{
+			bools: map[string]bool{
+				"debug":    true,
+				"no-input": true,
+				"internal": true,
+				"raw":      true,
+			},
+			strings: map[string]string{
+				"body": "updated body",
+			},
+		},
+	)
+
+	assert.Equal(t, "ISSUE-1", params.issueKey)
+	assert.Equal(t, "10042", params.commentID)
+	assert.Equal(t, "updated body", params.body)
+	assert.True(t, params.noInput)
+	assert.True(t, params.internal)
+	assert.True(t, params.raw)
+	assert.True(t, params.debug)
+}

--- a/internal/cmd/issue/create/create.go
+++ b/internal/cmd/issue/create/create.go
@@ -3,6 +3,7 @@ package create
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/spf13/cobra"
@@ -36,6 +37,9 @@ $ jira issue create --template /path/to/template.tmpl
 
 # Get description from standard input
 $ jira issue create --template -
+
+	# Create issue from a Deviniti Issue Template
+	$ jira issue create --jira-template 14866 --template-var TITLE="My Task" -tStory --no-input
 
 # Create issue in the configured project with JSON output
 $ jira issue create --raw
@@ -78,6 +82,16 @@ func create(cmd *cobra.Command, _ []string) {
 
 	params := parseFlags(cmd.Flags())
 	client := api.DefaultClient(params.Debug)
+	if params.JiraTemplate != "" {
+		if params.IssueType == "" {
+			cmdutil.Failed("Param `--type` is mandatory when using `--jira-template`")
+		}
+		s := cmdutil.Info("Fetching template...")
+		err := applyIssueTemplate(client, project, params)
+		s.Stop()
+		cmdutil.ExitIfError(err)
+	}
+
 	cc := createCmd{
 		client: client,
 		params: params,
@@ -108,12 +122,17 @@ func create(cmd *cobra.Command, _ []string) {
 		s := cmdutil.Info("Creating an issue...")
 		defer s.Stop()
 
+		var body any = params.Body
+		if params.BodyIsJiraMarkup {
+			body = jira.JiraMarkup(params.Body)
+		}
+
 		cr := jira.CreateRequest{
 			Project:          project,
 			IssueType:        params.IssueType,
 			ParentIssueKey:   params.ParentIssueKey,
 			Summary:          params.Summary,
-			Body:             params.Body,
+			Body:             body,
 			Reporter:         params.Reporter,
 			Assignee:         params.Assignee,
 			Priority:         params.Priority,
@@ -125,6 +144,7 @@ func create(cmd *cobra.Command, _ []string) {
 			CustomFields:     params.CustomFields,
 			EpicField:        viper.GetString("epic.link"),
 		}
+		cr.JiraTemplateID = params.JiraTemplate
 		cr.ForProjectType(projectType)
 		cr.ForInstallationType(installation)
 		if configuredCustomFields, err := cmdcommon.GetConfiguredCustomFields(); err == nil {
@@ -158,6 +178,114 @@ func create(cmd *cobra.Command, _ []string) {
 	}
 }
 
+func applyIssueTemplate(client *jira.Client, project string, params *cmdcommon.CreateParams) error {
+	projectResp, err := client.GetProjectV2(project)
+	if err != nil {
+		return err
+	}
+
+	issueTypeID, err := resolveIssueTypeID(params.IssueType)
+	if err != nil {
+		return err
+	}
+
+	templateResp, err := client.GetIssueTemplate(params.JiraTemplate, projectResp.ID, issueTypeID)
+	if err != nil {
+		return err
+	}
+
+	for _, variable := range templateResp.UserVariables {
+		if !variable.Required {
+			continue
+		}
+		if strings.TrimSpace(params.TemplateVars[variable.Key]) == "" {
+			return fmt.Errorf("required template variable %q is missing", variable.Key)
+		}
+	}
+
+	for _, field := range templateResp.Fields {
+		substituted := jira.SubstituteTemplateVars(field.Text1, params.TemplateVars)
+
+		switch field.FieldType {
+		case jira.TemplateFieldSummary:
+			if params.Summary == "" || field.Overwritable {
+				params.Summary = substituted
+			}
+		case jira.TemplateFieldDescription:
+			if params.Body == "" || field.Overwritable {
+				params.Body = substituted
+				params.BodyIsJiraMarkup = true
+			}
+		case jira.TemplateFieldLabels:
+			labels := strings.FieldsFunc(substituted, func(r rune) bool {
+				return r == ',' || r == '\n'
+			})
+			for i := range labels {
+				labels[i] = strings.TrimSpace(labels[i])
+			}
+			filtered := labels[:0]
+			for _, label := range labels {
+				if label != "" {
+					filtered = append(filtered, label)
+				}
+			}
+			params.Labels = mergeLabels(filtered, params.Labels)
+		}
+	}
+
+	return nil
+}
+
+func resolveIssueTypeID(issueType string) (string, error) {
+	availableTypes, ok := viper.Get("issue.types").([]any)
+	if !ok {
+		return "", fmt.Errorf("invalid issue types in config")
+	}
+
+	for _, availableType := range availableTypes {
+		typeMap, ok := availableType.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		name, _ := typeMap["name"].(string)
+		handle, _ := typeMap["handle"].(string)
+		id, _ := typeMap["id"].(string)
+
+		if strings.EqualFold(issueType, handle) || strings.EqualFold(issueType, name) {
+			return id, nil
+		}
+	}
+
+	return "", fmt.Errorf("issue type %q not found in config", issueType)
+}
+
+func mergeLabels(templateLabels, userLabels []string) []string {
+	if len(templateLabels) == 0 {
+		return userLabels
+	}
+
+	merged := make([]string, 0, len(templateLabels)+len(userLabels))
+	seen := make(map[string]struct{}, len(templateLabels)+len(userLabels))
+
+	for _, label := range templateLabels {
+		if _, ok := seen[label]; ok {
+			continue
+		}
+		seen[label] = struct{}{}
+		merged = append(merged, label)
+	}
+	for _, label := range userLabels {
+		if _, ok := seen[label]; ok {
+			continue
+		}
+		seen[label] = struct{}{}
+		merged = append(merged, label)
+	}
+
+	return merged
+}
+
 type createCmd struct {
 	client     *jira.Client
 	issueTypes []*jira.IssueType
@@ -166,12 +294,12 @@ type createCmd struct {
 
 func (cc *createCmd) setIssueTypes() error {
 	issueTypes := make([]*jira.IssueType, 0)
-	availableTypes, ok := viper.Get("issue.types").([]interface{})
+	availableTypes, ok := viper.Get("issue.types").([]any)
 	if !ok {
 		return fmt.Errorf("invalid issue types in config")
 	}
 	for _, at := range availableTypes {
-		tp := at.(map[string]interface{})
+		tp := at.(map[string]any)
 		name := tp["name"].(string)
 		handle, _ := tp["handle"].(string)
 		if handle == jira.IssueTypeEpic || name == jira.IssueTypeEpic {
@@ -373,6 +501,12 @@ func parseFlags(flags query.FlagParser) *cmdcommon.CreateParams {
 	template, err := flags.GetString("template")
 	cmdutil.ExitIfError(err)
 
+	jiraTemplate, err := flags.GetString("jira-template")
+	cmdutil.ExitIfError(err)
+
+	templateVars, err := flags.GetStringToString("template-var")
+	cmdutil.ExitIfError(err)
+
 	noInput, err := flags.GetBool("no-input")
 	cmdutil.ExitIfError(err)
 
@@ -394,6 +528,8 @@ func parseFlags(flags query.FlagParser) *cmdcommon.CreateParams {
 		OriginalEstimate: originalEstimate,
 		CustomFields:     custom,
 		Template:         template,
+		JiraTemplate:     jiraTemplate,
+		TemplateVars:     templateVars,
 		NoInput:          noInput,
 		Debug:            debug,
 	}

--- a/internal/cmd/issue/create/create.go
+++ b/internal/cmd/issue/create/create.go
@@ -1,8 +1,10 @@
 package create
 
 import (
+	"bufio"
 	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/AlecAivazis/survey/v2"
@@ -117,6 +119,11 @@ func create(cmd *cobra.Command, _ []string) {
 
 	params.Reporter = cmdcommon.GetRelevantUser(client, project, params.Reporter)
 	params.Assignee = cmdcommon.GetRelevantUser(client, project, params.Assignee)
+	cc.params = params
+
+	if err := cc.warnOnDuplicateSubtaskType(); err != nil {
+		cmdutil.ExitIfError(err)
+	}
 
 	issue, err := func() (*jira.CreateResponse, error) {
 		s := cmdutil.Info("Creating an issue...")
@@ -513,8 +520,12 @@ func parseFlags(flags query.FlagParser) *cmdcommon.CreateParams {
 	debug, err := flags.GetBool("debug")
 	cmdutil.ExitIfError(err)
 
+	noDuplicateCheck, err := flags.GetBool("no-duplicate-check")
+	cmdutil.ExitIfError(err)
+
 	return &cmdcommon.CreateParams{
 		IssueType:        issueType,
+		NoDuplicateCheck: noDuplicateCheck,
 		ParentIssueKey:   parentIssueKey,
 		Summary:          summary,
 		Body:             body,
@@ -533,4 +544,91 @@ func parseFlags(flags query.FlagParser) *cmdcommon.CreateParams {
 		NoInput:          noInput,
 		Debug:            debug,
 	}
+}
+
+func (cc *createCmd) warnOnDuplicateSubtaskType() error {
+	if cc.params.NoDuplicateCheck || cc.params.ParentIssueKey == "" || !cc.isSubtaskIssueType() {
+		return nil
+	}
+
+	subtasks, err := cc.client.GetSubtasks(cc.params.ParentIssueKey)
+	if err != nil {
+		cmdutil.Warn(
+			"Warning: unable to check existing subtasks for %s: %s",
+			cc.params.ParentIssueKey,
+			err,
+		)
+		return nil
+	}
+
+	targetType := cc.issueTypeName()
+	for _, subtask := range subtasks {
+		if !strings.EqualFold(subtask.Fields.IssueType.Name, targetType) {
+			continue
+		}
+
+		message := fmt.Sprintf(
+			"Warning: parent %s already has a subtask of type %s (%s). Proceed? [y/N]",
+			cc.params.ParentIssueKey,
+			targetType,
+			subtask.Key,
+		)
+		if cc.params.NoInput {
+			cmdutil.Warn(message)
+			return nil
+		}
+
+		proceed, err := promptForConfirmation(message)
+		if err != nil {
+			return err
+		}
+		if !proceed {
+			cmdutil.Failed("Action aborted")
+		}
+
+		return nil
+	}
+
+	return nil
+}
+
+func (cc *createCmd) issueTypeName() string {
+	for _, issueType := range cc.issueTypes {
+		if strings.EqualFold(cc.params.IssueType, issueType.Name) ||
+			(issueType.Handle != "" && strings.EqualFold(cc.params.IssueType, issueType.Handle)) {
+			return issueType.Name
+		}
+	}
+
+	return cc.params.IssueType
+}
+
+func (cc *createCmd) isSubtaskIssueType() bool {
+	for _, issueType := range cc.issueTypes {
+		if !issueType.Subtask {
+			continue
+		}
+
+		if strings.EqualFold(cc.params.IssueType, issueType.Name) ||
+			(issueType.Handle != "" && strings.EqualFold(cc.params.IssueType, issueType.Handle)) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func promptForConfirmation(message string) (bool, error) {
+	_, err := fmt.Fprintf(os.Stderr, "%s ", message)
+	if err != nil {
+		return false, err
+	}
+
+	answer, err := bufio.NewReader(os.Stdin).ReadString('\n')
+	if err != nil {
+		return false, err
+	}
+
+	answer = strings.TrimSpace(answer)
+	return strings.EqualFold(answer, "y") || strings.EqualFold(answer, "yes"), nil
 }

--- a/internal/cmd/issue/issue.go
+++ b/internal/cmd/issue/issue.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ankitpokhrel/jira-cli/internal/cmd/issue/link"
 	"github.com/ankitpokhrel/jira-cli/internal/cmd/issue/list"
 	"github.com/ankitpokhrel/jira-cli/internal/cmd/issue/move"
+	"github.com/ankitpokhrel/jira-cli/internal/cmd/issue/moveproject"
 	"github.com/ankitpokhrel/jira-cli/internal/cmd/issue/unlink"
 	"github.com/ankitpokhrel/jira-cli/internal/cmd/issue/view"
 	"github.com/ankitpokhrel/jira-cli/internal/cmd/issue/watch"
@@ -37,7 +38,7 @@ func NewCmdIssue() *cobra.Command {
 	cmd.AddCommand(
 		lc, cc, edit.NewCmdEdit(), move.NewCmdMove(), view.NewCmdView(), assign.NewCmdAssign(),
 		link.NewCmdLink(), unlink.NewCmdUnlink(), comment.NewCmdComment(), clone.NewCmdClone(),
-		delete.NewCmdDelete(), watch.NewCmdWatch(), worklog.NewCmdWorklog(),
+		delete.NewCmdDelete(), watch.NewCmdWatch(), worklog.NewCmdWorklog(), moveproject.NewCmdMoveProject(),
 	)
 
 	list.SetFlags(lc)

--- a/internal/cmd/issue/list/list.go
+++ b/internal/cmd/issue/list/list.go
@@ -157,6 +157,9 @@ func loadList(cmd *cobra.Command, args []string) {
 	noTruncate, err := cmd.Flags().GetBool("no-truncate")
 	cmdutil.ExitIfError(err)
 
+	compact, err := cmd.Flags().GetBool("compact")
+	cmdutil.ExitIfError(err)
+
 	fixedColumns, err := cmd.Flags().GetUint("fixed-columns")
 	cmdutil.ExitIfError(err)
 
@@ -180,6 +183,7 @@ func loadList(cmd *cobra.Command, args []string) {
 		},
 		Display: view.DisplayFormat{
 			Plain:        plain,
+			Compact:      compact,
 			Delimiter:    delimiter,
 			CSV:          csv,
 			NoHeaders:    noHeaders,
@@ -241,6 +245,7 @@ func SetFlags(cmd *cobra.Command) {
 	cmd.Flags().Bool("reverse", false, "Reverse the display order (default \"DESC\")")
 	cmd.Flags().String("paginate", "0:100", "Paginate the result. Max 100 at a time, format: <from>:<limit> where <from> is optional")
 	cmd.Flags().Bool("plain", false, "Display output in plain mode")
+	cmd.Flags().Bool("compact", false, "Display compact LLM-friendly output with essential fields only")
 	cmd.Flags().Bool("no-headers", false, "Don't display table headers in plain mode. Works only with --plain")
 	cmd.Flags().Bool("no-truncate", false, "Show all available columns in plain mode. Works only with --plain")
 	cmd.Flags().String("delimiter", "\t", "Custom delimeter for columns in plain mode. Works only with --plain")

--- a/internal/cmd/issue/list/list.go
+++ b/internal/cmd/issue/list/list.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ankitpokhrel/jira-cli/internal/query"
 	"github.com/ankitpokhrel/jira-cli/internal/view"
 	"github.com/ankitpokhrel/jira-cli/pkg/jira"
+	"github.com/ankitpokhrel/jira-cli/pkg/jql"
 )
 
 const (
@@ -104,7 +105,7 @@ func loadList(cmd *cobra.Command, args []string) {
 		jqlFlag, err := cmd.Flags().GetString("jql")
 		cmdutil.ExitIfError(err)
 		if jqlFlag != "" {
-			searchQuery = fmt.Sprintf(`%s AND %s`, jqlFlag, searchQuery)
+			searchQuery = jql.AppendAnd(jqlFlag, searchQuery)
 		}
 		cmdutil.ExitIfError(cmd.Flags().Set("jql", searchQuery))
 	}

--- a/internal/cmd/issue/move/move.go
+++ b/internal/cmd/issue/move/move.go
@@ -252,7 +252,7 @@ func (mc *moveCmd) verifyTransition(it string) (*jira.Transition, error) {
 		}
 
 		return nil, fmt.Errorf(
-			"Issue %s has 0 available transitions (workflow may be broken).\n\nThis can happen when issues are created via REST API without proper template initialization.\nWorkaround: Move the issue to another project and back to re-initialize the workflow:\n  jira issue move-project %s JIRA\n  jira issue move-project JIRA-NNNN %s",
+			"issue %s has 0 available transitions (workflow may be broken).\n\nThis can happen when issues are created via REST API without proper template initialization.\nWorkaround: Move the issue to another project and back to re-initialize the workflow:\n  jira issue move-project %s JIRA\n  jira issue move-project JIRA-NNNN %s",
 			mc.params.key,
 			mc.params.key,
 			currentProject,

--- a/internal/cmd/issue/move/move.go
+++ b/internal/cmd/issue/move/move.go
@@ -245,6 +245,20 @@ func (mc *moveCmd) setAvailableTransitions() error {
 func (mc *moveCmd) verifyTransition(it string) (*jira.Transition, error) {
 	var tr *jira.Transition
 
+	if len(mc.transitions) == 0 {
+		currentProject := mc.params.key
+		if parts := strings.SplitN(mc.params.key, "-", 2); len(parts) > 0 && parts[0] != "" {
+			currentProject = parts[0]
+		}
+
+		return nil, fmt.Errorf(
+			"Issue %s has 0 available transitions (workflow may be broken).\n\nThis can happen when issues are created via REST API without proper template initialization.\nWorkaround: Move the issue to another project and back to re-initialize the workflow:\n  jira issue move-project %s JIRA\n  jira issue move-project JIRA-NNNN %s",
+			mc.params.key,
+			mc.params.key,
+			currentProject,
+		)
+	}
+
 	st := strings.ToLower(mc.params.state)
 	all := make([]string, 0, len(mc.transitions))
 	for _, t := range mc.transitions {

--- a/internal/cmd/issue/moveproject/moveproject.go
+++ b/internal/cmd/issue/moveproject/moveproject.go
@@ -1,0 +1,110 @@
+package moveproject
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"net/http"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/ankitpokhrel/jira-cli/api"
+	"github.com/ankitpokhrel/jira-cli/internal/cmdutil"
+	"github.com/ankitpokhrel/jira-cli/pkg/jira"
+)
+
+const helpText = `Move issue to a different Jira project.`
+
+func NewCmdMoveProject() *cobra.Command {
+	cmd := cobra.Command{
+		Use:   "move-project ISSUE-KEY TARGET-PROJECT",
+		Short: "Move issue to a different project",
+		Long:  helpText,
+		Args:  cobra.ExactArgs(2),
+		Annotations: map[string]string{
+			"help:args": `ISSUE-KEY\tIssue key, eg: ISSUE-1
+TARGET-PROJECT\tProject key to move the issue to`,
+		},
+		RunE: moveProject,
+	}
+
+	cmd.Flags().String("issue-type", "", "Issue type in the target project")
+	cmd.Flags().Bool("dry-run", false, "Preview the project move without submitting it")
+
+	return &cmd
+}
+
+func moveProject(cmd *cobra.Command, args []string) error {
+	debug, err := cmd.Flags().GetBool("debug")
+	cmdutil.ExitIfError(err)
+
+	issueType, err := cmd.Flags().GetString("issue-type")
+	cmdutil.ExitIfError(err)
+
+	dryRun, err := cmd.Flags().GetBool("dry-run")
+	cmdutil.ExitIfError(err)
+
+	server := viper.GetString("server")
+	login := viper.GetString("login")
+	token := viper.GetString("api_token")
+	authType := jira.AuthType(viper.GetString("auth_type"))
+	insecure := viper.GetBool("insecure")
+
+	restClient := api.DefaultClient(debug)
+
+	var sessionOpts []func(*http.Transport)
+	if insecure {
+		sessionOpts = append(sessionOpts, func(t *http.Transport) {
+			if t.TLSClientConfig == nil {
+				t.TLSClientConfig = &tls.Config{}
+			}
+			t.TLSClientConfig.InsecureSkipVerify = true
+		})
+	}
+	if authType == jira.AuthTypeMTLS {
+		mtlsConfig := jira.MTLSConfig{
+			CaCert:     viper.GetString("mtls.ca_cert"),
+			ClientCert: viper.GetString("mtls.client_cert"),
+			ClientKey:  viper.GetString("mtls.client_key"),
+		}
+		sessionOpts = append(sessionOpts, func(t *http.Transport) {
+			if t.TLSClientConfig == nil {
+				t.TLSClientConfig = &tls.Config{}
+			}
+			if mtlsConfig.CaCert != "" {
+				caCert, readErr := os.ReadFile(mtlsConfig.CaCert)
+				cmdutil.ExitIfError(readErr)
+				pool := x509.NewCertPool()
+				pool.AppendCertsFromPEM(caCert)
+				t.TLSClientConfig.RootCAs = pool
+			}
+			if mtlsConfig.ClientCert != "" || mtlsConfig.ClientKey != "" {
+				cert, loadErr := tls.LoadX509KeyPair(mtlsConfig.ClientCert, mtlsConfig.ClientKey)
+				cmdutil.ExitIfError(loadErr)
+				t.TLSClientConfig.Certificates = []tls.Certificate{cert}
+				t.TLSClientConfig.Renegotiation = tls.RenegotiateFreelyAsClient
+			}
+		})
+	}
+
+	sessionClient, err := jira.NewSessionClient(server, login, token, authType, sessionOpts...)
+	cmdutil.ExitIfError(err)
+
+	result, err := jira.MoveProject(sessionClient, restClient, jira.MoveProjectParams{
+		IssueKey:      cmdutil.GetJiraIssueKey(viper.GetString("project.key"), args[0]),
+		TargetProject: args[1],
+		IssueType:     issueType,
+		DryRun:        dryRun,
+	})
+	cmdutil.ExitIfError(err)
+
+	if dryRun {
+		fmt.Printf("Would move %s from %s to %s as %s\n", result.OldKey, result.OldProject, result.NewProject, result.IssueType)
+		return nil
+	}
+
+	fmt.Printf("Issue moved: %s → %s\n", result.OldKey, result.NewKey)
+	return nil
+}

--- a/internal/cmd/issue/view/view.go
+++ b/internal/cmd/issue/view/view.go
@@ -21,12 +21,16 @@ const (
 $ jira issue view ISSUE-1 --comments 5
 
 # Get the raw JSON data
-$ jira issue view ISSUE-1 --raw`
+$ jira issue view ISSUE-1 --raw
+
+# Get compact LLM-friendly output
+$ jira issue view ISSUE-1 --compact`
 
 	flagRaw      = "raw"
 	flagDebug    = "debug"
 	flagComments = "comments"
 	flagPlain    = "plain"
+	flagCompact  = "compact"
 
 	configProject = "project.key"
 	configServer  = "server"
@@ -52,6 +56,7 @@ func NewCmdView() *cobra.Command {
 	cmd.Flags().Uint(flagComments, 1, "Show N comments")
 	cmd.Flags().Bool(flagPlain, false, "Display output in plain mode")
 	cmd.Flags().Bool(flagRaw, false, "Print raw Jira API response")
+	cmd.Flags().Bool(flagCompact, false, "Display compact LLM-friendly output with essential fields only")
 
 	return &cmd
 }
@@ -111,10 +116,13 @@ func viewPretty(cmd *cobra.Command, args []string) {
 	plain, err := cmd.Flags().GetBool(flagPlain)
 	cmdutil.ExitIfError(err)
 
+	compact, err := cmd.Flags().GetBool(flagCompact)
+	cmdutil.ExitIfError(err)
+
 	v := tuiView.Issue{
 		Server:  viper.GetString(configServer),
 		Data:    iss,
-		Display: tuiView.DisplayFormat{Plain: plain},
+		Display: tuiView.DisplayFormat{Plain: plain, Compact: compact},
 		Options: tuiView.IssueOption{NumComments: comments},
 	}
 	cmdutil.ExitIfError(v.Render())

--- a/internal/cmd/project/list/list.go
+++ b/internal/cmd/project/list/list.go
@@ -11,13 +11,17 @@ import (
 
 // NewCmdList is a list command.
 func NewCmdList() *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:     "list",
 		Short:   "List lists Jira projects",
 		Long:    "List lists Jira projects that a user has access to.",
 		Aliases: []string{"lists", "ls"},
 		Run:     List,
 	}
+
+	SetFlags(cmd)
+
+	return cmd
 }
 
 // List displays a list view.
@@ -42,7 +46,26 @@ func List(cmd *cobra.Command, _ []string) {
 		return
 	}
 
-	v := view.NewProject(projects)
+	plain, err := cmd.Flags().GetBool("plain")
+	cmdutil.ExitIfError(err)
+
+	noHeaders, err := cmd.Flags().GetBool("no-headers")
+	cmdutil.ExitIfError(err)
+
+	delimiter, err := cmd.Flags().GetString("delimiter")
+	cmdutil.ExitIfError(err)
+
+	v := view.NewProject(projects, view.WithProjectDisplay(view.DisplayFormat{
+		Plain:     plain,
+		NoHeaders: noHeaders,
+		Delimiter: delimiter,
+	}))
 
 	cmdutil.ExitIfError(v.Render())
+}
+
+func SetFlags(cmd *cobra.Command) {
+	cmd.Flags().Bool("plain", false, "Display output in plain mode")
+	cmd.Flags().Bool("no-headers", false, "Don't display table headers in plain mode. Works only with --plain")
+	cmd.Flags().String("delimiter", "\t", "Custom delimeter for columns in plain mode. Works only with --plain")
 }

--- a/internal/cmdcommon/create.go
+++ b/internal/cmdcommon/create.go
@@ -28,6 +28,7 @@ type CreateParams struct {
 	ParentIssueKey   string
 	Summary          string
 	Body             string
+	BodyIsJiraMarkup bool
 	Priority         string
 	Reporter         string
 	Assignee         string
@@ -38,6 +39,8 @@ type CreateParams struct {
 	OriginalEstimate string
 	CustomFields     map[string]string
 	Template         string
+	JiraTemplate     string
+	TemplateVars     map[string]string
 	NoInput          bool
 	Debug            bool
 }
@@ -67,6 +70,10 @@ And, this field is mandatory when creating a sub-task.`)
 	cmd.Flags().StringP("original-estimate", "e", "", prefix+" Original estimate")
 	cmd.Flags().StringToString("custom", custom, "Set custom fields")
 	cmd.Flags().StringP("template", "T", "", "Path to a file to read body/description from")
+	if prefix != "Epic" {
+		cmd.Flags().String("jira-template", "", "Deviniti Issue Template ID (e.g. 14866)")
+		cmd.Flags().StringToString("template-var", custom, "Set Deviniti Issue Template variables")
+	}
 	cmd.Flags().Bool("web", false, "Open in web browser after successful creation")
 	cmd.Flags().Bool("no-input", false, "Disable prompt for non-required fields")
 }

--- a/internal/cmdcommon/create.go
+++ b/internal/cmdcommon/create.go
@@ -25,6 +25,7 @@ const (
 type CreateParams struct {
 	Name             string
 	IssueType        string
+	NoDuplicateCheck bool
 	ParentIssueKey   string
 	Summary          string
 	Body             string
@@ -55,6 +56,7 @@ func SetCreateFlags(cmd *cobra.Command, prefix string) {
 		cmd.Flags().StringP("name", "n", "", "Epic name")
 	} else {
 		cmd.Flags().StringP("type", "t", "", "Issue type")
+		cmd.Flags().Bool("no-duplicate-check", false, "Skip duplicate subtask type warning when creating a sub-task")
 		cmd.Flags().StringP("parent", "P", "", `Parent issue key can be used to attach epic to an issue.
 And, this field is mandatory when creating a sub-task.`)
 	}

--- a/internal/query/issue.go
+++ b/internal/query/issue.go
@@ -105,10 +105,12 @@ func (i *Issue) Get() string {
 		}
 	})
 
-	if i.params.Reverse {
-		q.OrderBy(obf, jql.DirectionAscending)
-	} else {
-		q.OrderBy(obf, jql.DirectionDescending)
+	if !q.HasOrderBy() {
+		if i.params.Reverse {
+			q.OrderBy(obf, jql.DirectionAscending)
+		} else {
+			q.OrderBy(obf, jql.DirectionDescending)
+		}
 	}
 
 	return q.String()

--- a/internal/query/issue_test.go
+++ b/internal/query/issue_test.go
@@ -432,11 +432,20 @@ func TestIssueGet(t *testing.T) {
 				`type="test" AND resolution="test" AND priority="test" AND reporter="test" ` +
 				`AND assignee="test" AND component="test" AND parent="test" ORDER BY lastViewed ASC`,
 		},
+		{
+			name: "query with jql order by parameter",
+			initialize: func() *Issue {
+				i, err := NewIssue("TEST", &issueFlagParser{jql: "assignee = currentUser() ORDER BY updated DESC"})
+				assert.NoError(t, err)
+				return i
+			},
+			expected: `project="TEST" AND assignee = currentUser() AND issue IN issueHistory() AND issue IN watchedIssues() AND ` +
+				`type="test" AND resolution="test" AND priority="test" AND reporter="test" ` +
+				`AND assignee="test" AND component="test" AND parent="test" ORDER BY updated DESC`,
+		},
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/view/issue.go
+++ b/internal/view/issue.go
@@ -55,6 +55,9 @@ type Issue struct {
 
 // Render renders the view.
 func (i Issue) Render() error {
+	if i.Display.Compact {
+		return i.renderCompact(os.Stdout)
+	}
 	if i.Display.Plain || tui.IsDumbTerminal() || tui.IsNotTTY() {
 		return i.renderPlain(os.Stdout)
 	}
@@ -452,5 +455,72 @@ func (i Issue) renderPlain(w io.Writer) error {
 		return err
 	}
 	_, err = fmt.Fprint(w, out)
+	return err
+}
+
+func (i Issue) renderCompact(w io.Writer) error {
+	var s strings.Builder
+
+	d := i.Data
+	fmt.Fprintf(&s, "Key: %s\n", d.Key)
+	fmt.Fprintf(&s, "Type: %s\n", d.Fields.IssueType.Name)
+	fmt.Fprintf(&s, "Summary: %s\n", d.Fields.Summary)
+	fmt.Fprintf(&s, "Status: %s\n", d.Fields.Status.Name)
+	fmt.Fprintf(&s, "Priority: %s\n", d.Fields.Priority.Name)
+	if d.Fields.Assignee.Name != "" {
+		fmt.Fprintf(&s, "Assignee: %s\n", d.Fields.Assignee.Name)
+	}
+	if len(d.Fields.Labels) > 0 {
+		fmt.Fprintf(&s, "Labels: %s\n", strings.Join(d.Fields.Labels, ", "))
+	}
+	if d.Fields.Parent != nil && d.Fields.Parent.Key != "" {
+		fmt.Fprintf(&s, "Parent: %s\n", d.Fields.Parent.Key)
+	}
+
+	desc := i.description()
+	if desc != "" {
+		fmt.Fprintf(&s, "\nDescription:\n%s\n", desc)
+	}
+
+	if len(d.Fields.Subtasks) > 0 {
+		fmt.Fprintf(&s, "\nSubtasks:\n")
+		for _, st := range d.Fields.Subtasks {
+			fmt.Fprintf(&s, "- %s %s [%s]\n", st.Key, st.Fields.Summary, st.Fields.Status.Name)
+		}
+	}
+
+	if len(d.Fields.IssueLinks) > 0 {
+		fmt.Fprintf(&s, "\nLinked Issues:\n")
+		for _, link := range d.Fields.IssueLinks {
+			if link.InwardIssue != nil {
+				fmt.Fprintf(&s, "- %s: %s %s\n", link.LinkType.Inward, link.InwardIssue.Key, link.InwardIssue.Fields.Summary)
+			} else if link.OutwardIssue != nil {
+				fmt.Fprintf(&s, "- %s: %s %s\n", link.LinkType.Outward, link.OutwardIssue.Key, link.OutwardIssue.Fields.Summary)
+			}
+		}
+	}
+
+	total := d.Fields.Comment.Total
+	if total > 0 && i.Options.NumComments > 0 {
+		limit := min(int(i.Options.NumComments), total)
+		fmt.Fprintf(&s, "\nComments (%d total, showing %d):\n", total, limit)
+		for idx := total - 1; idx >= total-limit; idx-- {
+			c := d.Fields.Comment.Comments[idx]
+			author := c.Author.DisplayName
+			if author == "" {
+				author = c.Author.Name
+			}
+			var body string
+			if adfNode, ok := c.Body.(*adf.ADF); ok {
+				body = adf.NewTranslator(adfNode, adf.NewMarkdownTranslator()).Translate()
+			} else {
+				body = c.Body.(string)
+				body = md.FromJiraMD(body)
+			}
+			fmt.Fprintf(&s, "\n[%s] %s:\n%s\n", c.Created, author, body)
+		}
+	}
+
+	_, err := fmt.Fprint(w, s.String())
 	return err
 }

--- a/internal/view/issues.go
+++ b/internal/view/issues.go
@@ -16,6 +16,7 @@ import (
 // DisplayFormat is a issue display type.
 type DisplayFormat struct {
 	Plain        bool
+	Compact      bool
 	Delimiter    string
 	CSV          bool
 	NoHeaders    bool
@@ -39,6 +40,10 @@ type IssueList struct {
 
 // Render renders the view.
 func (l *IssueList) Render() error {
+	if l.Display.Compact {
+		return l.renderCompact(os.Stdout)
+	}
+
 	// Prioritize CSV format when explicitly requested
 	if l.Display.CSV {
 		w := os.Stdout
@@ -143,6 +148,35 @@ func (l *IssueList) renderPlain(w io.Writer, delimeter string) error {
 // renderCSV renders issues in csv format.
 func (l *IssueList) renderCSV(w io.Writer) error {
 	return renderCSV(w, l.data())
+}
+
+// renderCompact renders issues in a compact LLM-friendly format.
+// Only essential fields are included to minimize token usage.
+func (l *IssueList) renderCompact(w io.Writer) error {
+	var s strings.Builder
+
+	for idx, iss := range l.Data {
+		if idx > 0 {
+			s.WriteString("\n")
+		}
+		fmt.Fprintf(&s, "Key: %s\n", iss.Key)
+		fmt.Fprintf(&s, "Type: %s\n", iss.Fields.IssueType.Name)
+		fmt.Fprintf(&s, "Summary: %s\n", iss.Fields.Summary)
+		fmt.Fprintf(&s, "Status: %s\n", iss.Fields.Status.Name)
+		fmt.Fprintf(&s, "Priority: %s\n", iss.Fields.Priority.Name)
+		if iss.Fields.Assignee.Name != "" {
+			fmt.Fprintf(&s, "Assignee: %s\n", iss.Fields.Assignee.Name)
+		}
+		if len(iss.Fields.Labels) > 0 {
+			fmt.Fprintf(&s, "Labels: %s\n", strings.Join(iss.Fields.Labels, ", "))
+		}
+		if iss.Fields.Parent != nil && iss.Fields.Parent.Key != "" {
+			fmt.Fprintf(&s, "Parent: %s\n", iss.Fields.Parent.Key)
+		}
+	}
+
+	_, err := fmt.Fprint(w, s.String())
+	return err
 }
 
 func (*IssueList) validColumnsMap() map[string]struct{} {

--- a/internal/view/project.go
+++ b/internal/view/project.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"os"
 	"text/tabwriter"
 
 	"github.com/ankitpokhrel/jira-cli/pkg/jira"
@@ -15,9 +16,11 @@ type ProjectOption func(*Project)
 
 // Project is a project view.
 type Project struct {
-	data   []*jira.Project
-	writer io.Writer
-	buf    *bytes.Buffer
+	data            []*jira.Project
+	writer          io.Writer
+	buf             *bytes.Buffer
+	hasCustomWriter bool
+	Display         DisplayFormat
 }
 
 // NewProject initializes a project.
@@ -38,24 +41,65 @@ func NewProject(data []*jira.Project, opts ...ProjectOption) *Project {
 func WithProjectWriter(w io.Writer) ProjectOption {
 	return func(p *Project) {
 		p.writer = w
+		p.hasCustomWriter = true
+	}
+}
+
+func WithProjectDisplay(display DisplayFormat) ProjectOption {
+	return func(p *Project) {
+		p.Display = display
 	}
 }
 
 // Render renders the project view.
 func (p Project) Render() error {
-	p.printHeader()
+	if p.Display.Plain || tui.IsDumbTerminal() || tui.IsNotTTY() {
+		delimiter := "\t"
+		if p.Display.Plain && p.Display.Delimiter != "" {
+			delimiter = p.Display.Delimiter
+		}
+		if p.hasCustomWriter {
+			return p.renderPlain(p.writer, delimiter)
+		}
 
-	for _, d := range p.data {
-		_, _ = fmt.Fprintf(p.writer, "%s\t%s\t%s\t%s\n", d.Key, prepareTitle(d.Name), d.Type, d.Lead.Name)
+		w := tabwriter.NewWriter(os.Stdout, 0, tabWidth, 1, '\t', 0)
+		return p.renderPlain(w, delimiter)
 	}
-	if _, ok := p.writer.(*tabwriter.Writer); ok {
-		err := p.writer.(*tabwriter.Writer).Flush()
+
+	if p.hasCustomWriter {
+		w := tabwriter.NewWriter(p.writer, 0, tabWidth, 1, '\t', 0)
+		if err := p.renderTable(w); err != nil {
+			return err
+		}
+		return w.Flush()
+	}
+
+	if err := p.renderTable(p.writer); err != nil {
+		return err
+	}
+	if w, ok := p.writer.(*tabwriter.Writer); ok {
+		err := w.Flush()
 		if err != nil {
 			return err
 		}
 	}
 
 	return tui.PagerOut(p.buf.String())
+}
+
+func (p Project) renderPlain(w io.Writer, delimiter string) error {
+	return renderPlain(w, p.tableData(), delimiter)
+}
+
+func (p Project) renderTable(w io.Writer) error {
+	for _, items := range p.tableData() {
+		_, err := fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", items[0], items[1], items[2], items[3])
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func (p Project) header() []string {
@@ -67,14 +111,15 @@ func (p Project) header() []string {
 	}
 }
 
-func (p Project) printHeader() {
-	headers := p.header()
-	end := len(headers) - 1
-	for i, h := range headers {
-		_, _ = fmt.Fprintf(p.writer, "%s", h)
-		if i != end {
-			_, _ = fmt.Fprintf(p.writer, "\t")
-		}
+func (p Project) tableData() tui.TableData {
+	data := tui.TableData{}
+	if !p.Display.Plain || !p.Display.NoHeaders {
+		data = append(data, p.header())
 	}
-	_, _ = fmt.Fprintln(p.writer)
+
+	for _, d := range p.data {
+		data = append(data, []string{d.Key, prepareTitle(d.Name), d.Type, d.Lead.Name})
+	}
+
+	return data
 }

--- a/internal/view/project_test.go
+++ b/internal/view/project_test.go
@@ -2,6 +2,7 @@ package view
 
 import (
 	"bytes"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -27,8 +28,132 @@ func TestProjectRender(t *testing.T) {
 
 	expected := `KEY	NAME	TYPE	LEAD
 FRST	First	classic	Person A
-SCND	[2[] Second	next-gen	Person B
+SCND	[2] Second	next-gen	Person B
 THIRD	Third	classic	Person C
 `
 	assert.Equal(t, expected, b.String())
+}
+
+func TestProjectRenderPlain(t *testing.T) {
+	var b bytes.Buffer
+
+	//nolint:unused
+	type lead struct {
+		Name string `json:"displayName"`
+	}
+
+	data := []*jira.Project{
+		{Key: "FRST", Name: "First", Lead: lead{Name: "Person A"}, Type: jira.ProjectTypeClassic},
+		{Key: "SCND", Name: "[2] Second", Lead: lead{Name: "Person B"}, Type: jira.ProjectTypeNextGen},
+	}
+	project := NewProject(
+		data,
+		WithProjectWriter(&b),
+		WithProjectDisplay(DisplayFormat{Plain: true}),
+	)
+	assert.NoError(t, project.Render())
+
+	expected := "KEY\tNAME\tTYPE\tLEAD\nFRST\tFirst\tclassic\tPerson A\nSCND\t[2] Second\tnext-gen\tPerson B\n"
+	assert.Equal(t, expected, b.String())
+}
+
+func TestProjectRenderPlainNoHeadersWithDelimiter(t *testing.T) {
+	var b bytes.Buffer
+
+	//nolint:unused
+	type lead struct {
+		Name string `json:"displayName"`
+	}
+
+	data := []*jira.Project{
+		{Key: "FRST", Name: "First", Lead: lead{Name: "Person A"}, Type: jira.ProjectTypeClassic},
+	}
+	project := NewProject(
+		data,
+		WithProjectWriter(&b),
+		WithProjectDisplay(DisplayFormat{Plain: true, NoHeaders: true, Delimiter: "|"}),
+	)
+	assert.NoError(t, project.Render())
+
+	expected := "FRST|First|classic|Person A\n"
+	assert.Equal(t, expected, b.String())
+}
+
+func TestProjectRenderNoHeadersIgnoredWithoutPlain(t *testing.T) {
+	var b bytes.Buffer
+
+	//nolint:unused
+	type lead struct {
+		Name string `json:"displayName"`
+	}
+
+	data := []*jira.Project{
+		{Key: "FRST", Name: "First", Lead: lead{Name: "Person A"}, Type: jira.ProjectTypeClassic},
+	}
+	project := NewProject(
+		data,
+		WithProjectWriter(&b),
+		WithProjectDisplay(DisplayFormat{NoHeaders: true}),
+	)
+	assert.NoError(t, project.Render())
+
+	expected := "KEY\tNAME\tTYPE\tLEAD\nFRST\tFirst\tclassic\tPerson A\n"
+	assert.Equal(t, expected, b.String())
+}
+
+func TestProjectRenderPlainWithDelimiterKeepsHeaders(t *testing.T) {
+	var b bytes.Buffer
+
+	//nolint:unused
+	type lead struct {
+		Name string `json:"displayName"`
+	}
+
+	data := []*jira.Project{
+		{Key: "FRST", Name: "First", Lead: lead{Name: "Person A"}, Type: jira.ProjectTypeClassic},
+	}
+	project := NewProject(
+		data,
+		WithProjectWriter(&b),
+		WithProjectDisplay(DisplayFormat{Plain: true, Delimiter: "|"}),
+	)
+	assert.NoError(t, project.Render())
+
+	expected := "KEY|NAME|TYPE|LEAD\nFRST|First|classic|Person A\n"
+	assert.Equal(t, expected, b.String())
+}
+
+func TestProjectRenderPlainUsesStdoutWithoutCustomWriter(t *testing.T) {
+	t.Cleanup(func() {
+		os.Stdout = os.NewFile(uintptr(1), "/dev/stdout")
+	})
+
+	reader, writer, err := os.Pipe()
+	assert.NoError(t, err)
+
+	originalStdout := os.Stdout
+	os.Stdout = writer
+
+	//nolint:unused
+	type lead struct {
+		Name string `json:"displayName"`
+	}
+
+	data := []*jira.Project{
+		{Key: "SOS", Name: "Service Operations", Lead: lead{Name: "Marks, Philipp"}, Type: jira.ProjectTypeClassic},
+	}
+	project := NewProject(data, WithProjectDisplay(DisplayFormat{Plain: true}))
+	assert.NoError(t, project.Render())
+	assert.NoError(t, writer.Close())
+	os.Stdout = originalStdout
+
+	var b bytes.Buffer
+	_, err = b.ReadFrom(reader)
+	assert.NoError(t, err)
+	assert.NoError(t, reader.Close())
+
+	out := b.String()
+	assert.Contains(t, out, "KEY\tNAME")
+	assert.Contains(t, out, "TYPE\tLEAD")
+	assert.Contains(t, out, "SOS\tService Operations\tclassic\tMarks, Philipp\n")
 }

--- a/pkg/jira/client.go
+++ b/pkg/jira/client.go
@@ -76,17 +76,17 @@ func (e Errors) String() string {
 	if len(e.ErrorMessages) > 0 || len(e.Errors) > 0 {
 		out.WriteString("\nError:\n")
 		for _, v := range e.ErrorMessages {
-			out.WriteString(fmt.Sprintf("  - %s\n", v))
+			_, _ = fmt.Fprintf(&out, "  - %s\n", v)
 		}
 		for k, v := range e.Errors {
-			out.WriteString(fmt.Sprintf("  - %s: %s\n", k, v))
+			_, _ = fmt.Fprintf(&out, "  - %s: %s\n", k, v)
 		}
 	}
 
 	if len(e.WarningMessages) > 0 {
 		out.WriteString("\nWarning:\n")
 		for _, v := range e.WarningMessages {
-			out.WriteString(fmt.Sprintf("  - %s\n", v))
+			_, _ = fmt.Fprintf(&out, "  - %s\n", v)
 		}
 	}
 
@@ -192,6 +192,11 @@ func WithInsecureTLS(ins bool) ClientFunc {
 	return func(c *Client) {
 		c.insecure = ins
 	}
+}
+
+// GetRaw sends GET request to an arbitrary path on the server (no base URL prefix).
+func (c *Client) GetRaw(ctx context.Context, path string, headers Header) (*http.Response, error) {
+	return c.request(ctx, http.MethodGet, c.server+path, nil, headers)
 }
 
 // Get sends GET request to v3 version of the jira api.

--- a/pkg/jira/create.go
+++ b/pkg/jira/create.go
@@ -121,6 +121,7 @@ func (c *Client) create(req *CreateRequest, ver string) (*CreateResponse, error)
 	return &out, err
 }
 
+//nolint:gocyclo
 func (*Client) getRequestData(req *CreateRequest) *createRequest {
 	if req.Labels == nil {
 		req.Labels = []string{}

--- a/pkg/jira/create.go
+++ b/pkg/jira/create.go
@@ -3,6 +3,7 @@ package jira
 import (
 	"context"
 	"encoding/json"
+	"maps"
 	"net/http"
 	"strconv"
 	"strings"
@@ -26,7 +27,7 @@ type CreateRequest struct {
 	// This can also be used to attach epic for next-gen project.
 	ParentIssueKey   string
 	Summary          string
-	Body             interface{} // string in v1/v2 and adf.ADF in v3
+	Body             any // string in v1/v2 and adf.ADF in v3
 	Reporter         string
 	Assignee         string
 	Priority         string
@@ -44,12 +45,15 @@ type CreateRequest struct {
 	SubtaskField string
 	// CustomFields holds all custom fields passed
 	// while creating an issue.
-	CustomFields map[string]string
+	CustomFields   map[string]string
+	JiraTemplateID string
 
 	projectType            string
 	installationType       string
 	configuredCustomFields []IssueTypeField
 }
+
+type JiraMarkup string
 
 // ForProjectType sets jira project type.
 func (cr *CreateRequest) ForProjectType(pt string) {
@@ -138,6 +142,8 @@ func (*Client) getRequestData(req *CreateRequest) *createRequest {
 	switch v := req.Body.(type) {
 	case string:
 		cf.Description = md.ToJiraMD(v)
+	case JiraMarkup:
+		cf.Description = string(v)
 	case *adf.ADF:
 		cf.Description = v
 	}
@@ -223,6 +229,12 @@ func (*Client) getRequestData(req *CreateRequest) *createRequest {
 	}
 
 	constructCustomFields(req.CustomFields, req.configuredCustomFields, &data)
+	if req.JiraTemplateID != "" {
+		if data.Fields.M.customFields == nil {
+			data.Fields.M.customFields = make(customField)
+		}
+		data.Fields.M.customFields["customfield_10203"] = req.JiraTemplateID
+	}
 
 	return &data
 }
@@ -294,7 +306,7 @@ type createFields struct {
 	} `json:"parent,omitempty"`
 	Name        string           `json:"name,omitempty"`
 	Summary     string           `json:"summary"`
-	Description interface{}      `json:"description,omitempty"`
+	Description any              `json:"description,omitempty"`
 	Reporter    *nameOrAccountID `json:"reporter,omitempty"`
 	Assignee    *nameOrAccountID `json:"assignee,omitempty"`
 	Priority    *struct {
@@ -328,11 +340,11 @@ func (cfm *createFieldsMarshaler) MarshalJSON() ([]byte, error) {
 		return m, err
 	}
 
-	var temp interface{}
+	var temp any
 	if err := json.Unmarshal(m, &temp); err != nil {
 		return nil, err
 	}
-	dm := temp.(map[string]interface{})
+	dm := temp.(map[string]any)
 
 	if epic, ok := dm["name"]; ok {
 		if cfm.M.epicField != "" {
@@ -341,9 +353,7 @@ func (cfm *createFieldsMarshaler) MarshalJSON() ([]byte, error) {
 		delete(dm, "name")
 	}
 
-	for key, val := range cfm.M.customFields {
-		dm[key] = val
-	}
+	maps.Copy(dm, cfm.M.customFields)
 
 	return json.Marshal(dm)
 }

--- a/pkg/jira/create_test.go
+++ b/pkg/jira/create_test.go
@@ -178,3 +178,90 @@ func TestCreateEpicNextGen(t *testing.T) {
 	_, err = client.CreateV2(&requestData)
 	assert.Error(t, &ErrUnexpectedResponse{}, err)
 }
+
+func TestCreateWithJiraTemplate(t *testing.T) {
+	expectedBody := `{"update":{},"fields":{"project":{"key":"TEST"},"issuetype":{"name":"Story"},` +
+		`"summary":"SOS - Test","customfield_10203":"14866"}}`
+	testServer := createTestServer{code: 201}
+	server := testServer.serve(t, expectedBody)
+	defer server.Close()
+
+	client := NewClient(Config{Server: server.URL}, WithTimeout(3*time.Second))
+
+	requestData := CreateRequest{
+		Project:        "TEST",
+		IssueType:      "Story",
+		Summary:        "SOS - Test",
+		JiraTemplateID: "14866",
+	}
+	actual, err := client.CreateV2(&requestData)
+	assert.NoError(t, err)
+
+	expected := &CreateResponse{
+		ID:  "10057",
+		Key: "TEST-3",
+	}
+	assert.Equal(t, expected, actual)
+}
+
+func TestCreateWithJiraTemplateAndCustomFields(t *testing.T) {
+	expectedBody := `{"update":{},"fields":{"project":{"key":"TEST"},"issuetype":{"name":"Story"},` +
+		`"summary":"Test","customfield_10203":"14866","customfield_10002":3}}`
+	testServer := createTestServer{code: 201}
+	server := testServer.serve(t, expectedBody)
+	defer server.Close()
+
+	client := NewClient(Config{Server: server.URL}, WithTimeout(3*time.Second))
+
+	requestData := CreateRequest{
+		Project:        "TEST",
+		IssueType:      "Story",
+		Summary:        "Test",
+		JiraTemplateID: "14866",
+		CustomFields:   map[string]string{"story-points": "3"},
+	}
+	requestData.WithCustomFields([]IssueTypeField{
+		{
+			Key:  "customfield_10002",
+			Name: "Story Points",
+			Schema: struct {
+				DataType string `json:"type"`
+				Items    string `json:"items,omitempty"`
+			}{DataType: "number"},
+		},
+	})
+	actual, err := client.CreateV2(&requestData)
+	assert.NoError(t, err)
+
+	expected := &CreateResponse{
+		ID:  "10057",
+		Key: "TEST-3",
+	}
+	assert.Equal(t, expected, actual)
+}
+
+func TestCreateWithJiraMarkupDescription(t *testing.T) {
+	expectedBody := `{"update":{},"fields":{"project":{"key":"TEST"},"issuetype":{"name":"Story"},` +
+		`"summary":"SOS - Test","description":"h2. Checklist\n(x) done\n(/) accepted","customfield_10203":"14866"}}`
+	testServer := createTestServer{code: 201}
+	server := testServer.serve(t, expectedBody)
+	defer server.Close()
+
+	client := NewClient(Config{Server: server.URL}, WithTimeout(3*time.Second))
+
+	requestData := CreateRequest{
+		Project:        "TEST",
+		IssueType:      "Story",
+		Summary:        "SOS - Test",
+		Body:           JiraMarkup("h2. Checklist\n(x) done\n(/) accepted"),
+		JiraTemplateID: "14866",
+	}
+	actual, err := client.CreateV2(&requestData)
+	assert.NoError(t, err)
+
+	expected := &CreateResponse{
+		ID:  "10057",
+		Key: "TEST-3",
+	}
+	assert.Equal(t, expected, actual)
+}

--- a/pkg/jira/epic_tree.go
+++ b/pkg/jira/epic_tree.go
@@ -1,0 +1,176 @@
+package jira
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+const epicTreeMaxResults uint = 100
+
+// EpicTree represents the full issue hierarchy for an epic.
+type EpicTree struct {
+	Epic     *Issue           `json:"epic"`
+	Children []*EpicTreeChild `json:"children"`
+}
+
+// EpicTreeChild holds a direct child issue and its subtasks.
+type EpicTreeChild struct {
+	Issue    *Issue   `json:"issue"`
+	Subtasks []*Issue `json:"subtasks"`
+}
+
+// EpicTree fetches an epic and its direct child issues and subtasks.
+func (c *Client) EpicTree(key string) (*EpicTree, error) {
+	epic, err := c.GetIssueV2(key)
+	if err != nil {
+		return nil, err
+	}
+
+	children, err := c.searchV2All(fmt.Sprintf(`"Epic Link" = %s OR parent = %s ORDER BY created ASC`, key, key))
+	if err != nil {
+		return nil, err
+	}
+
+	tree := &EpicTree{Epic: epic, Children: make([]*EpicTreeChild, 0, len(children))}
+	childIndex := make(map[string]*EpicTreeChild, len(children))
+	subtaskParentKeys := make([]string, 0, len(children))
+
+	for _, child := range children {
+		treeChild := &EpicTreeChild{
+			Issue:    child,
+			Subtasks: dedupeIssues(child.Fields.Subtasks),
+		}
+		tree.Children = append(tree.Children, treeChild)
+		childIndex[child.Key] = treeChild
+		subtaskParentKeys = append(subtaskParentKeys, child.Key)
+	}
+
+	if len(subtaskParentKeys) == 0 {
+		return tree, nil
+	}
+
+	for _, chunk := range chunkStrings(subtaskParentKeys, 50) {
+		subtasks, err := c.searchV2All(fmt.Sprintf("parent in (%s) ORDER BY created ASC", strings.Join(chunk, ", ")))
+		if err != nil {
+			return nil, err
+		}
+
+		for _, subtask := range subtasks {
+			if subtask.Fields.Parent == nil {
+				continue
+			}
+
+			parent := childIndex[subtask.Fields.Parent.Key]
+			if parent == nil {
+				continue
+			}
+
+			parent.Subtasks = appendIfMissing(parent.Subtasks, subtask)
+		}
+	}
+
+	return tree, nil
+}
+
+func (c *Client) searchV2All(jql string) ([]*Issue, error) {
+	startAt := uint(0)
+	issues := make([]*Issue, 0)
+
+	for {
+		res, err := c.searchV2Page(jql, startAt, epicTreeMaxResults)
+		if err != nil {
+			return nil, err
+		}
+
+		issues = append(issues, res.Issues...)
+
+		next := res.StartAt + res.MaxResults
+		if next >= res.Total || len(res.Issues) == 0 {
+			break
+		}
+
+		startAt = next
+	}
+
+	return issues, nil
+}
+
+type searchV2PageResult struct {
+	Issues     []*Issue `json:"issues"`
+	StartAt    uint     `json:"startAt"`
+	MaxResults uint     `json:"maxResults"`
+	Total      uint     `json:"total"`
+}
+
+func (c *Client) searchV2Page(jql string, from, limit uint) (*searchV2PageResult, error) {
+	path := fmt.Sprintf(
+		"/search?jql=%s&startAt=%d&maxResults=%d&fields=*all",
+		url.QueryEscape(jql),
+		from,
+		limit,
+	)
+
+	res, err := c.GetV2(context.Background(), path, nil)
+	if err != nil {
+		return nil, err
+	}
+	if res == nil {
+		return nil, ErrEmptyResponse
+	}
+	defer func() { _ = res.Body.Close() }()
+
+	if res.StatusCode != http.StatusOK {
+		return nil, formatUnexpectedResponse(res)
+	}
+
+	var out searchV2PageResult
+	if err := json.NewDecoder(res.Body).Decode(&out); err != nil {
+		return nil, err
+	}
+
+	return &out, nil
+}
+
+func chunkStrings(items []string, size int) [][]string {
+	if len(items) == 0 || size <= 0 {
+		return nil
+	}
+
+	chunks := make([][]string, 0, (len(items)+size-1)/size)
+	for i := 0; i < len(items); i += size {
+		end := min(i+size, len(items))
+		chunks = append(chunks, items[i:end])
+	}
+
+	return chunks
+}
+
+func dedupeIssues(issues []Issue) []*Issue {
+	out := make([]*Issue, 0, len(issues))
+	seen := make(map[string]struct{}, len(issues))
+
+	for idx := range issues {
+		if _, ok := seen[issues[idx].Key]; ok {
+			continue
+		}
+		seen[issues[idx].Key] = struct{}{}
+		issue := issues[idx]
+		out = append(out, &issue)
+	}
+
+	return out
+}
+
+func appendIfMissing(issues []*Issue, issue *Issue) []*Issue {
+	for _, existing := range issues {
+		if existing != nil && issue != nil && existing.Key == issue.Key {
+			return issues
+		}
+	}
+
+	return append(issues, issue)
+}

--- a/pkg/jira/epic_tree.go
+++ b/pkg/jira/epic_tree.go
@@ -11,6 +11,8 @@ import (
 
 const epicTreeMaxResults uint = 100
 
+const jqlChunkSize = 50
+
 // EpicTree represents the full issue hierarchy for an epic.
 type EpicTree struct {
 	Epic     *Issue           `json:"epic"`
@@ -53,7 +55,7 @@ func (c *Client) EpicTree(key string) (*EpicTree, error) {
 		return tree, nil
 	}
 
-	for _, chunk := range chunkStrings(subtaskParentKeys, 50) {
+	for _, chunk := range chunkStrings(subtaskParentKeys, jqlChunkSize) {
 		subtasks, err := c.searchV2All(fmt.Sprintf("parent in (%s) ORDER BY created ASC", strings.Join(chunk, ", ")))
 		if err != nil {
 			return nil, err

--- a/pkg/jira/epic_tree.go
+++ b/pkg/jira/epic_tree.go
@@ -32,7 +32,7 @@ func (c *Client) EpicTree(key string) (*EpicTree, error) {
 		return nil, err
 	}
 
-	children, err := c.searchV2All(fmt.Sprintf(`"Epic Link" = %s OR parent = %s ORDER BY created ASC`, key, key))
+	children, err := c.epicTreeSearchAll(fmt.Sprintf(`"Epic Link" = %s OR parent = %s ORDER BY created ASC`, key, key))
 	if err != nil {
 		return nil, err
 	}
@@ -56,7 +56,7 @@ func (c *Client) EpicTree(key string) (*EpicTree, error) {
 	}
 
 	for _, chunk := range chunkStrings(subtaskParentKeys, jqlChunkSize) {
-		subtasks, err := c.searchV2All(fmt.Sprintf("parent in (%s) ORDER BY created ASC", strings.Join(chunk, ", ")))
+		subtasks, err := c.epicTreeSearchAll(fmt.Sprintf("parent in (%s) ORDER BY created ASC", strings.Join(chunk, ", ")))
 		if err != nil {
 			return nil, err
 		}
@@ -76,6 +76,71 @@ func (c *Client) EpicTree(key string) (*EpicTree, error) {
 	}
 
 	return tree, nil
+}
+
+// epicTreeSearchAll fetches every page for a JQL query. Jira Cloud removed the
+// classic /search endpoints (CHANGE-2046), so the token-paginated /search/jql
+// API is tried first; Server/DC has no v3 API and falls back to v2 /search.
+func (c *Client) epicTreeSearchAll(jql string) ([]*Issue, error) {
+	issues, v3Unavailable, err := c.searchV3All(jql)
+	if err != nil && v3Unavailable {
+		return c.searchV2All(jql)
+	}
+	return issues, err
+}
+
+type searchV3PageResult struct {
+	Issues        []*Issue `json:"issues"`
+	NextPageToken string   `json:"nextPageToken"`
+	IsLast        bool     `json:"isLast"`
+}
+
+func (c *Client) searchV3All(jql string) ([]*Issue, bool, error) {
+	var (
+		issues []*Issue
+		token  string
+	)
+
+	for {
+		path := fmt.Sprintf("/search/jql?jql=%s&maxResults=%d&fields=*all", url.QueryEscape(jql), epicTreeMaxResults)
+		if token != "" {
+			path += "&nextPageToken=" + url.QueryEscape(token)
+		}
+
+		res, err := c.Get(context.Background(), path, nil)
+		if err != nil {
+			return nil, false, err
+		}
+		if res == nil {
+			return nil, false, ErrEmptyResponse
+		}
+
+		if res.StatusCode == http.StatusNotFound || res.StatusCode == http.StatusGone {
+			_ = res.Body.Close()
+			return nil, true, fmt.Errorf("jira: /search/jql unavailable (%d)", res.StatusCode)
+		}
+		if res.StatusCode != http.StatusOK {
+			err := formatUnexpectedResponse(res)
+			_ = res.Body.Close()
+			return nil, false, err
+		}
+
+		var out searchV3PageResult
+		err = json.NewDecoder(res.Body).Decode(&out)
+		_ = res.Body.Close()
+		if err != nil {
+			return nil, false, err
+		}
+
+		issues = append(issues, out.Issues...)
+
+		if out.IsLast || out.NextPageToken == "" || len(out.Issues) == 0 {
+			break
+		}
+		token = out.NextPageToken
+	}
+
+	return issues, false, nil
 }
 
 func (c *Client) searchV2All(jql string) ([]*Issue, error) {

--- a/pkg/jira/epic_tree_test.go
+++ b/pkg/jira/epic_tree_test.go
@@ -1,0 +1,199 @@
+package jira
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEpicTree(t *testing.T) {
+	call := 0
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		switch call {
+		case 0:
+			assert.Equal(t, "/rest/api/2/issue/EPIC-1", r.URL.Path)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{
+				"key":"EPIC-1",
+				"fields":{
+					"summary":"Epic summary",
+					"issuetype":{"name":"Epic"},
+					"status":{"name":"In Progress"}
+				}
+			}`))
+		case 1:
+			assert.Equal(t, "/rest/api/2/search", r.URL.Path)
+			assert.Equal(t, url.Values{
+				"fields":     []string{"*all"},
+				"jql":        []string{`"Epic Link" = EPIC-1 OR parent = EPIC-1 ORDER BY created ASC`},
+				"maxResults": []string{"100"},
+				"startAt":    []string{"0"},
+			}, r.URL.Query())
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{
+				"startAt":0,
+				"maxResults":100,
+				"total":2,
+				"issues":[
+					{
+						"key":"STORY-1",
+						"fields":{
+							"summary":"Story one",
+							"issuetype":{"name":"Story"},
+							"status":{"name":"To Do"},
+							"subtasks":[
+								{
+									"key":"SUB-1",
+									"fields":{
+										"summary":"Subtask one",
+										"issuetype":{"name":"Sub-task"},
+										"status":{"name":"Done"}
+									}
+								}
+							]
+						}
+					},
+					{
+						"key":"TASK-1",
+						"fields":{
+							"summary":"Task one",
+							"issuetype":{"name":"Task"},
+							"status":{"name":"In Progress"}
+						}
+					}
+				]
+			}`))
+		case 2:
+			assert.Equal(t, "/rest/api/2/search", r.URL.Path)
+			assert.Equal(t, url.Values{
+				"fields":     []string{"*all"},
+				"jql":        []string{"parent in (STORY-1, TASK-1) ORDER BY created ASC"},
+				"maxResults": []string{"100"},
+				"startAt":    []string{"0"},
+			}, r.URL.Query())
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{
+				"startAt":0,
+				"maxResults":100,
+				"total":2,
+				"issues":[
+					{
+						"key":"SUB-1",
+						"fields":{
+							"summary":"Subtask one",
+							"issuetype":{"name":"Sub-task"},
+							"status":{"name":"Done"},
+							"parent":{"key":"STORY-1"}
+						}
+					},
+					{
+						"key":"SUB-2",
+						"fields":{
+							"summary":"Subtask two",
+							"issuetype":{"name":"Sub-task"},
+							"status":{"name":"To Do"},
+							"parent":{"key":"STORY-1"}
+						}
+					}
+				]
+			}`))
+		default:
+			t.Fatalf("unexpected request %d: %s", call, r.URL.String())
+		}
+
+		call++
+	}))
+	defer server.Close()
+
+	client := NewClient(Config{Server: server.URL}, WithTimeout(3*time.Second))
+
+	actual, err := client.EpicTree("EPIC-1")
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	if assert.NotNil(t, actual) && assert.NotNil(t, actual.Epic) {
+		assert.Equal(t, "EPIC-1", actual.Epic.Key)
+		assert.Len(t, actual.Children, 2)
+		assert.Equal(t, "STORY-1", actual.Children[0].Issue.Key)
+		assert.Len(t, actual.Children[0].Subtasks, 2)
+		assert.Equal(t, "SUB-1", actual.Children[0].Subtasks[0].Key)
+		assert.Equal(t, "SUB-2", actual.Children[0].Subtasks[1].Key)
+		assert.Equal(t, "TASK-1", actual.Children[1].Issue.Key)
+		assert.Empty(t, actual.Children[1].Subtasks)
+	}
+
+	assert.Equal(t, 3, call)
+}
+
+func TestEpicTreeUnexpectedResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/rest/api/2/issue/EPIC-1", r.URL.Path)
+		w.WriteHeader(http.StatusBadRequest)
+	}))
+	defer server.Close()
+
+	client := NewClient(Config{Server: server.URL}, WithTimeout(3*time.Second))
+
+	_, err := client.EpicTree("EPIC-1")
+	assert.Error(t, &ErrUnexpectedResponse{}, err)
+}
+
+func TestEpicTreePagination(t *testing.T) {
+	call := 0
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		switch call {
+		case 0:
+			assert.Equal(t, "/rest/api/2/issue/EPIC-9", r.URL.Path)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"key":"EPIC-9","fields":{"summary":"Epic","issuetype":{"name":"Epic"},"status":{"name":"To Do"}}}`))
+		case 1:
+			assert.Equal(t, "/rest/api/2/search", r.URL.Path)
+			assert.Equal(t, "0", r.URL.Query().Get("startAt"))
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"startAt":0,"maxResults":100,"total":101,"issues":[{"key":"STORY-1","fields":{"summary":"Story 1","issuetype":{"name":"Story"},"status":{"name":"To Do"}}}]}`))
+		case 2:
+			assert.Equal(t, "/rest/api/2/search", r.URL.Path)
+			assert.Equal(t, "100", r.URL.Query().Get("startAt"))
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"startAt":100,"maxResults":100,"total":101,"issues":[{"key":"STORY-2","fields":{"summary":"Story 2","issuetype":{"name":"Story"},"status":{"name":"Done"}}}]}`))
+		case 3:
+			assert.Equal(t, "/rest/api/2/search", r.URL.Path)
+			assert.Equal(t, url.Values{
+				"fields":     []string{"*all"},
+				"jql":        []string{"parent in (STORY-1, STORY-2) ORDER BY created ASC"},
+				"maxResults": []string{"100"},
+				"startAt":    []string{"0"},
+			}, r.URL.Query())
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"startAt":0,"maxResults":100,"total":0,"issues":[]}`))
+		default:
+			t.Fatalf("unexpected request %d: %s", call, r.URL.String())
+		}
+
+		call++
+	}))
+	defer server.Close()
+
+	client := NewClient(Config{Server: server.URL}, WithTimeout(3*time.Second))
+
+	tree, err := client.EpicTree("EPIC-9")
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	assert.Len(t, tree.Children, 2)
+	assert.Equal(t, "STORY-1", tree.Children[0].Issue.Key)
+	assert.Equal(t, "STORY-2", tree.Children[1].Issue.Key)
+	assert.Equal(t, 4, call)
+}

--- a/pkg/jira/epic_tree_test.go
+++ b/pkg/jira/epic_tree_test.go
@@ -29,18 +29,15 @@ func TestEpicTree(t *testing.T) {
 				}
 			}`))
 		case 1:
-			assert.Equal(t, "/rest/api/2/search", r.URL.Path)
+			assert.Equal(t, "/rest/api/3/search/jql", r.URL.Path)
 			assert.Equal(t, url.Values{
 				"fields":     []string{"*all"},
 				"jql":        []string{`"Epic Link" = EPIC-1 OR parent = EPIC-1 ORDER BY created ASC`},
 				"maxResults": []string{"100"},
-				"startAt":    []string{"0"},
 			}, r.URL.Query())
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write([]byte(`{
-				"startAt":0,
-				"maxResults":100,
-				"total":2,
+				"isLast":true,
 				"issues":[
 					{
 						"key":"STORY-1",
@@ -71,18 +68,15 @@ func TestEpicTree(t *testing.T) {
 				]
 			}`))
 		case 2:
-			assert.Equal(t, "/rest/api/2/search", r.URL.Path)
+			assert.Equal(t, "/rest/api/3/search/jql", r.URL.Path)
 			assert.Equal(t, url.Values{
 				"fields":     []string{"*all"},
 				"jql":        []string{"parent in (STORY-1, TASK-1) ORDER BY created ASC"},
 				"maxResults": []string{"100"},
-				"startAt":    []string{"0"},
 			}, r.URL.Query())
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write([]byte(`{
-				"startAt":0,
-				"maxResults":100,
-				"total":2,
+				"isLast":true,
 				"issues":[
 					{
 						"key":"SUB-1",
@@ -158,25 +152,24 @@ func TestEpicTreePagination(t *testing.T) {
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write([]byte(`{"key":"EPIC-9","fields":{"summary":"Epic","issuetype":{"name":"Epic"},"status":{"name":"To Do"}}}`))
 		case 1:
-			assert.Equal(t, "/rest/api/2/search", r.URL.Path)
-			assert.Equal(t, "0", r.URL.Query().Get("startAt"))
+			assert.Equal(t, "/rest/api/3/search/jql", r.URL.Path)
+			assert.Empty(t, r.URL.Query().Get("nextPageToken"))
 			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(`{"startAt":0,"maxResults":100,"total":101,"issues":[{"key":"STORY-1","fields":{"summary":"Story 1","issuetype":{"name":"Story"},"status":{"name":"To Do"}}}]}`))
+			_, _ = w.Write([]byte(`{"isLast":false,"nextPageToken":"page2","issues":[{"key":"STORY-1","fields":{"summary":"Story 1","issuetype":{"name":"Story"},"status":{"name":"To Do"}}}]}`))
 		case 2:
-			assert.Equal(t, "/rest/api/2/search", r.URL.Path)
-			assert.Equal(t, "100", r.URL.Query().Get("startAt"))
+			assert.Equal(t, "/rest/api/3/search/jql", r.URL.Path)
+			assert.Equal(t, "page2", r.URL.Query().Get("nextPageToken"))
 			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(`{"startAt":100,"maxResults":100,"total":101,"issues":[{"key":"STORY-2","fields":{"summary":"Story 2","issuetype":{"name":"Story"},"status":{"name":"Done"}}}]}`))
+			_, _ = w.Write([]byte(`{"isLast":true,"issues":[{"key":"STORY-2","fields":{"summary":"Story 2","issuetype":{"name":"Story"},"status":{"name":"Done"}}}]}`))
 		case 3:
-			assert.Equal(t, "/rest/api/2/search", r.URL.Path)
+			assert.Equal(t, "/rest/api/3/search/jql", r.URL.Path)
 			assert.Equal(t, url.Values{
 				"fields":     []string{"*all"},
 				"jql":        []string{"parent in (STORY-1, STORY-2) ORDER BY created ASC"},
 				"maxResults": []string{"100"},
-				"startAt":    []string{"0"},
 			}, r.URL.Query())
 			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(`{"startAt":0,"maxResults":100,"total":0,"issues":[]}`))
+			_, _ = w.Write([]byte(`{"isLast":true,"issues":[]}`))
 		default:
 			t.Fatalf("unexpected request %d: %s", call, r.URL.String())
 		}
@@ -196,4 +189,52 @@ func TestEpicTreePagination(t *testing.T) {
 	assert.Equal(t, "STORY-1", tree.Children[0].Issue.Key)
 	assert.Equal(t, "STORY-2", tree.Children[1].Issue.Key)
 	assert.Equal(t, 4, call)
+}
+
+func TestEpicTreeServerFallbackToV2(t *testing.T) {
+	call := 0
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		switch call {
+		case 0:
+			assert.Equal(t, "/rest/api/2/issue/EPIC-1", r.URL.Path)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"key":"EPIC-1","fields":{"summary":"Epic","issuetype":{"name":"Epic"},"status":{"name":"To Do"}}}`))
+		case 1:
+			// Server/DC has no v3 API.
+			assert.Equal(t, "/rest/api/3/search/jql", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		case 2:
+			assert.Equal(t, "/rest/api/2/search", r.URL.Path)
+			assert.Equal(t, "0", r.URL.Query().Get("startAt"))
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"startAt":0,"maxResults":100,"total":1,"issues":[{"key":"STORY-1","fields":{"summary":"Story 1","issuetype":{"name":"Story"},"status":{"name":"To Do"}}}]}`))
+		case 3:
+			assert.Equal(t, "/rest/api/3/search/jql", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		case 4:
+			assert.Equal(t, "/rest/api/2/search", r.URL.Path)
+			assert.Equal(t, "parent in (STORY-1) ORDER BY created ASC", r.URL.Query().Get("jql"))
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"startAt":0,"maxResults":100,"total":0,"issues":[]}`))
+		default:
+			t.Fatalf("unexpected request %d: %s", call, r.URL.String())
+		}
+
+		call++
+	}))
+	defer server.Close()
+
+	client := NewClient(Config{Server: server.URL}, WithTimeout(3*time.Second))
+
+	tree, err := client.EpicTree("EPIC-1")
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	assert.Len(t, tree.Children, 1)
+	assert.Equal(t, "STORY-1", tree.Children[0].Issue.Key)
+	assert.Equal(t, 5, call)
 }

--- a/pkg/jira/issue.go
+++ b/pkg/jira/issue.go
@@ -341,6 +341,66 @@ type issueWorklogRequest struct {
 	Comment   string `json:"comment"`
 }
 
+// IssueComment holds data for a single Jira issue comment (v2 API).
+type IssueComment struct {
+	ID   string `json:"id"`
+	Body string `json:"body"`
+}
+
+// GetIssueComment fetches a single comment using GET /issue/{key}/comment/{commentID}.
+func (c *Client) GetIssueComment(key, commentID string) (*IssueComment, error) {
+	path := fmt.Sprintf("/issue/%s/comment/%s", key, commentID)
+	res, err := c.GetV2(context.Background(), path, Header{
+		"Accept": "application/json",
+	})
+	if err != nil {
+		return nil, err
+	}
+	if res == nil {
+		return nil, ErrEmptyResponse
+	}
+	defer func() { _ = res.Body.Close() }()
+
+	if res.StatusCode != http.StatusOK {
+		return nil, formatUnexpectedResponse(res)
+	}
+
+	var comment IssueComment
+	if err := json.NewDecoder(res.Body).Decode(&comment); err != nil {
+		return nil, err
+	}
+	return &comment, nil
+}
+
+// UpdateIssueComment updates a comment using PUT /issue/{key}/comment/{commentID}.
+func (c *Client) UpdateIssueComment(key, commentID, comment string, internal bool) error {
+	body, err := json.Marshal(&issueCommentRequest{
+		Body:       md.ToJiraMD(comment),
+		Properties: []issueCommentProperty{{Key: "sd.public.comment", Value: issueCommentPropertyValue{Internal: internal}}},
+	})
+	if err != nil {
+		return err
+	}
+
+	path := fmt.Sprintf("/issue/%s/comment/%s", key, commentID)
+	res, err := c.PutV2(context.Background(), path, body, Header{
+		"Accept":       "application/json",
+		"Content-Type": "application/json",
+	})
+	if err != nil {
+		return err
+	}
+	if res == nil {
+		return ErrEmptyResponse
+	}
+	defer func() { _ = res.Body.Close() }()
+
+	if res.StatusCode != http.StatusOK {
+		return formatUnexpectedResponse(res)
+	}
+	return nil
+}
+
 // AddIssueWorklog adds worklog to an issue using POST /issue/{key}/worklog endpoint.
 // Leave param `started` empty to use the server's current datetime as start date.
 func (c *Client) AddIssueWorklog(key, started, timeSpent, comment, newEstimate string) error {

--- a/pkg/jira/issue.go
+++ b/pkg/jira/issue.go
@@ -372,6 +372,32 @@ func (c *Client) GetIssueComment(key, commentID string) (*IssueComment, error) {
 	return &comment, nil
 }
 
+// GetSubtasks fetches subtasks of an issue using GET /issue/{key}?fields=subtasks.
+func (c *Client) GetSubtasks(key string) ([]Issue, error) {
+	path := fmt.Sprintf("/issue/%s?fields=subtasks", key)
+	res, err := c.GetV2(context.Background(), path, Header{
+		"Accept": "application/json",
+	})
+	if err != nil {
+		return nil, err
+	}
+	if res == nil {
+		return nil, ErrEmptyResponse
+	}
+	defer func() { _ = res.Body.Close() }()
+
+	if res.StatusCode != http.StatusOK {
+		return nil, formatUnexpectedResponse(res)
+	}
+
+	var issue Issue
+	if err := json.NewDecoder(res.Body).Decode(&issue); err != nil {
+		return nil, err
+	}
+
+	return issue.Fields.Subtasks, nil
+}
+
 // UpdateIssueComment updates a comment using PUT /issue/{key}/comment/{commentID}.
 func (c *Client) UpdateIssueComment(key, commentID, comment string, internal bool) error {
 	body, err := json.Marshal(&issueCommentRequest{

--- a/pkg/jira/issue.go
+++ b/pkg/jira/issue.go
@@ -306,12 +306,16 @@ type issueCommentProperty struct {
 }
 type issueCommentRequest struct {
 	Body       string                 `json:"body"`
-	Properties []issueCommentProperty `json:"properties"`
+	Properties []issueCommentProperty `json:"properties,omitempty"`
 }
 
 // AddIssueComment adds comment to an issue using POST /issue/{key}/comment endpoint.
 func (c *Client) AddIssueComment(key, comment string, internal bool) error {
-	body, err := json.Marshal(&issueCommentRequest{Body: md.ToJiraMD(comment), Properties: []issueCommentProperty{{Key: "sd.public.comment", Value: issueCommentPropertyValue{Internal: internal}}}})
+	req := &issueCommentRequest{Body: comment}
+	if internal {
+		req.Properties = []issueCommentProperty{{Key: "sd.public.comment", Value: issueCommentPropertyValue{Internal: internal}}}
+	}
+	body, err := json.Marshal(req)
 	if err != nil {
 		return err
 	}
@@ -400,10 +404,11 @@ func (c *Client) GetSubtasks(key string) ([]Issue, error) {
 
 // UpdateIssueComment updates a comment using PUT /issue/{key}/comment/{commentID}.
 func (c *Client) UpdateIssueComment(key, commentID, comment string, internal bool) error {
-	body, err := json.Marshal(&issueCommentRequest{
-		Body:       md.ToJiraMD(comment),
-		Properties: []issueCommentProperty{{Key: "sd.public.comment", Value: issueCommentPropertyValue{Internal: internal}}},
-	})
+	req := &issueCommentRequest{Body: comment}
+	if internal {
+		req.Properties = []issueCommentProperty{{Key: "sd.public.comment", Value: issueCommentPropertyValue{Internal: internal}}}
+	}
+	body, err := json.Marshal(req)
 	if err != nil {
 		return err
 	}

--- a/pkg/jira/issue_test.go
+++ b/pkg/jira/issue_test.go
@@ -554,6 +554,71 @@ func TestAddIssueComment(t *testing.T) {
 	assert.Error(t, &ErrUnexpectedResponse{}, err)
 }
 
+func TestGetIssueComment(t *testing.T) {
+	var notFound bool
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.Equal(t, "/rest/api/2/issue/TEST-1/comment/10042", r.URL.Path)
+		assert.Equal(t, "application/json", r.Header.Get("Accept"))
+
+		if notFound {
+			w.WriteHeader(404)
+			return
+		}
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{"id":"10042","body":"existing comment text"}`))
+	}))
+	defer server.Close()
+
+	client := NewClient(Config{Server: server.URL}, WithTimeout(3*time.Second))
+
+	comment, err := client.GetIssueComment("TEST-1", "10042")
+	assert.NoError(t, err)
+	assert.Equal(t, "10042", comment.ID)
+	assert.Equal(t, "existing comment text", comment.Body)
+
+	notFound = true
+
+	comment, err = client.GetIssueComment("TEST-1", "10042")
+	assert.Nil(t, comment)
+	assert.Error(t, err)
+}
+
+func TestUpdateIssueComment(t *testing.T) {
+	var unexpectedStatusCode bool
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "PUT", r.Method)
+		assert.Equal(t, "/rest/api/2/issue/TEST-1/comment/10042", r.URL.Path)
+		assert.Equal(t, "application/json", r.Header.Get("Accept"))
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+
+		actualBody := new(strings.Builder)
+		_, _ = io.Copy(actualBody, r.Body)
+
+		expectedBody := `{"body":"updated comment","properties":[{"key":"sd.public.comment","value":{"internal":false}}]}`
+		assert.Equal(t, expectedBody, actualBody.String())
+
+		if unexpectedStatusCode {
+			w.WriteHeader(400)
+		} else {
+			w.WriteHeader(200)
+		}
+	}))
+	defer server.Close()
+
+	client := NewClient(Config{Server: server.URL}, WithTimeout(3*time.Second))
+
+	err := client.UpdateIssueComment("TEST-1", "10042", "updated comment", false)
+	assert.NoError(t, err)
+
+	unexpectedStatusCode = true
+
+	err = client.UpdateIssueComment("TEST-1", "10042", "updated comment", false)
+	assert.Error(t, &ErrUnexpectedResponse{}, err)
+}
+
 func TestAddIssueWorklog(t *testing.T) {
 	var unexpectedStatusCode bool
 

--- a/pkg/jira/issue_test.go
+++ b/pkg/jira/issue_test.go
@@ -585,6 +585,42 @@ func TestGetIssueComment(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestGetSubtasks(t *testing.T) {
+	var notFound bool
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/rest/api/2/issue/TEST-1", r.URL.Path)
+		assert.Equal(t, "fields=subtasks", r.URL.RawQuery)
+		assert.Equal(t, "application/json", r.Header.Get("Accept"))
+
+		if notFound {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"fields":{"subtasks":[{"key":"TEST-2","fields":{"issuetype":{"name":"Impact Analysis"},"summary":"Impact task","status":{"name":"To Do"}}}]}}`))
+	}))
+	defer server.Close()
+
+	client := NewClient(Config{Server: server.URL}, WithTimeout(3*time.Second))
+
+	subtasks, err := client.GetSubtasks("TEST-1")
+	assert.NoError(t, err)
+	assert.Len(t, subtasks, 1)
+	assert.Equal(t, "TEST-2", subtasks[0].Key)
+	assert.Equal(t, "Impact Analysis", subtasks[0].Fields.IssueType.Name)
+	assert.Equal(t, "Impact task", subtasks[0].Fields.Summary)
+	assert.Equal(t, "To Do", subtasks[0].Fields.Status.Name)
+
+	notFound = true
+
+	subtasks, err = client.GetSubtasks("TEST-1")
+	assert.Nil(t, subtasks)
+	assert.Error(t, err)
+}
+
 func TestUpdateIssueComment(t *testing.T) {
 	var unexpectedStatusCode bool
 

--- a/pkg/jira/issue_test.go
+++ b/pkg/jira/issue_test.go
@@ -531,7 +531,7 @@ func TestAddIssueComment(t *testing.T) {
 		actualBody := new(strings.Builder)
 		_, _ = io.Copy(actualBody, r.Body)
 
-		expectedBody := `{"body":"comment","properties":[{"key":"sd.public.comment","value":{"internal":false}}]}`
+		expectedBody := `{"body":"comment"}`
 
 		assert.Equal(t, expectedBody, actualBody.String())
 
@@ -552,6 +552,23 @@ func TestAddIssueComment(t *testing.T) {
 
 	err = client.AddIssueComment("TEST-1", "comment", false)
 	assert.Error(t, &ErrUnexpectedResponse{}, err)
+}
+
+func TestAddIssueCommentInternal(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		actualBody := new(strings.Builder)
+		_, _ = io.Copy(actualBody, r.Body)
+
+		expectedBody := `{"body":"comment","properties":[{"key":"sd.public.comment","value":{"internal":true}}]}`
+		assert.Equal(t, expectedBody, actualBody.String())
+
+		w.WriteHeader(201)
+	}))
+	defer server.Close()
+
+	client := NewClient(Config{Server: server.URL}, WithTimeout(3*time.Second))
+	err := client.AddIssueComment("TEST-1", "comment", true)
+	assert.NoError(t, err)
 }
 
 func TestGetIssueComment(t *testing.T) {
@@ -633,7 +650,7 @@ func TestUpdateIssueComment(t *testing.T) {
 		actualBody := new(strings.Builder)
 		_, _ = io.Copy(actualBody, r.Body)
 
-		expectedBody := `{"body":"updated comment","properties":[{"key":"sd.public.comment","value":{"internal":false}}]}`
+		expectedBody := `{"body":"updated comment"}`
 		assert.Equal(t, expectedBody, actualBody.String())
 
 		if unexpectedStatusCode {
@@ -653,6 +670,23 @@ func TestUpdateIssueComment(t *testing.T) {
 
 	err = client.UpdateIssueComment("TEST-1", "10042", "updated comment", false)
 	assert.Error(t, &ErrUnexpectedResponse{}, err)
+}
+
+func TestUpdateIssueCommentInternal(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		actualBody := new(strings.Builder)
+		_, _ = io.Copy(actualBody, r.Body)
+
+		expectedBody := `{"body":"updated comment","properties":[{"key":"sd.public.comment","value":{"internal":true}}]}`
+		assert.Equal(t, expectedBody, actualBody.String())
+
+		w.WriteHeader(200)
+	}))
+	defer server.Close()
+
+	client := NewClient(Config{Server: server.URL}, WithTimeout(3*time.Second))
+	err := client.UpdateIssueComment("TEST-1", "10042", "updated comment", true)
+	assert.NoError(t, err)
 }
 
 func TestAddIssueWorklog(t *testing.T) {

--- a/pkg/jira/moveproject.go
+++ b/pkg/jira/moveproject.go
@@ -1,0 +1,184 @@
+package jira
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/url"
+	"regexp"
+	"strings"
+)
+
+var moveProjectBrowsePattern = regexp.MustCompile(`/browse/([A-Z]+-\d+)`)
+
+// MoveProjectParams holds parameters for moving an issue between projects.
+type MoveProjectParams struct {
+	IssueKey      string
+	TargetProject string
+	IssueType     string // empty = keep same
+	DryRun        bool
+}
+
+// MoveProjectResult holds the result of a project move.
+type MoveProjectResult struct {
+	OldKey     string
+	NewKey     string
+	OldProject string
+	NewProject string
+	IssueType  string
+}
+
+// MoveProject moves an issue from one Jira project to another using the legacy JSP workflow.
+func MoveProject(sc *SessionClient, client *Client, params MoveProjectParams) (*MoveProjectResult, error) {
+	if sc == nil {
+		return nil, fmt.Errorf("session client is required")
+	}
+	if client == nil {
+		return nil, fmt.Errorf("client is required")
+	}
+	if strings.TrimSpace(params.IssueKey) == "" {
+		return nil, fmt.Errorf("issue key is required")
+	}
+	if strings.TrimSpace(params.TargetProject) == "" {
+		return nil, fmt.Errorf("target project is required")
+	}
+
+	type issueResponse struct {
+		ID     string `json:"id"`
+		Key    string `json:"key"`
+		Fields struct {
+			Project struct {
+				ID  string `json:"id"`
+				Key string `json:"key"`
+			} `json:"project"`
+			IssueType struct {
+				ID   string `json:"id"`
+				Name string `json:"name"`
+			} `json:"issuetype"`
+		} `json:"fields"`
+	}
+
+	type projectResponse struct {
+		ID         string `json:"id"`
+		Key        string `json:"key"`
+		IssueTypes []struct {
+			ID   string `json:"id"`
+			Name string `json:"name"`
+		} `json:"issueTypes"`
+	}
+
+	issueResp, err := client.GetV2(context.Background(), "/issue/"+params.IssueKey+"?fields=project,issuetype", nil)
+	if err != nil {
+		return nil, err
+	}
+	defer issueResp.Body.Close()
+
+	issueBody, err := io.ReadAll(issueResp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var issueInfo issueResponse
+	if err := json.Unmarshal(issueBody, &issueInfo); err != nil {
+		return nil, fmt.Errorf("parse issue response: %w", err)
+	}
+
+	if strings.TrimSpace(issueInfo.ID) == "" {
+		return nil, fmt.Errorf("issue %q missing id", params.IssueKey)
+	}
+	if strings.TrimSpace(issueInfo.Fields.Project.Key) == "" {
+		return nil, fmt.Errorf("issue %q missing project key", params.IssueKey)
+	}
+	if strings.TrimSpace(issueInfo.Fields.IssueType.Name) == "" {
+		return nil, fmt.Errorf("issue %q missing issue type", params.IssueKey)
+	}
+
+	targetResp, err := client.GetV2(context.Background(), "/project/"+params.TargetProject, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer targetResp.Body.Close()
+
+	targetBody, err := io.ReadAll(targetResp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var targetInfo projectResponse
+	if err := json.Unmarshal(targetBody, &targetInfo); err != nil {
+		return nil, fmt.Errorf("parse target project response: %w", err)
+	}
+
+	if strings.TrimSpace(targetInfo.ID) == "" {
+		return nil, fmt.Errorf("target project %q missing id", params.TargetProject)
+	}
+	if strings.TrimSpace(targetInfo.Key) == "" {
+		return nil, fmt.Errorf("target project %q missing key", params.TargetProject)
+	}
+
+	if strings.EqualFold(issueInfo.Fields.Project.Key, targetInfo.Key) {
+		return nil, fmt.Errorf("issue %q is already in project %q", params.IssueKey, targetInfo.Key)
+	}
+
+	issueTypeName := strings.TrimSpace(params.IssueType)
+	if issueTypeName == "" {
+		issueTypeName = issueInfo.Fields.IssueType.Name
+	}
+
+	issueTypeID := ""
+	for _, targetIssueType := range targetInfo.IssueTypes {
+		if targetIssueType.Name == issueTypeName {
+			issueTypeID = targetIssueType.ID
+			break
+		}
+	}
+	if issueTypeID == "" {
+		return nil, fmt.Errorf("issue type %q is not available in project %q", issueTypeName, targetInfo.Key)
+	}
+
+	result := &MoveProjectResult{
+		OldKey:     issueInfo.Key,
+		OldProject: issueInfo.Fields.Project.Key,
+		NewProject: targetInfo.Key,
+		IssueType:  issueTypeName,
+	}
+
+	if params.DryRun {
+		return result, nil
+	}
+
+	if _, err := sc.Get("/secure/MoveIssue!default.jspa?id=" + issueInfo.ID); err != nil {
+		return nil, err
+	}
+
+	stepTwo := url.Values{}
+	stepTwo.Set("id", issueInfo.ID)
+	stepTwo.Set("pid", targetInfo.ID)
+	stepTwo.Set("issuetype", issueTypeID)
+	if _, _, err := sc.PostForm("/secure/MoveIssue.jspa", stepTwo); err != nil {
+		return nil, err
+	}
+
+	stepThree := url.Values{}
+	stepThree.Set("id", issueInfo.ID)
+	if _, _, err := sc.PostForm("/secure/MoveIssueUpdateFields.jspa", stepThree); err != nil {
+		return nil, err
+	}
+
+	stepFour := url.Values{}
+	stepFour.Set("id", issueInfo.ID)
+	_, finalURL, err := sc.PostForm("/secure/MoveIssueConfirm.jspa", stepFour)
+	if err != nil {
+		return nil, err
+	}
+
+	match := moveProjectBrowsePattern.FindStringSubmatch(finalURL)
+	if len(match) != 2 {
+		return nil, fmt.Errorf("could not extract new issue key from redirect URL %q", finalURL)
+	}
+
+	result.NewKey = match[1]
+
+	return result, nil
+}

--- a/pkg/jira/moveproject.go
+++ b/pkg/jira/moveproject.go
@@ -32,6 +32,126 @@ type MoveProjectResult struct {
 	IssueType  string
 }
 
+type issueInfo struct {
+	ID     string `json:"id"`
+	Key    string `json:"key"`
+	Fields struct {
+		Project struct {
+			ID  string `json:"id"`
+			Key string `json:"key"`
+		} `json:"project"`
+		IssueType struct {
+			ID   string `json:"id"`
+			Name string `json:"name"`
+		} `json:"issuetype"`
+	} `json:"fields"`
+}
+
+type projectInfo struct {
+	ID         string `json:"id"`
+	Key        string `json:"key"`
+	IssueTypes []struct {
+		ID   string `json:"id"`
+		Name string `json:"name"`
+	} `json:"issueTypes"`
+}
+
+func fetchIssueInfo(client *Client, issueKey string) (*issueInfo, error) {
+	issueResp, err := client.GetV2(context.Background(), "/issue/"+issueKey+"?fields=project,issuetype", nil)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = issueResp.Body.Close() }()
+
+	issueBody, err := io.ReadAll(issueResp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var info issueInfo
+	if err := json.Unmarshal(issueBody, &info); err != nil {
+		return nil, fmt.Errorf("parse issue response: %w", err)
+	}
+
+	if strings.TrimSpace(info.ID) == "" {
+		return nil, fmt.Errorf("issue %q missing id", issueKey)
+	}
+	if strings.TrimSpace(info.Fields.Project.Key) == "" {
+		return nil, fmt.Errorf("issue %q missing project key", issueKey)
+	}
+	if strings.TrimSpace(info.Fields.IssueType.Name) == "" {
+		return nil, fmt.Errorf("issue %q missing issue type", issueKey)
+	}
+
+	return &info, nil
+}
+
+func fetchProjectInfo(client *Client, projectKey string) (*projectInfo, error) {
+	targetResp, err := client.GetV2(context.Background(), "/project/"+projectKey, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = targetResp.Body.Close() }()
+
+	targetBody, err := io.ReadAll(targetResp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var info projectInfo
+	if err := json.Unmarshal(targetBody, &info); err != nil {
+		return nil, fmt.Errorf("parse target project response: %w", err)
+	}
+
+	if strings.TrimSpace(info.ID) == "" {
+		return nil, fmt.Errorf("target project %q missing id", projectKey)
+	}
+	if strings.TrimSpace(info.Key) == "" {
+		return nil, fmt.Errorf("target project %q missing key", projectKey)
+	}
+
+	return &info, nil
+}
+
+func resolveTargetIssueType(issue *issueInfo, project *projectInfo, requestedType string) (string, string, error) {
+	issueTypeName := strings.TrimSpace(requestedType)
+	if issueTypeName == "" {
+		issueTypeName = issue.Fields.IssueType.Name
+	}
+
+	for _, targetIssueType := range project.IssueTypes {
+		if targetIssueType.Name == issueTypeName {
+			return issueTypeName, targetIssueType.ID, nil
+		}
+	}
+
+	return "", "", fmt.Errorf("issue type %q is not available in project %q", issueTypeName, project.Key)
+}
+
+func extractMovedIssueKey(result *MoveProjectResult, originalKey, finalURL, body string) bool {
+	match := moveProjectBrowsePattern.FindStringSubmatch(finalURL)
+	if len(match) == 2 && match[1] != originalKey {
+		result.NewKey = match[1]
+		return true
+	}
+
+	for _, m := range moveProjectTitlePattern.FindAllStringSubmatch(body, -1) {
+		if len(m) == 2 && m[1] != originalKey {
+			result.NewKey = m[1]
+			return true
+		}
+	}
+
+	for _, m := range moveProjectBrowsePattern.FindAllStringSubmatch(body, -1) {
+		if len(m) == 2 && m[1] != originalKey {
+			result.NewKey = m[1]
+			return true
+		}
+	}
+
+	return false
+}
+
 // MoveProject moves an issue from one Jira project to another using the legacy JSP workflow.
 func MoveProject(sc *SessionClient, client *Client, params MoveProjectParams) (*MoveProjectResult, error) {
 	if sc == nil {
@@ -47,97 +167,23 @@ func MoveProject(sc *SessionClient, client *Client, params MoveProjectParams) (*
 		return nil, fmt.Errorf("target project is required")
 	}
 
-	type issueResponse struct {
-		ID     string `json:"id"`
-		Key    string `json:"key"`
-		Fields struct {
-			Project struct {
-				ID  string `json:"id"`
-				Key string `json:"key"`
-			} `json:"project"`
-			IssueType struct {
-				ID   string `json:"id"`
-				Name string `json:"name"`
-			} `json:"issuetype"`
-		} `json:"fields"`
-	}
-
-	type projectResponse struct {
-		ID         string `json:"id"`
-		Key        string `json:"key"`
-		IssueTypes []struct {
-			ID   string `json:"id"`
-			Name string `json:"name"`
-		} `json:"issueTypes"`
-	}
-
-	issueResp, err := client.GetV2(context.Background(), "/issue/"+params.IssueKey+"?fields=project,issuetype", nil)
-	if err != nil {
-		return nil, err
-	}
-	defer issueResp.Body.Close()
-
-	issueBody, err := io.ReadAll(issueResp.Body)
+	issueInfo, err := fetchIssueInfo(client, params.IssueKey)
 	if err != nil {
 		return nil, err
 	}
 
-	var issueInfo issueResponse
-	if err := json.Unmarshal(issueBody, &issueInfo); err != nil {
-		return nil, fmt.Errorf("parse issue response: %w", err)
-	}
-
-	if strings.TrimSpace(issueInfo.ID) == "" {
-		return nil, fmt.Errorf("issue %q missing id", params.IssueKey)
-	}
-	if strings.TrimSpace(issueInfo.Fields.Project.Key) == "" {
-		return nil, fmt.Errorf("issue %q missing project key", params.IssueKey)
-	}
-	if strings.TrimSpace(issueInfo.Fields.IssueType.Name) == "" {
-		return nil, fmt.Errorf("issue %q missing issue type", params.IssueKey)
-	}
-
-	targetResp, err := client.GetV2(context.Background(), "/project/"+params.TargetProject, nil)
+	targetInfo, err := fetchProjectInfo(client, params.TargetProject)
 	if err != nil {
 		return nil, err
-	}
-	defer targetResp.Body.Close()
-
-	targetBody, err := io.ReadAll(targetResp.Body)
-	if err != nil {
-		return nil, err
-	}
-
-	var targetInfo projectResponse
-	if err := json.Unmarshal(targetBody, &targetInfo); err != nil {
-		return nil, fmt.Errorf("parse target project response: %w", err)
-	}
-
-	if strings.TrimSpace(targetInfo.ID) == "" {
-		return nil, fmt.Errorf("target project %q missing id", params.TargetProject)
-	}
-	if strings.TrimSpace(targetInfo.Key) == "" {
-		return nil, fmt.Errorf("target project %q missing key", params.TargetProject)
 	}
 
 	if strings.EqualFold(issueInfo.Fields.Project.Key, targetInfo.Key) {
 		return nil, fmt.Errorf("issue %q is already in project %q", params.IssueKey, targetInfo.Key)
 	}
 
-	issueTypeName := strings.TrimSpace(params.IssueType)
-	if issueTypeName == "" {
-		issueTypeName = issueInfo.Fields.IssueType.Name
-	}
-
-	issueTypeID := ""
-	for _, targetIssueType := range targetInfo.IssueTypes {
-		if targetIssueType.Name == issueTypeName {
-			issueTypeID = targetIssueType.ID
-			break
-		}
-	}
-	if issueTypeID == "" {
-		return nil, fmt.Errorf("issue type %q is not available in project %q", issueTypeName, targetInfo.Key)
+	issueTypeName, issueTypeID, err := resolveTargetIssueType(issueInfo, targetInfo, params.IssueType)
+	if err != nil {
+		return nil, err
 	}
 
 	result := &MoveProjectResult{
@@ -178,30 +224,9 @@ func MoveProject(sc *SessionClient, client *Client, params MoveProjectParams) (*
 		return nil, err
 	}
 
-	// Try extracting the new key from the redirect URL first.
-	match := moveProjectBrowsePattern.FindStringSubmatch(finalURL)
-	if len(match) == 2 && match[1] != params.IssueKey {
-		result.NewKey = match[1]
+	if extractMovedIssueKey(result, issueInfo.Key, finalURL, body) {
 		return result, nil
 	}
 
-	// Fallback: find the new key in the page title [KEY-123] that differs from the original key.
-	for _, m := range moveProjectTitlePattern.FindAllStringSubmatch(body, -1) {
-		if len(m) == 2 && m[1] != issueInfo.Key {
-			result.NewKey = m[1]
-			return result, nil
-		}
-	}
-
-	// Last resort: find any /browse/KEY that differs from the original.
-	for _, m := range moveProjectBrowsePattern.FindAllStringSubmatch(body, -1) {
-		if len(m) == 2 && m[1] != issueInfo.Key {
-			result.NewKey = m[1]
-			return result, nil
-		}
-	}
-
 	return nil, fmt.Errorf("could not extract new issue key from response")
-
-	return result, nil
 }

--- a/pkg/jira/moveproject.go
+++ b/pkg/jira/moveproject.go
@@ -10,7 +10,10 @@ import (
 	"strings"
 )
 
-var moveProjectBrowsePattern = regexp.MustCompile(`/browse/([A-Z]+-\d+)`)
+var (
+	moveProjectBrowsePattern = regexp.MustCompile(`/browse/([A-Z]+-\d+)`)
+	moveProjectTitlePattern  = regexp.MustCompile(`\[([A-Z]+-\d+)\]`)
+)
 
 // MoveProjectParams holds parameters for moving an issue between projects.
 type MoveProjectParams struct {
@@ -168,17 +171,37 @@ func MoveProject(sc *SessionClient, client *Client, params MoveProjectParams) (*
 
 	stepFour := url.Values{}
 	stepFour.Set("id", issueInfo.ID)
-	_, finalURL, err := sc.PostForm("/secure/MoveIssueConfirm.jspa", stepFour)
+	stepFour.Set("confirm", "true")
+	stepFour.Set("Move", "Move")
+	body, finalURL, err := sc.PostForm("/secure/MoveIssueConfirm.jspa", stepFour)
 	if err != nil {
 		return nil, err
 	}
 
+	// Try extracting the new key from the redirect URL first.
 	match := moveProjectBrowsePattern.FindStringSubmatch(finalURL)
-	if len(match) != 2 {
-		return nil, fmt.Errorf("could not extract new issue key from redirect URL %q", finalURL)
+	if len(match) == 2 && match[1] != params.IssueKey {
+		result.NewKey = match[1]
+		return result, nil
 	}
 
-	result.NewKey = match[1]
+	// Fallback: find the new key in the page title [KEY-123] that differs from the original key.
+	for _, m := range moveProjectTitlePattern.FindAllStringSubmatch(body, -1) {
+		if len(m) == 2 && m[1] != issueInfo.Key {
+			result.NewKey = m[1]
+			return result, nil
+		}
+	}
+
+	// Last resort: find any /browse/KEY that differs from the original.
+	for _, m := range moveProjectBrowsePattern.FindAllStringSubmatch(body, -1) {
+		if len(m) == 2 && m[1] != issueInfo.Key {
+			result.NewKey = m[1]
+			return result, nil
+		}
+	}
+
+	return nil, fmt.Errorf("could not extract new issue key from response")
 
 	return result, nil
 }

--- a/pkg/jira/session.go
+++ b/pkg/jira/session.go
@@ -1,0 +1,155 @@
+package jira
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/cookiejar"
+	"net/url"
+	"regexp"
+	"strings"
+)
+
+var atlTokenPattern = regexp.MustCompile(`name="atl_token"\s+value="([^"]+)"`)
+
+type SessionClient struct {
+	client    *http.Client
+	server    string
+	login     string
+	token     string
+	authType  AuthType
+	xsrfToken string
+}
+
+func NewSessionClient(server, login, token string, authType AuthType, opts ...func(*http.Transport)) (*SessionClient, error) {
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		return nil, err
+	}
+
+	transport := &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+	}
+
+	for _, opt := range opts {
+		opt(transport)
+	}
+
+	return &SessionClient{
+		client: &http.Client{
+			Jar:       jar,
+			Transport: transport,
+		},
+		server:   strings.TrimSuffix(server, "/"),
+		login:    login,
+		token:    token,
+		authType: authType,
+	}, nil
+}
+
+func (s *SessionClient) Get(path string) (string, error) {
+	req, err := http.NewRequest(http.MethodGet, s.server+path, nil)
+	if err != nil {
+		return "", err
+	}
+
+	s.setAuth(req)
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	bodyText := string(body)
+	s.extractXSRFToken(resp, bodyText)
+
+	return bodyText, nil
+}
+
+func (s *SessionClient) PostForm(path string, data url.Values) (string, string, error) {
+	form := url.Values{}
+	for key, values := range data {
+		copied := make([]string, len(values))
+		copy(copied, values)
+		form[key] = copied
+	}
+
+	if s.xsrfToken != "" && form.Get("atl_token") == "" {
+		form.Set("atl_token", s.xsrfToken)
+	}
+
+	req, err := http.NewRequest(http.MethodPost, s.server+path, strings.NewReader(form.Encode()))
+	if err != nil {
+		return "", "", err
+	}
+
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	s.setAuth(req)
+
+	finalURL := req.URL.String()
+	client := *s.client
+	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		finalURL = req.URL.String()
+		if len(via) >= 10 {
+			return fmt.Errorf("stopped after 10 redirects")
+		}
+		return nil
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", finalURL, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", finalURL, err
+	}
+
+	if resp.Request != nil && resp.Request.URL != nil {
+		finalURL = resp.Request.URL.String()
+	}
+
+	bodyText := string(body)
+	s.extractXSRFToken(resp, bodyText)
+
+	return bodyText, finalURL, nil
+}
+
+func (s *SessionClient) GetXSRFToken() string {
+	return s.xsrfToken
+}
+
+func (s *SessionClient) extractXSRFToken(resp *http.Response, body string) {
+	for _, cookie := range resp.Cookies() {
+		if cookie.Name == "atlassian.xsrf.token" && cookie.Value != "" {
+			s.xsrfToken = cookie.Value
+			return
+		}
+	}
+
+	match := atlTokenPattern.FindStringSubmatch(body)
+	if len(match) == 2 {
+		s.xsrfToken = match[1]
+	}
+}
+
+func (s *SessionClient) setAuth(req *http.Request) {
+	switch s.authType.String() {
+	case string(AuthTypeMTLS):
+		if s.token != "" {
+			req.Header.Add("Authorization", "Bearer "+s.token)
+		}
+	case string(AuthTypeBearer):
+		req.Header.Add("Authorization", "Bearer "+s.token)
+	case string(AuthTypeBasic):
+		req.SetBasicAuth(s.login, s.token)
+	}
+}

--- a/pkg/jira/session.go
+++ b/pkg/jira/session.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 )
 
+const maxRedirects = 10
+
 var atlTokenPattern = regexp.MustCompile(`name="atl_token"\s+value="([^"]+)"`)
 
 type SessionClient struct {
@@ -59,7 +61,7 @@ func (s *SessionClient) Get(path string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
@@ -96,8 +98,8 @@ func (s *SessionClient) PostForm(path string, data url.Values) (string, string, 
 	client := *s.client
 	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
 		finalURL = req.URL.String()
-		if len(via) >= 10 {
-			return fmt.Errorf("stopped after 10 redirects")
+		if len(via) >= maxRedirects {
+			return fmt.Errorf("stopped after %d redirects", maxRedirects)
 		}
 		return nil
 	}
@@ -106,7 +108,7 @@ func (s *SessionClient) PostForm(path string, data url.Values) (string, string, 
 	if err != nil {
 		return "", finalURL, err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {

--- a/pkg/jira/template.go
+++ b/pkg/jira/template.go
@@ -1,0 +1,104 @@
+package jira
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+const (
+	TemplateFieldSummary     = 1
+	TemplateFieldDescription = 2
+	TemplateFieldLabels      = 4
+)
+
+type TemplateField struct {
+	FieldType             int    `json:"fieldType"`
+	Text1                 string `json:"text1"`
+	JiraField             bool   `json:"jiraField"`
+	ReadOnly              bool   `json:"readOnly"`
+	Overwritable          bool   `json:"overwritable"`
+	AtlassianWikiRenderer bool   `json:"atlassianWikiRenderer"`
+}
+
+type TemplateVariable struct {
+	ID               int      `json:"id"`
+	Key              string   `json:"key"`
+	FieldType        string   `json:"fieldType"`
+	Required         bool     `json:"required"`
+	Options          []string `json:"options"`
+	Order            int      `json:"order"`
+	IsUsedInTemplate bool     `json:"isUsedInTemplate"`
+}
+
+type TemplateResponse struct {
+	Fields              []TemplateField    `json:"fields"`
+	TemplateID          string             `json:"templateID"`
+	TemplateName        string             `json:"templateName"`
+	PatternFields       []string           `json:"patternFields"`
+	UserVariables       []TemplateVariable `json:"userVariables"`
+	TemplateDescription string             `json:"templateDescription"`
+}
+
+func (c *Client) GetIssueTemplate(templateID, projectID, issueTypeID string) (*TemplateResponse, error) {
+	path := fmt.Sprintf(
+		"/rest/it/1.0/template/autocomplete?templateId=%s&projectId=%s&issueTypeId=%s",
+		templateID,
+		projectID,
+		issueTypeID,
+	)
+
+	res, err := c.GetRaw(context.Background(), path, nil)
+	if err != nil {
+		return nil, err
+	}
+	if res == nil {
+		return nil, ErrEmptyResponse
+	}
+	defer func() { _ = res.Body.Close() }()
+
+	if res.StatusCode != http.StatusOK {
+		return nil, formatUnexpectedResponse(res)
+	}
+
+	var out TemplateResponse
+
+	err = json.NewDecoder(res.Body).Decode(&out)
+
+	return &out, err
+}
+
+func (c *Client) GetProjectV2(key string) (*Project, error) {
+	res, err := c.GetV2(context.Background(), "/project/"+key, nil)
+	if err != nil {
+		return nil, err
+	}
+	if res == nil {
+		return nil, ErrEmptyResponse
+	}
+	defer func() { _ = res.Body.Close() }()
+
+	if res.StatusCode != http.StatusOK {
+		return nil, formatUnexpectedResponse(res)
+	}
+
+	var out Project
+
+	err = json.NewDecoder(res.Body).Decode(&out)
+
+	return &out, err
+}
+
+func SubstituteTemplateVars(text string, vars map[string]string) string {
+	if len(vars) == 0 || text == "" {
+		return text
+	}
+
+	for key, val := range vars {
+		text = strings.ReplaceAll(text, "["+key+"]", val)
+	}
+
+	return text
+}

--- a/pkg/jira/template_test.go
+++ b/pkg/jira/template_test.go
@@ -1,0 +1,29 @@
+package jira
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSubstituteTemplateVars(t *testing.T) {
+	tests := []struct {
+		name     string
+		text     string
+		vars     map[string]string
+		expected string
+	}{
+		{"basic substitution", "SOS - [TITLE]", map[string]string{"TITLE": "My Task"}, "SOS - My Task"},
+		{"multiple vars", "[A] and [B]", map[string]string{"A": "X", "B": "Y"}, "X and Y"},
+		{"nil vars", "SOS - [TITLE]", nil, "SOS - [TITLE]"},
+		{"empty vars", "SOS - [TITLE]", map[string]string{}, "SOS - [TITLE]"},
+		{"no match", "plain text", map[string]string{"X": "Y"}, "plain text"},
+		{"repeated var", "[X] [X]", map[string]string{"X": "Z"}, "Z Z"},
+		{"empty value", "SOS - [TITLE]", map[string]string{"TITLE": ""}, "SOS - "},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, SubstituteTemplateVars(tt.text, tt.vars))
+		})
+	}
+}

--- a/pkg/jira/types.go
+++ b/pkg/jira/types.go
@@ -113,7 +113,7 @@ type IssueFields struct {
 		} `json:"comments"`
 		Total int `json:"total"`
 	} `json:"comment"`
-	Subtasks   []Issue
+	Subtasks   []Issue `json:"subtasks"`
 	IssueLinks []struct {
 		ID       string `json:"id"`
 		LinkType struct {

--- a/pkg/jira/types.go
+++ b/pkg/jira/types.go
@@ -28,6 +28,7 @@ func (at AuthType) String() string {
 
 // Project holds project info.
 type Project struct {
+	ID   string `json:"id"`
 	Key  string `json:"key"`
 	Name string `json:"name"`
 	Lead struct {
@@ -38,12 +39,12 @@ type Project struct {
 
 // ProjectVersion holds project version info.
 type ProjectVersion struct {
-	Archived    bool        `json:"archived"`
-	Description interface{} `json:"description"`
-	ID          string      `json:"id"`
-	Name        string      `json:"name"`
-	ProjectID   int         `json:"projectId"`
-	Released    bool        `json:"released"`
+	Archived    bool   `json:"archived"`
+	Description any    `json:"description"`
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	ProjectID   int    `json:"projectId"`
+	Released    bool   `json:"released"`
 }
 
 // Board holds board info.
@@ -61,15 +62,16 @@ type Epic struct {
 
 // Issue holds issue info.
 type Issue struct {
+	ID     string      `json:"id"`
 	Key    string      `json:"key"`
 	Fields IssueFields `json:"fields"`
 }
 
 // IssueFields holds issue fields.
 type IssueFields struct {
-	Summary     string      `json:"summary"`
-	Description interface{} `json:"description"` // string in v1/v2, adf.ADF in v3
-	Labels      []string    `json:"labels"`
+	Summary     string   `json:"summary"`
+	Description any      `json:"description"` // string in v1/v2, adf.ADF in v3
+	Labels      []string `json:"labels"`
 	Resolution  struct {
 		Name string `json:"name"`
 	} `json:"resolution"`
@@ -104,10 +106,10 @@ type IssueFields struct {
 	} `json:"versions"`
 	Comment struct {
 		Comments []struct {
-			ID      string      `json:"id"`
-			Author  User        `json:"author"`
-			Body    interface{} `json:"body"` // string in v1/v2, adf.ADF in v3
-			Created string      `json:"created"`
+			ID      string `json:"id"`
+			Author  User   `json:"author"`
+			Body    any    `json:"body"` // string in v1/v2, adf.ADF in v3
+			Created string `json:"created"`
 		} `json:"comments"`
 		Total int `json:"total"`
 	} `json:"comment"`

--- a/pkg/jql/jql.go
+++ b/pkg/jql/jql.go
@@ -23,6 +23,8 @@ type JQL struct {
 	orderBy string
 }
 
+var orderByRegex = regexp.MustCompile(`(?i)\sORDER\s+BY\s`)
+
 // NewJQL initializes jql query builder.
 func NewJQL(project string) *JQL {
 	return &JQL{
@@ -123,9 +125,9 @@ func (j *JQL) In(field string, value ...string) *JQL {
 	if field != "" && n > 0 {
 		var q strings.Builder
 
-		q.WriteString(fmt.Sprintf("%s IN (", field))
+		_, _ = fmt.Fprintf(&q, "%s IN (", field)
 		for i, v := range value {
-			q.WriteString(fmt.Sprintf("%q", v))
+			_, _ = fmt.Fprintf(&q, "%q", v)
 			if i != n-1 {
 				q.WriteString(", ")
 			}
@@ -143,9 +145,9 @@ func (j *JQL) NotIn(field string, value ...string) *JQL {
 	if field != "" && n > 0 {
 		var q strings.Builder
 
-		q.WriteString(fmt.Sprintf("%s NOT IN (", field))
+		_, _ = fmt.Fprintf(&q, "%s NOT IN (", field)
 		for i, v := range value {
-			q.WriteString(fmt.Sprintf("%q", v))
+			_, _ = fmt.Fprintf(&q, "%q", v)
 			if i != n-1 {
 				q.WriteString(", ")
 			}
@@ -161,6 +163,11 @@ func (j *JQL) NotIn(field string, value ...string) *JQL {
 func (j *JQL) OrderBy(field, dir string) *JQL {
 	j.orderBy = fmt.Sprintf("ORDER BY %s %s", field, dir)
 	return j
+}
+
+// HasOrderBy reports whether the query already contains an ORDER BY clause.
+func (j *JQL) HasOrderBy() bool {
+	return j.orderBy != ""
 }
 
 // And combines filter with AND operator.
@@ -179,15 +186,70 @@ func (j *JQL) Or(fn GroupFunc) *JQL {
 
 // Raw sets the passed JQL query along with project context.
 func (j *JQL) Raw(q string) *JQL {
-	q = strings.TrimSpace(q)
-	if q == "" {
+	filters, orderBy := SplitOrderByClause(q)
+	if filters == "" && orderBy == "" {
 		return j
 	}
-	if hasProjectFilter(q) {
+	if hasProjectFilter(filters) {
 		j.filters = j.filters[1:]
 	}
-	j.filters = append(j.filters, q)
+	if filters != "" {
+		j.filters = append(j.filters, filters)
+	}
+	if orderBy != "" {
+		j.orderBy = orderBy
+	}
 	return j
+}
+
+// SplitOrderByClause separates a trailing ORDER BY clause from a JQL query.
+func SplitOrderByClause(q string) (string, string) {
+	q = strings.TrimSpace(q)
+	if q == "" {
+		return "", ""
+	}
+
+	matches := orderByRegex.FindAllStringIndex(q, -1)
+	if len(matches) == 0 {
+		return q, ""
+	}
+
+	idx := matches[len(matches)-1][0]
+	filters := strings.TrimSpace(q[:idx])
+	orderBy := strings.TrimSpace(q[idx:])
+
+	if filters == "" {
+		return q, ""
+	}
+
+	return filters, orderBy
+}
+
+// AppendAnd appends clauses before a trailing ORDER BY clause, if present.
+func AppendAnd(q string, clauses ...string) string {
+	filters, orderBy := SplitOrderByClause(q)
+	parts := make([]string, 0, len(clauses)+1)
+
+	if filters != "" {
+		parts = append(parts, filters)
+	}
+
+	for _, clause := range clauses {
+		clause = strings.TrimSpace(clause)
+		if clause != "" {
+			parts = append(parts, clause)
+		}
+	}
+
+	joined := strings.Join(parts, " AND ")
+	if joined == "" {
+		return orderBy
+	}
+	if orderBy != "" {
+		return joined + " " + orderBy
+	}
+
+	return joined
 }
 
 // String returns the constructed query.
@@ -204,7 +266,7 @@ func (j *JQL) mergeFilters(separator string) {
 		qs.WriteString(filter)
 
 		if i != fLen-1 {
-			qs.WriteString(fmt.Sprintf(" %s ", separator))
+			_, _ = fmt.Fprintf(&qs, " %s ", separator)
 		}
 	}
 

--- a/pkg/jql/jql_test.go
+++ b/pkg/jql/jql_test.go
@@ -299,11 +299,45 @@ func TestJQL(t *testing.T) {
 			},
 			expected: "type=\"Story\" OR summary ~ cli AND project IN (TEST1,TEST2)",
 		},
+		{
+			name: "it keeps raw order by at the end of the query",
+			initialize: func() *JQL {
+				jql := NewJQL("TEST")
+				jql.And(func() {
+					jql.FilterBy("type", "Story").
+						Raw("summary ~ cli ORDER BY updated DESC")
+				})
+				return jql
+			},
+			expected: "project=\"TEST\" AND type=\"Story\" AND summary ~ cli ORDER BY updated DESC",
+		},
+		{
+			name: "it preserves raw order by with project override",
+			initialize: func() *JQL {
+				jql := NewJQL("TEST")
+				jql.And(func() {
+					jql.FilterBy("type", "Story").
+						Raw("project = TEST1 AND summary ~ cli ORDER BY updated DESC")
+				})
+				return jql
+			},
+			expected: "type=\"Story\" AND project = TEST1 AND summary ~ cli ORDER BY updated DESC",
+		},
+		{
+			name: "it keeps raw multi-column order by at the end of the query",
+			initialize: func() *JQL {
+				jql := NewJQL("TEST")
+				jql.And(func() {
+					jql.FilterBy("type", "Story").
+						Raw("summary ~ cli ORDER BY updated DESC, created DESC")
+				})
+				return jql
+			},
+			expected: "project=\"TEST\" AND type=\"Story\" AND summary ~ cli ORDER BY updated DESC, created DESC",
+		},
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -311,6 +345,38 @@ func TestJQL(t *testing.T) {
 			assert.Equal(t, tc.expected, jql.String())
 		})
 	}
+}
+
+func TestSplitOrderByClause(t *testing.T) {
+	t.Parallel()
+
+	filters, orderBy := SplitOrderByClause("summary ~ cli ORDER BY updated DESC")
+	assert.Equal(t, "summary ~ cli", filters)
+	assert.Equal(t, "ORDER BY updated DESC", orderBy)
+
+	filters, orderBy = SplitOrderByClause("summary ~ cli ORDER BY updated DESC, created DESC")
+	assert.Equal(t, "summary ~ cli", filters)
+	assert.Equal(t, "ORDER BY updated DESC, created DESC", orderBy)
+
+	filters, orderBy = SplitOrderByClause("summary ~ cli")
+	assert.Equal(t, "summary ~ cli", filters)
+	assert.Equal(t, "", orderBy)
+}
+
+func TestAppendAnd(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(
+		t,
+		`assignee = currentUser() AND text ~ "bug" ORDER BY updated DESC`,
+		AppendAnd(`assignee = currentUser() ORDER BY updated DESC`, `text ~ "bug"`),
+	)
+
+	assert.Equal(
+		t,
+		`assignee = currentUser() AND text ~ "bug" ORDER BY updated DESC, created DESC`,
+		AppendAnd(`assignee = currentUser() ORDER BY updated DESC, created DESC`, `text ~ "bug"`),
+	)
 }
 
 func TestHasProject(t *testing.T) {
@@ -373,8 +439,6 @@ func TestHasProject(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run("", func(t *testing.T) {
 			t.Parallel()
 


### PR DESCRIPTION
Jira Cloud removed the classic `/rest/api/2/search` endpoint (CHANGE-2046) — `jira epic tree` fails with 410 Gone on cloud. Migrate to the token-paginated `/rest/api/3/search/jql` API with automatic fallback to v2 `/search` for Server/DC (which has no v3 API).

Verified live against vectorgrp02.atlassian.net (XPE3-2444 renders) and covered by tests including token pagination and the DC fallback path.

https://claude.ai/code/session_012qTAdJSyqNg1aWb3PAF2A5