### PR TITLE
feat: add --body-format flag to bypass Markdown to wiki conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,9 +322,9 @@ $  jira issue create -tStory -s"Epic during creation" -PEPIC-42
 
 You can use a `--custom` flag to set custom fields while creating the issue. See [this post](https://github.com/ankitpokhrel/jira-cli/discussions/346) for more details.
 
-The command supports both [GitHub-flavored](https://github.github.com/gfm/)
-and [Jira-flavored](https://jira.atlassian.com/secure/WikiRendererHelpAction.jspa?section=all) Markdown for writing
-description.
+The command accepts a description written either as [GitHub-flavored
+Markdown](https://github.github.com/gfm/) or directly as
+[Jira wiki markup](https://jira.atlassian.com/secure/WikiRendererHelpAction.jspa?section=all).
 
 By default, the description is treated as [CommonMark
 Markdown](https://commonmark.org/) and converted to
@@ -342,11 +342,17 @@ $ jira issue create -tTask -s"Summary" -b"# foo"
 $ jira issue create -tTask -s"Summary" -b"# foo" --body-format=wiki
 ```
 
-The flag accepts `markdown` (default) or `wiki`. To skip the flag on every call,
-set `body.format: wiki` in `~/.config/.jira/.config.yml`; `jira init` writes this
-key with the `markdown` default. The same flag and config key work on `jira issue
-edit`, `jira issue comment add`, `jira issue worklog add`, `jira issue move
---comment`, and `jira epic create`.
+The flag accepts `markdown` (default) or `wiki`. To avoid passing it on every call, set the
+`body.format` key in `~/.config/.jira/.config.yml` — `jira init` writes it with the
+`markdown` default:
+
+```yaml
+body:
+  format: wiki
+```
+
+The same flag and config key work on `jira issue edit`, `jira issue comment add`,
+`jira issue worklog add`, `jira issue move --comment`, and `jira epic create`.
 
 You can load pre-defined templates using `--template` flag. Template, stdin,
 editor, and `-b` content all flow through the same body-format pipeline.

--- a/README.md
+++ b/README.md
@@ -324,7 +324,32 @@ You can use a `--custom` flag to set custom fields while creating the issue. See
 
 The command supports both [GitHub-flavored](https://github.github.com/gfm/)
 and [Jira-flavored](https://jira.atlassian.com/secure/WikiRendererHelpAction.jspa?section=all) Markdown for writing
-description. You can load pre-defined templates using `--template` flag.
+description.
+
+By default, the description is treated as [CommonMark
+Markdown](https://commonmark.org/) and converted to
+[Jira wiki markup](https://jira.atlassian.com/secure/WikiRendererHelpAction.jspa?section=all)
+before sending. If you'd rather write the description directly in Jira wiki markup —
+useful when wiki syntax (like `# item` for a numbered list, or `*bold*`) conflicts
+with what CommonMark would parse — pass `--body-format=wiki` to bypass the
+conversion:
+
+```sh
+# Default: -b is Markdown, converted to wiki ("# foo" → JIRA H1)
+$ jira issue create -tTask -s"Summary" -b"# foo"
+
+# Treat -b as wiki markup, send as-is ("# foo" → JIRA numbered-list item)
+$ jira issue create -tTask -s"Summary" -b"# foo" --body-format=wiki
+```
+
+The flag accepts `markdown` (default) or `wiki`. To skip the flag on every call,
+set `body.format: wiki` in `~/.config/.jira/.config.yml`; `jira init` writes this
+key with the `markdown` default. The same flag and config key work on `jira issue
+edit`, `jira issue comment add`, `jira issue worklog add`, `jira issue move
+--comment`, and `jira epic create`.
+
+You can load pre-defined templates using `--template` flag. Template, stdin,
+editor, and `-b` content all flow through the same body-format pipeline.
 
 ```sh
 # Load description from template file

--- a/internal/cmd/epic/create/create.go
+++ b/internal/cmd/epic/create/create.go
@@ -52,6 +52,11 @@ func create(cmd *cobra.Command, _ []string) {
 	installation := viper.GetString("installation")
 
 	params := parseFlags(cmd.Flags())
+
+	// Validate before any prompt or API call so a bad value doesn't discard user input.
+	bodyFormat, err := cmdcommon.ResolveBodyFormat(cmd.Flags())
+	cmdutil.ExitIfError(err)
+
 	client := api.DefaultClient(params.Debug)
 	cc := createCmd{
 		client: client,
@@ -92,6 +97,8 @@ func create(cmd *cobra.Command, _ []string) {
 
 	params.Reporter = cmdcommon.GetRelevantUser(client, project, params.Reporter)
 	params.Assignee = cmdcommon.GetRelevantUser(client, project, params.Assignee)
+
+	params.Body = cmdcommon.ConvertBody(params.Body, bodyFormat)
 
 	key, err := func() (string, error) {
 		s := cmdutil.Info("Creating an epic...")

--- a/internal/cmd/issue/comment/add/add.go
+++ b/internal/cmd/issue/comment/add/add.go
@@ -55,6 +55,7 @@ func NewCmdCommentAdd() *cobra.Command {
 
 	cmd.Flags().Bool("web", false, "Open issue in web browser after adding comment")
 	cmd.Flags().StringP("template", "T", "", "Path to a file to read comment body from")
+	cmdcommon.AddBodyFormatFlag(cmd.Flags())
 	cmd.Flags().Bool("no-input", false, "Disable prompt for non-required fields")
 	cmd.Flags().Bool("internal", false, "Make comment internal")
 
@@ -63,6 +64,11 @@ func NewCmdCommentAdd() *cobra.Command {
 
 func add(cmd *cobra.Command, args []string) {
 	params := parseArgsAndFlags(args, cmd.Flags())
+
+	// Validate before any prompt or API call so a bad value doesn't discard user input.
+	bodyFormat, err := cmdcommon.ResolveBodyFormat(cmd.Flags())
+	cmdutil.ExitIfError(err)
+
 	client := api.DefaultClient(params.debug)
 	ac := addCmd{
 		client:    client,
@@ -99,11 +105,13 @@ func add(cmd *cobra.Command, args []string) {
 		}
 	}
 
-	err := func() error {
+	body := cmdcommon.ConvertBody(ac.params.body, bodyFormat)
+
+	err = func() error {
 		s := cmdutil.Info("Adding comment")
 		defer s.Stop()
 
-		return client.AddIssueComment(ac.params.issueKey, ac.params.body, ac.params.internal)
+		return client.AddIssueComment(ac.params.issueKey, body, ac.params.internal)
 	}()
 	cmdutil.ExitIfError(err)
 

--- a/internal/cmd/issue/create/create.go
+++ b/internal/cmd/issue/create/create.go
@@ -77,6 +77,11 @@ func create(cmd *cobra.Command, _ []string) {
 	installation := viper.GetString("installation")
 
 	params := parseFlags(cmd.Flags())
+
+	// Validate before any prompt or API call so a bad value doesn't discard user input.
+	bodyFormat, err := cmdcommon.ResolveBodyFormat(cmd.Flags())
+	cmdutil.ExitIfError(err)
+
 	client := api.DefaultClient(params.Debug)
 	cc := createCmd{
 		client: client,
@@ -103,6 +108,8 @@ func create(cmd *cobra.Command, _ []string) {
 
 	params.Reporter = cmdcommon.GetRelevantUser(client, project, params.Reporter)
 	params.Assignee = cmdcommon.GetRelevantUser(client, project, params.Assignee)
+
+	params.Body = cmdcommon.ConvertBody(params.Body, bodyFormat)
 
 	issue, err := func() (*jira.CreateResponse, error) {
 		s := cmdutil.Info("Creating an issue...")

--- a/internal/cmd/issue/edit/edit.go
+++ b/internal/cmd/issue/edit/edit.go
@@ -14,7 +14,6 @@ import (
 	"github.com/ankitpokhrel/jira-cli/internal/query"
 	"github.com/ankitpokhrel/jira-cli/pkg/adf"
 	"github.com/ankitpokhrel/jira-cli/pkg/jira"
-	"github.com/ankitpokhrel/jira-cli/pkg/md"
 	"github.com/ankitpokhrel/jira-cli/pkg/surveyext"
 )
 
@@ -60,6 +59,11 @@ func edit(cmd *cobra.Command, args []string) {
 	project := viper.GetString("project.key")
 
 	params := parseArgsAndFlags(cmd.Flags(), args, project)
+
+	// Validate before any prompt or API call so a bad value doesn't discard an edited body.
+	bodyFormat, err := cmdcommon.ResolveBodyFormat(cmd.Flags())
+	cmdutil.ExitIfError(err)
+
 	client := api.DefaultClient(params.debug)
 	ec := editCmd{
 		client: client,
@@ -79,14 +83,10 @@ func edit(cmd *cobra.Command, args []string) {
 	}()
 	cmdutil.ExitIfError(err)
 
-	var (
-		isADF        bool
-		originalBody string
-	)
+	var originalBody string
 
 	if issue.Fields.Description != nil {
 		if adfBody, ok := issue.Fields.Description.(*adf.ADF); ok {
-			isADF = true
 			originalBody = adf.NewTranslator(adfBody, adf.NewJiraMarkdownTranslator()).Translate()
 		} else {
 			originalBody = issue.Fields.Description.(string)
@@ -137,10 +137,7 @@ func edit(cmd *cobra.Command, args []string) {
 		s := cmdutil.Info("Updating an issue...")
 		defer s.Stop()
 
-		body := params.body
-		if isADF {
-			body = md.ToJiraMD(body)
-		}
+		body := cmdcommon.ConvertBody(params.body, bodyFormat)
 
 		parent := cmdutil.GetJiraIssueKey(project, params.parentIssueKey)
 		if parent == "" && issue.Fields.Parent != nil {
@@ -444,6 +441,7 @@ func setFlags(cmd *cobra.Command) {
 	cmd.Flags().StringP("parent", "P", "", `Link to a parent key`)
 	cmd.Flags().StringP("summary", "s", "", "Edit summary or title")
 	cmd.Flags().StringP("body", "b", "", "Edit description")
+	cmdcommon.AddBodyFormatFlag(cmd.Flags())
 	cmd.Flags().StringP("priority", "y", "", "Edit priority")
 	cmd.Flags().StringP("assignee", "a", "", "Edit assignee (email or display name)")
 	cmd.Flags().StringArrayP("label", "l", []string{}, "Append labels")

--- a/internal/cmd/issue/move/move.go
+++ b/internal/cmd/issue/move/move.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/ankitpokhrel/jira-cli/api"
+	"github.com/ankitpokhrel/jira-cli/internal/cmdcommon"
 	"github.com/ankitpokhrel/jira-cli/internal/cmdutil"
 	"github.com/ankitpokhrel/jira-cli/internal/query"
 	"github.com/ankitpokhrel/jira-cli/pkg/jira"
@@ -41,6 +42,7 @@ STATE		State you want to transition the issue to`,
 	cmd.Flags().SortFlags = false
 
 	cmd.Flags().String("comment", "", "Add comment to the issue")
+	cmdcommon.AddBodyFormatFlag(cmd.Flags())
 	cmd.Flags().StringP("assignee", "a", "", "Assign issue to a user")
 	cmd.Flags().StringP("resolution", "R", "", "Set resolution")
 	cmd.Flags().Bool("web", false, "Open issue in web browser after successful transition")
@@ -52,6 +54,11 @@ func move(cmd *cobra.Command, args []string) {
 	project := viper.GetString("project.key")
 	installation := viper.GetString("installation")
 	params := parseArgsAndFlags(cmd.Flags(), args, project)
+
+	// Validate before any prompt or API call so a bad value doesn't discard user input.
+	bodyFormat, err := cmdcommon.ResolveBodyFormat(cmd.Flags())
+	cmdutil.ExitIfError(err)
+
 	client := api.DefaultClient(params.debug)
 	mc := moveCmd{
 		client:      client,
@@ -93,6 +100,8 @@ func move(cmd *cobra.Command, args []string) {
 			}{Name: mc.params.resolution}
 		}
 		if mc.params.comment != "" {
+			comment := cmdcommon.ConvertBody(mc.params.comment, bodyFormat)
+
 			trUpdateReq.Comment = []struct {
 				Add struct {
 					Body string `json:"body"`
@@ -100,7 +109,7 @@ func move(cmd *cobra.Command, args []string) {
 			}{
 				{Add: struct {
 					Body string `json:"body"`
-				}{Body: mc.params.comment}},
+				}{Body: comment}},
 			}
 		}
 

--- a/internal/cmd/issue/worklog/add/add.go
+++ b/internal/cmd/issue/worklog/add/add.go
@@ -57,6 +57,7 @@ func NewCmdWorklogAdd() *cobra.Command {
 	cmd.Flags().String("started", "", "The datetime on which the worklog effort was started, eg: 2022-01-01 09:30:00")
 	cmd.Flags().String("timezone", "UTC", "The timezone to use for the started date in IANA timezone format, eg: Europe/Berlin")
 	cmd.Flags().String("comment", "", "Comment about the worklog")
+	cmdcommon.AddBodyFormatFlag(cmd.Flags())
 	cmd.Flags().String("new-estimate", "", "the new estimate for the backlog to be completed by")
 	cmd.Flags().Bool("no-input", false, "Disable prompt for non-required fields")
 
@@ -65,6 +66,11 @@ func NewCmdWorklogAdd() *cobra.Command {
 
 func add(cmd *cobra.Command, args []string) {
 	params := parseArgsAndFlags(args, cmd.Flags())
+
+	// Validate before any prompt or API call so a bad value doesn't discard user input.
+	bodyFormat, err := cmdcommon.ResolveBodyFormat(cmd.Flags())
+	cmdutil.ExitIfError(err)
+
 	client := api.DefaultClient(params.debug)
 	ac := addCmd{
 		client: client,
@@ -97,11 +103,13 @@ func add(cmd *cobra.Command, args []string) {
 		}
 	}
 
-	err := func() error {
+	comment := cmdcommon.ConvertBody(ac.params.comment, bodyFormat)
+
+	err = func() error {
 		s := cmdutil.Info("Adding a worklog")
 		defer s.Stop()
 
-		return client.AddIssueWorklog(ac.params.issueKey, ac.params.started, ac.params.timeSpent, ac.params.comment, ac.params.newEstimate)
+		return client.AddIssueWorklog(ac.params.issueKey, ac.params.started, ac.params.timeSpent, comment, ac.params.newEstimate)
 	}()
 	cmdutil.ExitIfError(err)
 

--- a/internal/cmdcommon/bodyformat.go
+++ b/internal/cmdcommon/bodyformat.go
@@ -1,0 +1,55 @@
+package cmdcommon
+
+import (
+	"fmt"
+
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+
+	"github.com/ankitpokhrel/jira-cli/pkg/md"
+)
+
+// Body format values for the --body-format flag.
+const (
+	// FormatMarkdown means the body is CommonMark and should be converted to JIRA wiki markup before sending.
+	FormatMarkdown = "markdown"
+	// FormatWiki means the body is already JIRA wiki markup and should be sent verbatim.
+	FormatWiki = "wiki"
+
+	// FlagBodyFormat is the long flag name registered on each affected command.
+	FlagBodyFormat = "body-format"
+	// ConfigKeyBodyFormat is the viper config key that mirrors the flag.
+	ConfigKeyBodyFormat = "body.format"
+)
+
+// AddBodyFormatFlag registers --body-format on the given flag set.
+func AddBodyFormatFlag(flags *pflag.FlagSet) {
+	flags.String(FlagBodyFormat, "",
+		`Body source format: "markdown" (default, converted to JIRA wiki markup) or "wiki" (sent as-is)`)
+}
+
+// ResolveBodyFormat returns the effective body format using the resolution order:
+// flag value > viper "body.format" config key > FormatMarkdown default. The returned
+// value is validated against the allowed values and an error is returned otherwise.
+func ResolveBodyFormat(flags *pflag.FlagSet) (string, error) {
+	v, _ := flags.GetString(FlagBodyFormat)
+	if v == "" {
+		v = viper.GetString(ConfigKeyBodyFormat)
+	}
+	if v == "" {
+		v = FormatMarkdown
+	}
+	if v != FormatMarkdown && v != FormatWiki {
+		return "", fmt.Errorf("invalid --%s %q (allowed values: %s, %s)", FlagBodyFormat, v, FormatMarkdown, FormatWiki)
+	}
+	return v, nil
+}
+
+// ConvertBody returns body converted from CommonMark to JIRA wiki markup when format
+// is FormatMarkdown, or body verbatim when format is FormatWiki.
+func ConvertBody(body, format string) string {
+	if format == FormatWiki {
+		return body
+	}
+	return md.ToJiraMD(body)
+}

--- a/internal/cmdcommon/bodyformat.go
+++ b/internal/cmdcommon/bodyformat.go
@@ -32,7 +32,12 @@ func AddBodyFormatFlag(flags *pflag.FlagSet) {
 // flag value > viper "body.format" config key > FormatMarkdown default. The returned
 // value is validated against the allowed values and an error is returned otherwise.
 func ResolveBodyFormat(flags *pflag.FlagSet) (string, error) {
-	v, _ := flags.GetString(FlagBodyFormat)
+	// A lookup error here means the flag was never registered on this command, which is a
+	// wiring bug: silently falling back to the config would make --body-format look ignored.
+	v, err := flags.GetString(FlagBodyFormat)
+	if err != nil {
+		return "", err
+	}
 	if v == "" {
 		v = viper.GetString(ConfigKeyBodyFormat)
 	}

--- a/internal/cmdcommon/bodyformat_test.go
+++ b/internal/cmdcommon/bodyformat_test.go
@@ -1,0 +1,93 @@
+package cmdcommon
+
+import (
+	"testing"
+
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResolveBodyFormat(t *testing.T) {
+	cases := []struct {
+		name       string
+		flagValue  string
+		viperValue string
+		want       string
+		wantErr    bool
+	}{
+		{
+			name: "defaults to markdown when nothing is set",
+			want: FormatMarkdown,
+		},
+		{
+			name:       "viper value used when flag is unset",
+			viperValue: FormatWiki,
+			want:       FormatWiki,
+		},
+		{
+			name:       "flag overrides viper",
+			flagValue:  FormatMarkdown,
+			viperValue: FormatWiki,
+			want:       FormatMarkdown,
+		},
+		{
+			name:      "explicit wiki flag is honored",
+			flagValue: FormatWiki,
+			want:      FormatWiki,
+		},
+		{
+			name:      "invalid flag value errors",
+			flagValue: "html",
+			wantErr:   true,
+		},
+		{
+			name:       "invalid viper value errors",
+			viperValue: "asciidoc",
+			wantErr:    true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			viper.Reset()
+			if tc.viperValue != "" {
+				viper.Set(ConfigKeyBodyFormat, tc.viperValue)
+			}
+
+			flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+			AddBodyFormatFlag(flags)
+			if tc.flagValue != "" {
+				assert.NoError(t, flags.Set(FlagBodyFormat, tc.flagValue))
+			}
+
+			got, err := ResolveBodyFormat(flags)
+			if tc.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestConvertBody(t *testing.T) {
+	t.Run("markdown is converted to JIRA wiki", func(t *testing.T) {
+		// `# foo` is a CommonMark H1; the wiki form is `h1. foo`.
+		got := ConvertBody("# foo\n", FormatMarkdown)
+		assert.Contains(t, got, "h1. foo")
+	})
+
+	t.Run("wiki bypasses conversion verbatim", func(t *testing.T) {
+		// `# foo` in JIRA wiki is a numbered-list item; we must NOT convert it to `h1.`.
+		body := "# first\n# second\n"
+		got := ConvertBody(body, FormatWiki)
+		assert.Equal(t, body, got)
+	})
+
+	t.Run("empty body returns empty", func(t *testing.T) {
+		assert.Equal(t, "", ConvertBody("", FormatMarkdown))
+		assert.Equal(t, "", ConvertBody("", FormatWiki))
+	})
+}

--- a/internal/cmdcommon/bodyformat_test.go
+++ b/internal/cmdcommon/bodyformat_test.go
@@ -72,6 +72,18 @@ func TestResolveBodyFormat(t *testing.T) {
 	}
 }
 
+func TestResolveBodyFormatUnregisteredFlag(t *testing.T) {
+	// Forgetting AddBodyFormatFlag on a command is a wiring bug. It must surface as an
+	// error rather than silently resolving from config, which would make the flag look
+	// like it was ignored.
+	viper.Reset()
+	viper.Set(ConfigKeyBodyFormat, FormatWiki)
+	defer viper.Reset()
+
+	_, err := ResolveBodyFormat(pflag.NewFlagSet("empty", pflag.ContinueOnError))
+	assert.Error(t, err)
+}
+
 func TestConvertBody(t *testing.T) {
 	t.Run("markdown is converted to JIRA wiki", func(t *testing.T) {
 		// `# foo` is a CommonMark H1; the wiki form is `h1. foo`.

--- a/internal/cmdcommon/create.go
+++ b/internal/cmdcommon/create.go
@@ -67,6 +67,7 @@ And, this field is mandatory when creating a sub-task.`)
 	cmd.Flags().StringP("original-estimate", "e", "", prefix+" Original estimate")
 	cmd.Flags().StringToString("custom", custom, "Set custom fields")
 	cmd.Flags().StringP("template", "T", "", "Path to a file to read body/description from")
+	AddBodyFormatFlag(cmd.Flags())
 	cmd.Flags().Bool("web", false, "Open in web browser after successful creation")
 	cmd.Flags().Bool("no-input", false, "Disable prompt for non-required fields")
 }

--- a/internal/config/generator.go
+++ b/internal/config/generator.go
@@ -13,6 +13,7 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/ankitpokhrel/jira-cli/api"
+	"github.com/ankitpokhrel/jira-cli/internal/cmdcommon"
 	"github.com/ankitpokhrel/jira-cli/internal/cmdutil"
 	"github.com/ankitpokhrel/jira-cli/pkg/jira"
 )
@@ -762,6 +763,7 @@ func (c *JiraCLIConfigGenerator) write(path string) (string, error) {
 	config.Set("issue.fields.custom", c.value.customFields)
 	config.Set("auth_type", c.value.authType.String())
 	config.Set("timezone", c.value.timezone)
+	config.Set(cmdcommon.ConfigKeyBodyFormat, cmdcommon.FormatMarkdown)
 
 	// MTLS.
 	if c.value.mtls.caCert != "" {

--- a/pkg/jira/create.go
+++ b/pkg/jira/create.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/ankitpokhrel/jira-cli/pkg/adf"
-	"github.com/ankitpokhrel/jira-cli/pkg/md"
 )
 
 // CreateResponse struct holds response from POST /issue endpoint.
@@ -137,7 +136,7 @@ func (*Client) getRequestData(req *CreateRequest) *createRequest {
 
 	switch v := req.Body.(type) {
 	case string:
-		cf.Description = md.ToJiraMD(v)
+		cf.Description = v
 	case *adf.ADF:
 		cf.Description = v
 	}

--- a/pkg/jira/issue.go
+++ b/pkg/jira/issue.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/ankitpokhrel/jira-cli/pkg/adf"
 	"github.com/ankitpokhrel/jira-cli/pkg/jira/filter"
-	"github.com/ankitpokhrel/jira-cli/pkg/md"
 )
 
 const (
@@ -311,7 +310,7 @@ type issueCommentRequest struct {
 
 // AddIssueComment adds comment to an issue using POST /issue/{key}/comment endpoint.
 func (c *Client) AddIssueComment(key, comment string, internal bool) error {
-	body, err := json.Marshal(&issueCommentRequest{Body: md.ToJiraMD(comment), Properties: []issueCommentProperty{{Key: "sd.public.comment", Value: issueCommentPropertyValue{Internal: internal}}}})
+	body, err := json.Marshal(&issueCommentRequest{Body: comment, Properties: []issueCommentProperty{{Key: "sd.public.comment", Value: issueCommentPropertyValue{Internal: internal}}}})
 	if err != nil {
 		return err
 	}
@@ -346,7 +345,7 @@ type issueWorklogRequest struct {
 func (c *Client) AddIssueWorklog(key, started, timeSpent, comment, newEstimate string) error {
 	worklogReq := issueWorklogRequest{
 		TimeSpent: timeSpent,
-		Comment:   md.ToJiraMD(comment),
+		Comment:   comment,
 	}
 	if started != "" {
 		worklogReq.Started = started


### PR DESCRIPTION
**What does this PR solve?**

JiraCLI always converts body/comment/worklog text from CommonMark to JIRA wiki markup before sending it. That is convenient for Markdown writers, but it silently mangles text that is *already* wiki markup, because several wiki tokens collide with CommonMark:

| Input (wiki markup) | Intended | What JiraCLI sends today |
| --- | --- | --- |
| `# foo` | numbered-list item | `h1. foo` (parsed as a Markdown H1) |
| `*bold*` | bold | `_bold_` (parsed as Markdown emphasis) |

This adds an opt-in `--body-format` flag, plus a matching `body.format` config key, so users can say "this text is already wiki markup, don't convert it". The default stays `markdown`, so existing invocations behave exactly as before.

It also fixes a related inconsistency in `issue edit`. Conversion only ran when the source description was ADF (the `isADF` gate), so v2/Server/DC edits skipped conversion entirely. Since `Client.Edit` always issues `PutV2` — an endpoint that expects wiki markup on Cloud and Server alike — that gate was skipping a conversion that was actually needed. Removing it makes `edit` consistent with `create`/`comment`/`worklog`.

Details:

- New `internal/cmdcommon/bodyformat.go` exposing `AddBodyFormatFlag`, `ResolveBodyFormat` and `ConvertBody`. Resolution order is flag > config > `markdown`; invalid values error with a clear message.
- `pkg/jira` becomes format-agnostic: `md.ToJiraMD()` is removed from `CreateRequest` (string case), `AddIssueComment` and `AddIssueWorklog`. Conversion now happens in the command layer, so `md.ToJiraMD` has exactly one call site.
- Wired into `issue create`, `epic create`, `issue edit`, `issue comment add`, `issue worklog add` and `issue move --comment`.
- `issue clone` deliberately does not expose the flag: its body always comes from the source issue's stored description, which is already wiki or ADF. Dropping the `pkg/jira` conversion incidentally fixes a latent bug there, where a wiki description was re-parsed as Markdown on clone.
- Each command resolves the format immediately after flag parsing, before any prompt or API call, so a typo fails before the user has written a description in `$EDITOR`.
- `jira init` now writes `body.format: markdown` so the key is discoverable.

**How to test?**

Before, `-b` content was always converted, so wiki markup was mangled. After, the default is unchanged and `wiki` sends the body verbatim:

```sh
# Unchanged default (Markdown -> wiki): "# foo" becomes "h1. foo"
$ jira issue create -tTask -s"Summary" -b"# foo"

# New: sent as-is, so "# foo" stays a wiki numbered-list item
$ jira issue create -tTask -s"Summary" -b"# foo" --body-format=wiki

# Or set it once instead of passing the flag every time
#   body:
#     format: wiki

# Invalid values fail immediately, before any prompt or API call
$ jira issue edit ISSUE-1 --body-format=wik
Error: invalid --body-format "wik" (allowed values: markdown, wiki)
```

The same flag works on `issue edit`, `issue comment add`, `issue worklog add`, `epic create` and `issue move --comment`.

`go test ./internal/cmdcommon/` covers resolution precedence, defaulting, validation and conversion semantics.

I also verified the round trip against a live Jira Cloud instance: a comment sent with `--body-format=wiki` containing `*bold*`, `_italic_`, `{{mono}}`, `h4. Heading` and `# one / # two` comes back from the v3 API as ADF containing `strong`, `em`, `code`, `heading` and `orderedList` nodes, with the delimiters stripped — confirming Jira parses the wiki source rather than treating it as plain text.

**Checklist**

- [x] I have added/updated enough tests related to my changes.
- [x] I have also manually checked and verified that my changes fix the issue and doesn't break any other functionalities.
- [ ] My changes are backwards compatible.

On the last box — the flag default keeps every existing invocation byte-identical, but there are two deliberate behavior changes worth calling out explicitly:

1. `issue edit` on v2/Server/DC now converts Markdown to wiki markup, where previously it sent the body verbatim (the `isADF` gate described above).
2. `issue move --comment` now converts, where previously it was the one body path that never did.

Both are opt-out with `--body-format=wiki` (or `body.format: wiki`). Happy to gate either behind the config instead if you would prefer strict compatibility.
