### PR TITLE
fix: support auth_type with hyphen and bearer token for Jira Server

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"strings"
 	"time"
 
 	"github.com/spf13/viper"
@@ -42,6 +43,9 @@ func Client(config jira.Config) *jira.Client {
 	}
 	if config.AuthType == nil {
 		authType := jira.AuthType(viper.GetString("auth_type"))
+		if authType == "" {
+			authType = jira.AuthType(viper.GetString("auth-type"))
+		}
 		config.AuthType = &authType
 	}
 	if config.Insecure == nil {
@@ -86,7 +90,7 @@ func ProxyCreate(c *jira.Client, cr *jira.CreateRequest) (*jira.CreateResponse, 
 
 	it := viper.GetString("installation")
 
-	if it == jira.InstallationTypeLocal {
+	if strings.EqualFold(it, jira.InstallationTypeLocal) {
 		resp, err = c.CreateV2(cr)
 	} else {
 		resp, err = c.Create(cr)
@@ -98,7 +102,7 @@ func ProxyCreate(c *jira.Client, cr *jira.CreateRequest) (*jira.CreateResponse, 
 // ProxyGetIssueRaw executes the same request as ProxyGetIssue but returns raw API response body string.
 func ProxyGetIssueRaw(c *jira.Client, key string) (string, error) {
 	it := viper.GetString("installation")
-	if it == jira.InstallationTypeLocal {
+	if strings.EqualFold(it, jira.InstallationTypeLocal) {
 		return c.GetIssueV2Raw(key)
 	}
 	return c.GetIssueRaw(key)
@@ -115,7 +119,7 @@ func ProxyGetIssue(c *jira.Client, key string, opts ...filter.Filter) (*jira.Iss
 
 	it := viper.GetString("installation")
 
-	if it == jira.InstallationTypeLocal {
+	if strings.EqualFold(it, jira.InstallationTypeLocal) {
 		iss, err = c.GetIssueV2(key, opts...)
 	} else {
 		iss, err = c.GetIssue(key, opts...)
@@ -135,7 +139,7 @@ func ProxySearch(c *jira.Client, jql string, from, limit uint) (*jira.SearchResu
 
 	it := viper.GetString("installation")
 
-	if it == jira.InstallationTypeLocal {
+	if strings.EqualFold(it, jira.InstallationTypeLocal) {
 		issues, err = c.SearchV2(jql, from, limit)
 	} else {
 		issues, err = c.Search(jql, limit)
@@ -152,15 +156,15 @@ func ProxyAssignIssue(c *jira.Client, key string, user *jira.User, def string) e
 	assignee := def
 
 	if user != nil {
-		switch it {
-		case jira.InstallationTypeLocal:
+		switch {
+		case strings.EqualFold(it, jira.InstallationTypeLocal):
 			assignee = user.Name
 		default:
 			assignee = user.AccountID
 		}
 	}
 
-	if it == jira.InstallationTypeLocal {
+	if strings.EqualFold(it, jira.InstallationTypeLocal) {
 		return c.AssignIssueV2(key, assignee)
 	}
 	return c.AssignIssue(key, assignee)
@@ -177,7 +181,7 @@ func ProxyUserSearch(c *jira.Client, opts *jira.UserSearchOptions) ([]*jira.User
 
 	it := viper.GetString("installation")
 
-	if it == jira.InstallationTypeLocal {
+	if strings.EqualFold(it, jira.InstallationTypeLocal) {
 		users, err = c.UserSearchV2(opts)
 	} else {
 		users, err = c.UserSearch(opts)
@@ -197,7 +201,7 @@ func ProxyTransitions(c *jira.Client, key string) ([]*jira.Transition, error) {
 
 	it := viper.GetString("installation")
 
-	if it == jira.InstallationTypeLocal {
+	if strings.EqualFold(it, jira.InstallationTypeLocal) {
 		transitions, err = c.TransitionsV2(key)
 	} else {
 		transitions, err = c.Transitions(key)
@@ -215,15 +219,15 @@ func ProxyWatchIssue(c *jira.Client, key string, user *jira.User) error {
 	var assignee string
 
 	if user != nil {
-		switch it {
-		case jira.InstallationTypeLocal:
+		switch {
+		case strings.EqualFold(it, jira.InstallationTypeLocal):
 			assignee = user.Name
 		default:
 			assignee = user.AccountID
 		}
 	}
 
-	if it == jira.InstallationTypeLocal {
+	if strings.EqualFold(it, jira.InstallationTypeLocal) {
 		return c.WatchIssueV2(key, assignee)
 	}
 	return c.WatchIssue(key, assignee)

--- a/internal/cmd/root/root.go
+++ b/internal/cmd/root/root.go
@@ -85,7 +85,11 @@ func NewCmdRoot() *cobra.Command {
 			}
 
 			// mTLS and cf_access don't need Jira API Token.
-			if viper.GetString("auth_type") != string(jira.AuthTypeMTLS) && viper.GetString("auth_type") != string(jira.AuthTypeCFAccess) {
+			authType := viper.GetString("auth_type")
+			if authType == "" {
+				authType = viper.GetString("auth-type")
+			}
+			if authType != string(jira.AuthTypeMTLS) && authType != string(jira.AuthTypeCFAccess) {
 				checkForJiraToken(viper.GetString("server"), viper.GetString("login"))
 			}
 

--- a/internal/cmdcommon/create.go
+++ b/internal/cmdcommon/create.go
@@ -221,7 +221,7 @@ func GetRelevantUser(client *jira.Client, project string, user string) string {
 // GetUserKeyForConfiguredInstallation returns either the user name or account ID based on jira installation type.
 func GetUserKeyForConfiguredInstallation(user *jira.User) string {
 	it := viper.GetString("installation")
-	if it == jira.InstallationTypeLocal {
+	if strings.EqualFold(it, jira.InstallationTypeLocal) {
 		return user.Name
 	}
 	return user.AccountID

--- a/internal/query/issue.go
+++ b/internal/query/issue.go
@@ -64,6 +64,13 @@ func (i *Issue) Get() string {
 
 	if i.params.JQL != "" {
 		q.Raw(i.params.JQL)
+		// If project is empty and raw JQL doesn't have project filter, remove default empty project filter
+		if i.Project == "" {
+			q.RemoveDefaultProjectFilter()
+		}
+	} else if i.Project == "" {
+		// Remove default empty project filter when no project is specified
+		q.RemoveDefaultProjectFilter()
 	}
 
 	q.And(func() {
@@ -105,10 +112,13 @@ func (i *Issue) Get() string {
 		}
 	})
 
-	if i.params.Reverse {
-		q.OrderBy(obf, jql.DirectionAscending)
-	} else {
-		q.OrderBy(obf, jql.DirectionDescending)
+	// Only add ORDER BY if the raw JQL doesn't already contain it
+	if i.params.JQL == "" || !strings.Contains(strings.ToUpper(i.params.JQL), "ORDER BY") {
+		if i.params.Reverse {
+			q.OrderBy(obf, jql.DirectionAscending)
+		} else {
+			q.OrderBy(obf, jql.DirectionDescending)
+		}
 	}
 
 	return q.String()

--- a/internal/query/issue.go
+++ b/internal/query/issue.go
@@ -45,6 +45,56 @@ func splitPositiveNegative(labels []string) ([]string, []string) {
 	return positive, negative
 }
 
+// resolveOrderBy returns the effective order-by field, switching from "created" to "updated"
+// when only updated filters are present and no explicit created filters exist.
+func (i *Issue) resolveOrderBy() string {
+	obf := i.params.OrderBy
+	if obf != "created" {
+		return obf
+	}
+	hasUpdated := i.params.Updated != "" || i.params.UpdatedBefore != "" || i.params.UpdatedAfter != ""
+	hasCreated := i.params.Created != "" || i.params.CreatedBefore != "" || i.params.CreatedAfter != ""
+	if hasUpdated && !hasCreated {
+		return "updated"
+	}
+	return obf
+}
+
+// applyFilters applies all field filters inside the JQL AND block.
+func (i *Issue) applyFilters(q *jql.JQL, obf *string) {
+	if i.params.Latest {
+		q.History()
+		*obf = "lastViewed"
+	}
+	if i.params.Watching {
+		q.Watching()
+	}
+
+	q.FilterBy("type", i.params.IssueType).
+		FilterBy("resolution", i.params.Resolution).
+		FilterBy("priority", i.params.Priority).
+		FilterBy("reporter", i.params.Reporter).
+		FilterBy("assignee", i.params.Assignee).
+		FilterBy("component", i.params.Component).
+		FilterBy("parent", i.params.Parent)
+
+	i.setCreatedFilters(q)
+	i.setUpdatedFilters(q)
+	i.applyMultiFilters(q, "labels", i.params.Labels)
+	i.applyMultiFilters(q, "status", i.params.Status)
+}
+
+// applyMultiFilters applies positive IN and negative NOT IN filters for a multi-value field.
+func (i *Issue) applyMultiFilters(q *jql.JQL, field string, values []string) {
+	positive, negative := splitPositiveNegative(values)
+	if len(positive) > 0 {
+		q.In(field, positive...)
+	}
+	if len(negative) > 0 {
+		q.NotIn(field, negative...)
+	}
+}
+
 // Get returns constructed jql query.
 func (i *Issue) Get() string {
 	var q *jql.JQL
@@ -55,64 +105,22 @@ func (i *Issue) Get() string {
 		}
 	}()
 
-	q, obf := jql.NewJQL(i.Project), i.params.OrderBy
-	if obf == "created" &&
-		(i.params.Updated != "" || i.params.UpdatedBefore != "" || i.params.UpdatedAfter != "") &&
-		(i.params.Created == "" && i.params.CreatedBefore == "" && i.params.CreatedAfter == "") {
-		obf = "updated"
-	}
+	q = jql.NewJQL(i.Project)
+	obf := i.resolveOrderBy()
 
 	if i.params.JQL != "" {
 		q.Raw(i.params.JQL)
-		// If project is empty and raw JQL doesn't have project filter, remove default empty project filter
 		if i.Project == "" {
 			q.RemoveDefaultProjectFilter()
 		}
 	} else if i.Project == "" {
-		// Remove default empty project filter when no project is specified
 		q.RemoveDefaultProjectFilter()
 	}
 
 	q.And(func() {
-		if i.params.Latest {
-			q.History()
-			obf = "lastViewed"
-		}
-		if i.params.Watching {
-			q.Watching()
-		}
-
-		q.FilterBy("type", i.params.IssueType).
-			FilterBy("resolution", i.params.Resolution).
-			FilterBy("priority", i.params.Priority).
-			FilterBy("reporter", i.params.Reporter).
-			FilterBy("assignee", i.params.Assignee).
-			FilterBy("component", i.params.Component).
-			FilterBy("parent", i.params.Parent)
-
-		i.setCreatedFilters(q)
-		i.setUpdatedFilters(q)
-
-		positive, negative := splitPositiveNegative(i.params.Labels)
-		if len(positive) > 0 {
-			q.In("labels", positive...)
-		}
-
-		if len(negative) > 0 {
-			q.NotIn("labels", negative...)
-		}
-
-		positive, negative = splitPositiveNegative(i.params.Status)
-		if len(positive) > 0 {
-			q.In("status", positive...)
-		}
-
-		if len(negative) > 0 {
-			q.NotIn("status", negative...)
-		}
+		i.applyFilters(q, &obf)
 	})
 
-	// Only add ORDER BY if the raw JQL doesn't already contain it
 	if i.params.JQL == "" || !strings.Contains(strings.ToUpper(i.params.JQL), "ORDER BY") {
 		if i.params.Reverse {
 			q.OrderBy(obf, jql.DirectionAscending)

--- a/pkg/jql/jql.go
+++ b/pkg/jql/jql.go
@@ -186,13 +186,35 @@ func (j *JQL) Raw(q string) *JQL {
 	if hasProjectFilter(q) {
 		j.filters = j.filters[1:]
 	}
-	j.filters = append(j.filters, q)
+	// Check if the raw query contains ORDER BY clause
+	if orderByIdx := strings.Index(strings.ToUpper(q), "ORDER BY"); orderByIdx != -1 {
+		// Extract the query part without ORDER BY
+		queryPart := strings.TrimSpace(q[:orderByIdx])
+		// Extract the ORDER BY part
+		orderByPart := strings.TrimSpace(q[orderByIdx:])
+		// Extract the field and direction from ORDER BY
+		orderByParts := strings.SplitN(strings.TrimPrefix(strings.ToUpper(orderByPart), "ORDER BY"), " ", 2)
+		if len(orderByParts) == 2 {
+			j.orderBy = strings.TrimSpace(orderByPart)
+		}
+		j.filters = append(j.filters, queryPart)
+	} else {
+		j.filters = append(j.filters, q)
+	}
 	return j
 }
 
 // String returns the constructed query.
 func (j *JQL) String() string {
 	return j.compile()
+}
+
+// RemoveDefaultProjectFilter removes the default project filter if project is empty.
+func (j *JQL) RemoveDefaultProjectFilter() *JQL {
+	if j.project == "" && len(j.filters) > 0 {
+		j.filters = j.filters[1:]
+	}
+	return j
 }
 
 func (j *JQL) mergeFilters(separator string) {

--- a/pkg/jql/jql.go
+++ b/pkg/jql/jql.go
@@ -188,16 +188,9 @@ func (j *JQL) Raw(q string) *JQL {
 	}
 	// Check if the raw query contains ORDER BY clause
 	if orderByIdx := strings.Index(strings.ToUpper(q), "ORDER BY"); orderByIdx != -1 {
-		// Extract the query part without ORDER BY
-		queryPart := strings.TrimSpace(q[:orderByIdx])
-		// Extract the ORDER BY part
-		orderByPart := strings.TrimSpace(q[orderByIdx:])
-		// Extract the field and direction from ORDER BY
-		orderByParts := strings.SplitN(strings.TrimPrefix(strings.ToUpper(orderByPart), "ORDER BY"), " ", 2)
-		if len(orderByParts) == 2 {
-			j.orderBy = strings.TrimSpace(orderByPart)
-		}
-		j.filters = append(j.filters, queryPart)
+		// Find ORDER BY position and directly extract the entire tail
+		j.orderBy = strings.TrimSpace(q[orderByIdx:])
+		j.filters = append(j.filters, strings.TrimSpace(q[:orderByIdx]))
 	} else {
 		j.filters = append(j.filters, q)
 	}


### PR DESCRIPTION
## Summary

This PR fixes authentication issues when using jira-cli with self-hosted Jira Server instances that only accept Bearer token authentication.

### Changes

1. **auth_type fallback** (`api/client.go`, `internal/cmd/root/root.go`): Support both `auth-type` (hyphen) and `auth_type` (underscore) in config file, since viper does not auto-convert between them.

2. **installation comparison** (`api/client.go`, `internal/cmdcommon/create.go`): Use case-insensitive comparison for `installation` config value (`local` vs `Local`).

3. **JQL query handling** (`pkg/jql/jql.go`, `internal/query/issue.go`): When user provides custom JQL with `-q` flag, don't append default project filter or override ORDER BY clause.

### Problem

- Config file uses `auth-type: bearer` but code reads `viper.GetString("auth_type")` → returns empty → defaults to Basic auth
- Jira Server instances that reject Basic auth return 403 for all API calls except `jira me`
- Self-hosted Jira instances with `installation: local` fail because code compares with `"Local"` (capitalized)

### Testing

- `jira me` → ✅ returns username
- `jira issue list` → ✅ returns issues with Bearer token auth
- `jira issue list -q "..."` → ✅ custom JQL works correctly