### PR TITLE
fix: Editing array custom fields with non-option items

### DIFF
--- a/pkg/jira/customfield.go
+++ b/pkg/jira/customfield.go
@@ -19,6 +19,10 @@ type customFieldTypeStringSet struct {
 	Set string `json:"set"`
 }
 
+type customFieldTypeStringsSet struct {
+	Set []string `json:"set"`
+}
+
 type customFieldTypeOption struct {
 	Value string `json:"value"`
 }

--- a/pkg/jira/edit.go
+++ b/pkg/jira/edit.go
@@ -390,7 +390,9 @@ func constructCustomFieldsForEdit(fields map[string]string, configuredFields []I
 					}
 					data.Update.M.customFields[configured.Key] = items
 				} else {
-					data.Update.M.customFields[configured.Key] = pieces
+					// Custom fields live in the `update` block, which expects
+					// verb-value pairs. A bare array is rejected by the API.
+					data.Update.M.customFields[configured.Key] = []customFieldTypeStringsSet{{Set: pieces}}
 				}
 			case customFieldFormatNumber:
 				num, err := strconv.ParseFloat(val, 64) //nolint:gomnd

--- a/pkg/jira/edit_customfield_test.go
+++ b/pkg/jira/edit_customfield_test.go
@@ -1,0 +1,74 @@
+package jira
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetRequestDataForEditCustomFields(t *testing.T) {
+	field := func(name, key, datatype, items string) IssueTypeField {
+		f := IssueTypeField{Name: name, Key: key}
+		f.Schema.DataType = datatype
+		f.Schema.Items = items
+
+		return f
+	}
+
+	configured := []IssueTypeField{
+		field("Involved Services", "customfield_1", "array", "string"),
+		field("Platform", "customfield_2", "array", "option"),
+		field("Quarter", "customfield_3", "option", ""),
+		field("Story Points", "customfield_4", "number", ""),
+		field("Note", "customfield_5", "string", ""),
+	}
+
+	cases := []struct {
+		name     string
+		fields   map[string]string
+		expected string
+	}{
+		{
+			name:     "array of strings is set with an explicit verb",
+			fields:   map[string]string{"involved-services": "group:one,group:two"},
+			expected: `{"customfield_1":[{"set":["group:one","group:two"]}]}`,
+		},
+		{
+			name:     "array of options is added and removed",
+			fields:   map[string]string{"platform": "iOS,-Android"},
+			expected: `{"customfield_2":[{"add":{"value":"iOS"}},{"remove":{"value":"Android"}}]}`,
+		},
+		{
+			name:     "option is set",
+			fields:   map[string]string{"quarter": "Q3"},
+			expected: `{"customfield_3":[{"set":{"value":"Q3"}}]}`,
+		},
+		{
+			name:     "number is set",
+			fields:   map[string]string{"story-points": "3"},
+			expected: `{"customfield_4":[{"set":3}]}`,
+		},
+		{
+			name:     "string is set",
+			fields:   map[string]string{"note": "a custom note"},
+			expected: `{"customfield_5":[{"set":"a custom note"}]}`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := &EditRequest{CustomFields: tc.fields}
+			req.WithCustomFields(configured)
+
+			body, err := json.Marshal(getRequestDataForEdit(req))
+			assert.NoError(t, err)
+
+			var got struct {
+				Update json.RawMessage `json:"update"`
+			}
+			assert.NoError(t, json.Unmarshal(body, &got))
+			assert.JSONEq(t, tc.expected, string(got.Update))
+		})
+	}
+}


### PR DESCRIPTION
### Problem

`jira issue edit KEY --custom <field>=a,b` fails for any custom field whose schema is `array` with items other than `option` (labels, multi-checkbox, and picker fields backed by an array of strings):

```
Error:
  - Can not instantiate value of type [simple type, class com.atlassian.jira.rest.api.issue.FieldOperation] from JSON String
```

`constructCustomFieldsForEdit` writes custom fields into the `update` block of the `PUT /issue/{key}` payload, and that block expects a list of verb-value pairs. Every datatype in that switch emits an operation (`set`, `add`, `remove`) except the array/non-option branch, which assigned the raw `[]string`:

```json
{"update":{"customfield_10001":["one","two"]}}
```

Jira rejects that because the array elements are not field operations. Note `issue create` is unaffected: `constructCustomFields` writes to `fields`, where a bare array is correct.

Refs #548.

### Fix

Wrap the pieces in a `set` operation, consistent with the other branches:

```json
{"update":{"customfield_10001":[{"set":["one","two"]}]}}
```

`set` is reported as a supported operation for such fields by `/rest/api/2/issue/{key}/editmeta`, and the request now succeeds where the previous payload was rejected.

### Tests

Added `TestGetRequestDataForEditCustomFields`, which pins the generated `update` block for all custom field datatypes handled by the switch (array/string, array/option add+remove, option, number, string), so the other branches are protected too.

`go test ./...` passes.