### PR TITLE
fix(move): warn when Jira will discard --comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,6 +400,14 @@ $ jira issue move ISSUE-1 "In Progress"
 If your workflow allows to add comment, resolution or assignee while moving an issue, you can do so as shown below.
 See [this documentation](https://confluence.atlassian.com/jirakb/how-to-add-a-comment-during-a-transition-779160682.html) on how to setup your workflow to allow these fields.
 
+> [!IMPORTANT]
+> Jira applies `--comment` only when the target transition has a screen containing the
+> Comment field. When it doesn't, Jira performs the transition and **silently discards the
+> comment**: the API returns success in both cases, so nothing distinguishes them in the
+> response. JiraCLI warns when it can tell the transition has no screen at all, but a screen
+> that omits the Comment field cannot be detected. If you're unsure whether your workflow
+> allows it, add the comment separately with `jira issue comment add` instead.
+
 ```sh
 # Move an issue and add comment
 $ jira issue move ISSUE-1 "In Progress" --comment "Started working on it"

--- a/internal/cmd/issue/move/move.go
+++ b/internal/cmd/issue/move/move.go
@@ -40,7 +40,9 @@ STATE		State you want to transition the issue to`,
 
 	cmd.Flags().SortFlags = false
 
-	cmd.Flags().String("comment", "", "Add comment to the issue")
+	cmd.Flags().String("comment", "", `Add comment to the issue.
+Jira applies this only when the target transition has a screen containing the Comment field.
+Otherwise it is silently discarded; use "jira issue comment add" instead.`)
 	cmd.Flags().StringP("assignee", "a", "", "Assign issue to a user")
 	cmd.Flags().StringP("resolution", "R", "", "Set resolution")
 	cmd.Flags().Bool("web", false, "Open issue in web browser after successful transition")
@@ -73,6 +75,16 @@ func move(cmd *cobra.Command, args []string) {
 		fmt.Println()
 		cmdutil.Failed("Error: %s", err.Error())
 		return
+	}
+
+	// A transition with no screen cannot carry a comment: Jira accepts the request with
+	// 204 and drops the comment, so warn rather than let it vanish silently.
+	if mc.params.comment != "" && len(tr.Fields) == 0 {
+		fmt.Println()
+		cmdutil.Warn(
+			"Transition %q has no screen, so Jira will discard --comment.\nAdd it separately with: jira issue comment add %s",
+			tr.Name, mc.params.key,
+		)
 	}
 
 	err = func() error {

--- a/pkg/jira/transition.go
+++ b/pkg/jira/transition.go
@@ -55,7 +55,10 @@ func (c *Client) TransitionsV2(key string) ([]*Transition, error) {
 }
 
 func (c *Client) transitions(key, ver string) ([]*Transition, error) {
-	path := fmt.Sprintf("/issue/%s/transitions", key)
+	// The transitions.fields expansion tells us which fields each transition's screen
+	// carries. It costs nothing extra here and lets callers detect transitions that
+	// have no screen, where Jira silently drops a comment sent with the transition.
+	path := fmt.Sprintf("/issue/%s/transitions?expand=transitions.fields", key)
 
 	var (
 		res *http.Response

--- a/pkg/jira/transition_test.go
+++ b/pkg/jira/transition_test.go
@@ -104,3 +104,45 @@ func TestTransition(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, code, 204)
 }
+
+func TestTransitionsScreenFields(t *testing.T) {
+	// Mirrors a real Jira response: a transition with no screen reports an empty
+	// fields object, while one with a screen lists the fields it carries. Note that
+	// Jira never advertises "comment" here, even on transitions that do accept one.
+	const body = `{
+		"expand": "transitions",
+		"transitions": [
+			{"id": "421", "name": "Ready for review", "isAvailable": true, "fields": {}},
+			{"id": "451", "name": "Done", "isAvailable": true, "fields": {
+				"resolution": {"required": true},
+				"summary": {"required": true}
+			}}
+		]
+	}`
+
+	var gotQuery string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.Equal(t, "/rest/api/3/issue/TEST/transitions", r.URL.Path)
+		gotQuery = r.URL.RawQuery
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(body))
+	}))
+	defer server.Close()
+
+	client := NewClient(Config{Server: server.URL}, WithTimeout(3*time.Second))
+
+	actual, err := client.Transitions("TEST")
+	assert.NoError(t, err)
+
+	// The fields expansion must be requested, otherwise Fields is always empty and a
+	// screen-less transition is indistinguishable from one with a screen.
+	assert.Equal(t, "expand=transitions.fields", gotQuery)
+
+	assert.Len(t, actual, 2)
+	assert.Empty(t, actual[0].Fields, "transition without a screen should report no fields")
+	assert.Len(t, actual[1].Fields, 2, "transition with a screen should report its fields")
+}

--- a/pkg/jira/types.go
+++ b/pkg/jira/types.go
@@ -183,6 +183,10 @@ type Transition struct {
 	ID          json.Number `json:"id"`
 	Name        string      `json:"name"`
 	IsAvailable bool        `json:"isAvailable"`
+	// Fields holds the fields on the transition screen, from the transitions.fields
+	// expansion. It is empty when the transition has no screen, in which case Jira
+	// silently discards a comment submitted along with the transition.
+	Fields map[string]json.RawMessage `json:"fields,omitempty"`
 }
 
 // User holds user info.


### PR DESCRIPTION
**What does this PR solve?**

`jira issue move --comment` sends the comment inline in the transition request's `update.comment` block. Jira applies that only when the target transition has a screen containing the Comment field. Otherwise it performs the transition, returns `204`, and **silently discards the comment** — the user sees `✓ Issue transitioned` and the comment is simply gone.

The README already links Atlassian's KB article on configuring the workflow, but says only "if your workflow allows", without noting that the comment is lost when it doesn't.

I verified this against a live Jira Cloud workflow:

| Transition | Screen | Result |
| --- | --- | --- |
| `Done` | 6 fields | comment lands |
| every other transition in the workflow | none | HTTP 204, comment discarded |

Tested four ways — a no-op self-transition, a genuine state-changing transition, a hand-built minimal payload, and JiraCLI's own payload. The outcome depends only on whether the transition has a screen, not on whether the status actually changes. **This is not a payload bug in JiraCLI**: the request it sends is correct and the comment lands wherever Jira accepts it.

The discard cannot be detected from the response, which is `204` with an empty body in both cases. It also cannot be read off the transition metadata directly, because Jira never lists `comment` in the `transitions.fields` expansion — not even for a transition that demonstrably accepts one. The one usable signal is whether the transition has a screen at all: an empty `fields` map means there is nowhere for the comment to go.

Changes:

- `Transition` gains a `Fields` map, and the transitions lookup now requests `expand=transitions.fields`. This costs no extra request, because `issue move` already fetches the transition list to resolve the state name.
- `issue move` warns before transitioning when `--comment` is set and the target transition has no screen, pointing the user at `jira issue comment add`. Behavior is otherwise unchanged — the comment is still sent inline, so workflows where it works keep the atomic single-request update.
- The `--comment` flag help and the README now state the requirement and the failure mode.

A screen that exists but omits the Comment field still cannot be detected; that case is documented rather than warned about.

**How to test?**

On a workflow whose transitions have no screen (common for simple boards):

```
$ jira issue move ISSUE-1 "In Progress" --comment "this will be discarded"

Transition "In Progress" has no screen, so Jira will discard --comment.
Add it separately with: jira issue comment add ISSUE-1

✓ Issue transitioned to state "In Progress"
```

Before this change the same command printed only the success line and the comment vanished with no indication. Confirm with `jira issue view ISSUE-1 --comments 5` that the comment is indeed absent — that is pre-existing Jira behavior, unchanged by this PR; only the warning is new.

On a transition that does have a screen (for example a `Done` transition with a resolution screen), no warning is printed and the comment is applied exactly as before.

`go test ./pkg/jira/ -run TestTransitions` covers the new field parsing and asserts that `expand=transitions.fields` is actually requested — without it, `Fields` is always empty and a screen-less transition becomes indistinguishable from one with a screen.

**Checklist**

- [x] I have added/updated enough tests related to my changes.
- [x] I have also manually checked and verified that my changes fix the issue and doesn't break any other functionalities.
- [x] My changes are backwards compatible.
