### PR TITLE
Show the parent key in the issue view header

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,6 +425,8 @@ $ jira issue view ISSUE-1
 The view screen will display linked issues and the latest comment after the description. Note that the displayed comment may
 not be the latest one if you for some reason have more than 5k comments in a ticket.
 
+If the issue has a parent (for example, a sub-task or a story under an epic), the parent's key is shown in the header next to a 👪 marker.
+
 ```sh
 # Show 5 recent comments when viewing the issue
 $ jira issue view ISSUE-1 --comments 5

--- a/internal/view/issue.go
+++ b/internal/view/issue.go
@@ -229,10 +229,14 @@ func (i Issue) header() string {
 	} else if i.Data.Fields.Watches.IsWatching {
 		wch = fmt.Sprintf("You + %d watchers", i.Data.Fields.Watches.WatchCount-1)
 	}
+	var parent string
+	if i.Data.Fields.Parent != nil && i.Data.Fields.Parent.Key != "" {
+		parent = fmt.Sprintf("  👪 %s", i.Data.Fields.Parent.Key)
+	}
 	return fmt.Sprintf(
-		"%s %s  %s %s  ⌛ %s  👷 %s  🔑️ %s  💭 %d comments  \U0001F9F5 %d linked\n# %s\n⏱️  %s  🔎 %s  🚀 %s  📦 %s  🏷️  %s  👀 %s",
+		"%s %s  %s %s  ⌛ %s  👷 %s  🔑️ %s  💭 %d comments  \U0001F9F5 %d linked%s\n# %s\n⏱️  %s  🔎 %s  🚀 %s  📦 %s  🏷️  %s  👀 %s",
 		iti, it, sti, st, cmdutil.FormatDateTimeHuman(i.Data.Fields.Updated, jira.RFC3339), as, i.Data.Key,
-		i.Data.Fields.Comment.Total, len(i.Data.Fields.IssueLinks),
+		i.Data.Fields.Comment.Total, len(i.Data.Fields.IssueLinks), parent,
 		i.Data.Fields.Summary,
 		cmdutil.FormatDateTimeHuman(i.Data.Fields.Created, jira.RFC3339), i.Data.Fields.Reporter.Name,
 		i.Data.Fields.Priority.Name, cmpt, lbl, wch,

--- a/internal/view/issue_test.go
+++ b/internal/view/issue_test.go
@@ -310,3 +310,34 @@ func TestSeparator(t *testing.T) {
 		})
 	}
 }
+
+func TestIssueDetailsShowParentInHeader(t *testing.T) {
+	t.Parallel()
+
+	data := &jira.Issue{
+		Key: "TEST-2",
+		Fields: jira.IssueFields{
+			Summary:   "Sub-task with a parent",
+			IssueType: jira.IssueType{Name: "Sub-task"},
+			Status: struct {
+				Name string `json:"name"`
+			}{Name: "Open"},
+			Created: "2020-12-13T14:05:20.974+0100",
+			Updated: "2020-12-13T14:07:20.974+0100",
+		},
+	}
+	issue := Issue{
+		Server:  "https://test.local",
+		Data:    data,
+		Display: DisplayFormat{Plain: true},
+	}
+
+	// Without a parent, the header must not show the parent indicator.
+	assert.NotContains(t, issue.String(), "👪")
+
+	// With a parent, its key is shown in the header.
+	data.Fields.Parent = &struct {
+		Key string `json:"key"`
+	}{Key: "EPIC-1"}
+	assert.Contains(t, issue.String(), "👪 EPIC-1")
+}


### PR DESCRIPTION
This adds the parent's key to the header when you run `jira issue view` on an issue that has one, which covers the request in #766.

At the moment there's no way to tell from the view screen whether a ticket is a sub-task or sits under an epic without opening it in the browser. When the issue has a parent I append its key to the first line of the header next to a 👪 marker, e.g. `… 🧵 0 linked  👪 EPIC-1`. Issues without a parent render exactly as before, so existing output is unchanged.

The GET `/issue` endpoint already returns the `parent` field and it's already on the `Issue` model (used elsewhere by clone/edit), so this just surfaces it in the view. Added a test in `internal/view` covering both cases. `make lint` and `make test` pass.
